### PR TITLE
fix: credential handling, docs, and web UI security improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ vocabgen serve --port 3000    # custom port
 
 | Provider | Auth | Example |
 |----------|------|---------|
-| Bedrock (default) | AWS credential chain | `vocabgen lookup "word" -l nl --profile my-profile --region eu-west-1` |
+| Bedrock (default) | AWS credential chain | `vocabgen lookup "word" -l nl --profile my-profile --region us-east-1 --model-id us.anthropic.claude-sonnet-4-20250514-v1:0` |
 | OpenAI | API key | `vocabgen lookup "word" -l nl --provider openai --api-key sk-...` |
 | Anthropic | API key | `vocabgen lookup "word" -l nl --provider anthropic --api-key sk-ant-...` |
 | Vertex AI | Google ADC | `vocabgen lookup "word" -l nl --provider vertexai --gcp-project my-proj` |
@@ -129,7 +129,7 @@ aws_region: us-east-1
 default_source_language: nl
 default_target_language: hu
 db_path: ~/.vocabgen/vocabgen.db
-# model_id: claude-sonnet-4-20250514
+# model_id: us.anthropic.claude-sonnet-4-20250514-v1:0  # Bedrock cross-region inference profile
 # aws_profile: my-profile
 # base_url: http://localhost:11434/v1
 # gcp_project: my-project

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ vocabgen serve                # default port 8080
 vocabgen serve --port 3000    # custom port
 ```
 
+For first-time setup, the Web UI config page is the easiest way to configure your provider and languages — see [Quick Setup via Web UI](docs/user-guide.md#quick-setup-via-web-ui). Credentials (API keys, AWS profiles) must be set via environment variables before starting the server.
+
 ## Provider Configuration
 
 | Provider | Auth | Example |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,11 +28,20 @@ tar xzf vocabgen_darwin_arm64.tar.gz
 chmod +x vocabgen
 sudo mv vocabgen /usr/local/bin/
 
+# macOS (Intel)
+curl -LO https://github.com/user/vocabgen/releases/latest/download/vocabgen_darwin_amd64.tar.gz
+tar xzf vocabgen_darwin_amd64.tar.gz
+chmod +x vocabgen
+sudo mv vocabgen /usr/local/bin/
+
 # Linux (amd64)
 curl -LO https://github.com/user/vocabgen/releases/latest/download/vocabgen_linux_amd64.tar.gz
 tar xzf vocabgen_linux_amd64.tar.gz
 chmod +x vocabgen
 sudo mv vocabgen /usr/local/bin/
+
+# Windows (amd64)
+# Download vocabgen_windows_amd64.zip from the Releases page, extract, and add to PATH.
 ```
 
 ## First Run
@@ -195,11 +204,14 @@ Via the web UI database page: export filtered entries as an `.xlsx` file. The do
 
 ```bash
 # Uses AWS credential chain (env vars, ~/.aws/credentials, IAM role)
-vocabgen lookup "werk" -l nl
+# For cross-region inference profiles, prefix with region (e.g., us.)
+vocabgen lookup "werk" -l nl --model-id us.anthropic.claude-sonnet-4-20250514-v1:0
 
 # Specify profile and region
-vocabgen lookup "werk" -l nl --profile my-profile --region eu-west-1
+vocabgen lookup "werk" -l nl --profile my-profile --region us-east-1 --model-id us.anthropic.claude-3-5-haiku-20241022-v1:0
 ```
+
+> **Note:** Bedrock model IDs differ from direct Anthropic API IDs. Use the Bedrock format (e.g., `us.anthropic.claude-sonnet-4-20250514-v1:0`) not the Anthropic format (`claude-sonnet-4-20250514`). For cross-region inference profiles, include the region prefix (`us.`).
 
 #### AWS IAM: Least Privilege Setup
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -44,13 +44,86 @@ sudo mv vocabgen /usr/local/bin/
 # Download vocabgen_windows_amd64.zip from the Releases page, extract, and add to PATH.
 ```
 
-## First Run
+## Configuration
+
+On first run, vocabgen creates `~/.vocabgen/config.yaml` with defaults:
+
+| Setting | Default |
+|---------|---------|
+| Provider | `bedrock` |
+| Region | `us-east-1` |
+| Source language | `nl` (Dutch) |
+| Target language | `hu` (Hungarian) |
+| Database | `~/.vocabgen/vocabgen.db` |
+
+You can configure the app in two ways: the Web UI (recommended for most users) or CLI flags.
+
+### Quick Setup via Web UI
+
+The easiest way to configure vocabgen — no file editing required:
 
 ```bash
-vocabgen lookup "uitkomen" -l nl
+vocabgen serve --port 8080
 ```
 
-On first run, vocabgen creates `~/.vocabgen/` with a default config and SQLite database. The command sends "uitkomen" to the LLM provider (default: AWS Bedrock), validates the JSON response, stores it in the database, and prints the structured vocabulary entry as JSON.
+Open `http://localhost:8080/config` in your browser. From there you can:
+
+- Select your LLM provider (Bedrock, OpenAI, Anthropic, Vertex AI)
+- Set your default source and target languages
+- Choose a model ID
+- Test the connection (uses the API key from your environment variables automatically)
+
+Credentials must still be configured outside the Web UI — see [Provider Credentials](#provider-credentials) below. The config page saves provider, model, and language settings to `~/.vocabgen/config.yaml`.
+
+### CLI Flag Overrides
+
+You can also override any config setting per-command without editing files:
+
+```bash
+# OpenAI with API key from environment
+export OPENAI_API_KEY=sk-...
+vocabgen lookup "maison" -l French --provider openai --model-id gpt-4o
+
+# Anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+vocabgen lookup "Haus" -l German --provider anthropic --model-id claude-sonnet-4-20250514
+
+# Ollama (local, free, no API key needed)
+vocabgen lookup "casa" -l Italian --provider openai --base-url http://localhost:11434/v1 --model-id llama3
+```
+
+CLI flags always take precedence over `config.yaml` values.
+
+### Provider Credentials
+
+Each provider authenticates differently:
+
+| Provider | Credentials |
+|----------|-------------|
+| Bedrock | AWS credential chain (`~/.aws/credentials`, env vars, or IAM role) |
+| OpenAI | `OPENAI_API_KEY` env var or `--api-key` flag |
+| Anthropic | `ANTHROPIC_API_KEY` env var or `--api-key` flag |
+| Vertex AI | Google Application Default Credentials + `--gcp-project` or `GCP_PROJECT` env var |
+| Ollama | None (local server) |
+
+API keys are never stored in `config.yaml`. Use environment variables or CLI flags.
+
+## First Run
+
+Make sure you have configured a provider (see [Configuration](#configuration) above). The default provider is AWS Bedrock — if you don't have AWS credentials set up, switch to a different provider first.
+
+```bash
+# With default provider (Bedrock, requires AWS credentials)
+vocabgen lookup "uitkomen" -l nl
+
+# Or with OpenAI
+vocabgen lookup "uitkomen" -l nl --provider openai --model-id gpt-4o
+
+# Or with a free local model via Ollama
+vocabgen lookup "uitkomen" -l nl --provider openai --base-url http://localhost:11434/v1 --model-id llama3
+```
+
+On first run, vocabgen creates `~/.vocabgen/` with a default config and SQLite database. The command sends "uitkomen" to the LLM provider, validates the JSON response, stores it in the database, and prints the structured vocabulary entry as JSON.
 
 Expected output (abbreviated):
 
@@ -140,7 +213,7 @@ Open `http://localhost:8080` in your browser.
 
 - **Lookup** (`/`): Enter a word or expression, select source/target language, optionally provide context. Results display inline. Conflict resolution UI appears when an existing entry is found with a new context.
 - **Batch** (`/batch`): Upload a CSV file, select mode and languages, set conflict strategy. Progress streams via SSE. Summary shows processed/cached/failed/replaced/added counts.
-- **Config** (`/config`): View and edit provider settings, test connection to the LLM provider.
+- **Config** (`/config`): View and edit provider settings, test connection to the LLM provider. Credential env var hints are shown per provider; API keys are read from environment variables automatically.
 - **Database** (`/database`): Browse, search, edit, delete vocabulary entries. Import CSV, export to Excel. Filter by language, search text, or tags.
 
 ## Tags

--- a/internal/web/handlers_batch.go
+++ b/internal/web/handlers_batch.go
@@ -94,8 +94,7 @@ func (s *Server) handleBatchJSON(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apiKey := r.FormValue("api_key")
-	provider, err := s.createProvider(apiKey)
+	provider, err := s.createProvider()
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "provider error: "+err.Error())
 		return
@@ -164,8 +163,7 @@ func (s *Server) handleBatchHTML(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apiKey := r.FormValue("api_key")
-	provider, err := s.createProvider(apiKey)
+	provider, err := s.createProvider()
 	if err != nil {
 		renderPartial(w, "batch_summary", map[string]any{"Error": "Provider error: " + err.Error()})
 		return

--- a/internal/web/handlers_config.go
+++ b/internal/web/handlers_config.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 
 	"github.com/user/vocabgen/internal/config"
 	"github.com/user/vocabgen/internal/service"
@@ -51,6 +52,13 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		updated.DBPath = s.cfg.DBPath
 	}
 
+	// Validate provider credentials are available via environment.
+	if warning := validateProviderEnv(updated.Provider, updated.BaseURL, updated.GCPProject); warning != "" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(`<p class="text-red-600 text-sm mt-1">` + warning + `</p>`))
+		return
+	}
+
 	if err := config.SaveConfig(updated); err != nil {
 		s.logger.Error("save config failed", "error", err)
 		writeJSONError(w, http.StatusInternalServerError, "failed to save config: "+err.Error())
@@ -88,8 +96,7 @@ func (s *Server) handleConfigHTML(w http.ResponseWriter, r *http.Request) {
 
 // handleTestConnection handles POST /api/test-connection.
 func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
-	apiKey := r.FormValue("api_key")
-	provider, err := s.createProvider(apiKey)
+	provider, err := s.createProvider()
 	if err != nil {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Write([]byte(`<div class="bg-red-50 border border-red-200 text-red-700 rounded p-3 text-sm">` +
@@ -109,4 +116,35 @@ func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(`<div class="bg-green-50 border border-green-200 text-green-700 rounded p-3 text-sm">` +
 		"Connection successful! Provider: " + provider.Name() + `</div>`))
+}
+
+// validateProviderEnv checks that the required environment variables or
+// credentials are available for the given provider. Returns an empty string
+// if everything looks good, or a user-facing warning message otherwise.
+func validateProviderEnv(provider, baseURL, gcpProject string) string {
+	switch provider {
+	case "openai":
+		if os.Getenv("OPENAI_API_KEY") == "" && baseURL == "" {
+			return "OPENAI_API_KEY environment variable is not set. Set it before starting the server: export OPENAI_API_KEY=sk-..."
+		}
+	case "anthropic":
+		if os.Getenv("ANTHROPIC_API_KEY") == "" {
+			return "ANTHROPIC_API_KEY environment variable is not set. Set it before starting the server: export ANTHROPIC_API_KEY=sk-ant-..."
+		}
+	case "bedrock":
+		// Lightweight check: look for any common AWS credential source.
+		if os.Getenv("AWS_ACCESS_KEY_ID") == "" && os.Getenv("AWS_PROFILE") == "" && os.Getenv("AWS_SESSION_TOKEN") == "" {
+			home, _ := os.UserHomeDir()
+			if home != "" {
+				if _, err := os.Stat(home + "/.aws/credentials"); err != nil {
+					return "No AWS credentials found. Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY environment variables, configure an AWS profile, or use an IAM role."
+				}
+			}
+		}
+	case "vertexai":
+		if gcpProject == "" && os.Getenv("GCP_PROJECT") == "" {
+			return "GCP project ID is required for Vertex AI. Set the GCP_PROJECT environment variable or fill in the GCP Project field."
+		}
+	}
+	return ""
 }

--- a/internal/web/handlers_config_test.go
+++ b/internal/web/handlers_config_test.go
@@ -1,0 +1,195 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidateProviderEnv(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   string
+		baseURL    string
+		gcpProject string
+		envVars    map[string]string
+		wantEmpty  bool // true = no warning expected
+		wantSubstr string
+	}{
+		{
+			name:      "openai with env var set",
+			provider:  "openai",
+			envVars:   map[string]string{"OPENAI_API_KEY": "sk-test"},
+			wantEmpty: true,
+		},
+		{
+			name:       "openai without env var",
+			provider:   "openai",
+			wantSubstr: "OPENAI_API_KEY",
+		},
+		{
+			name:      "openai with base_url skips key check",
+			provider:  "openai",
+			baseURL:   "http://localhost:11434/v1",
+			wantEmpty: true,
+		},
+		{
+			name:      "anthropic with env var set",
+			provider:  "anthropic",
+			envVars:   map[string]string{"ANTHROPIC_API_KEY": "sk-ant-test"},
+			wantEmpty: true,
+		},
+		{
+			name:       "anthropic without env var",
+			provider:   "anthropic",
+			wantSubstr: "ANTHROPIC_API_KEY",
+		},
+		{
+			name:      "bedrock with AWS_PROFILE set",
+			provider:  "bedrock",
+			envVars:   map[string]string{"AWS_PROFILE": "vocabgen"},
+			wantEmpty: true,
+		},
+		{
+			name:      "bedrock with AWS_ACCESS_KEY_ID set",
+			provider:  "bedrock",
+			envVars:   map[string]string{"AWS_ACCESS_KEY_ID": "AKIA..."},
+			wantEmpty: true,
+		},
+		{
+			name:       "vertexai with gcp_project form field",
+			provider:   "vertexai",
+			gcpProject: "my-project",
+			wantEmpty:  true,
+		},
+		{
+			name:      "vertexai with GCP_PROJECT env var",
+			provider:  "vertexai",
+			envVars:   map[string]string{"GCP_PROJECT": "my-project"},
+			wantEmpty: true,
+		},
+		{
+			name:       "vertexai without project",
+			provider:   "vertexai",
+			wantSubstr: "GCP project ID",
+		},
+		{
+			name:      "unknown provider passes",
+			provider:  "unknown",
+			wantEmpty: true,
+		},
+	}
+
+	envKeys := []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_SESSION_TOKEN", "GCP_PROJECT"}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, k := range envKeys {
+				t.Setenv(k, "")
+			}
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			got := validateProviderEnv(tc.provider, tc.baseURL, tc.gcpProject)
+			if tc.wantEmpty && got != "" {
+				t.Fatalf("expected no warning, got %q", got)
+			}
+			if !tc.wantEmpty && got == "" {
+				t.Fatal("expected a warning, got empty string")
+			}
+			if tc.wantSubstr != "" && !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("expected warning to contain %q, got %q", tc.wantSubstr, got)
+			}
+		})
+	}
+}
+
+func TestPutConfig_EnvVarValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		form       string
+		envVars    map[string]string
+		wantStatus int
+		wantSubstr string // expected in response body
+	}{
+		{
+			name:       "openai missing env var returns error",
+			form:       "provider=openai&model_id=gpt-4o&default_source_language=nl&default_target_language=hu",
+			wantStatus: http.StatusOK,
+			wantSubstr: "OPENAI_API_KEY",
+		},
+		{
+			name:       "openai with env var saves ok",
+			form:       "provider=openai&model_id=gpt-4o&default_source_language=nl&default_target_language=hu",
+			envVars:    map[string]string{"OPENAI_API_KEY": "sk-test"},
+			wantStatus: http.StatusOK,
+			wantSubstr: "Configuration saved",
+		},
+		{
+			name:       "openai with base_url skips key check",
+			form:       "provider=openai&model_id=llama3&base_url=http://localhost:11434/v1&default_source_language=nl&default_target_language=hu",
+			wantStatus: http.StatusOK,
+			wantSubstr: "Configuration saved",
+		},
+		{
+			name:       "anthropic missing env var returns error",
+			form:       "provider=anthropic&model_id=claude-sonnet-4-20250514&default_source_language=nl&default_target_language=hu",
+			wantStatus: http.StatusOK,
+			wantSubstr: "ANTHROPIC_API_KEY",
+		},
+		{
+			name:       "anthropic with env var saves ok",
+			form:       "provider=anthropic&model_id=claude-sonnet-4-20250514&default_source_language=nl&default_target_language=hu",
+			envVars:    map[string]string{"ANTHROPIC_API_KEY": "sk-ant-test"},
+			wantStatus: http.StatusOK,
+			wantSubstr: "Configuration saved",
+		},
+		{
+			name:       "vertexai missing project returns error",
+			form:       "provider=vertexai&model_id=gemini-pro&default_source_language=nl&default_target_language=hu",
+			wantStatus: http.StatusOK,
+			wantSubstr: "GCP project ID",
+		},
+		{
+			name:       "vertexai with gcp_project field saves ok",
+			form:       "provider=vertexai&model_id=gemini-pro&gcp_project=my-proj&default_source_language=nl&default_target_language=hu",
+			wantStatus: http.StatusOK,
+			wantSubstr: "Configuration saved",
+		},
+		{
+			name:       "bedrock with AWS_PROFILE saves ok",
+			form:       "provider=bedrock&aws_profile=vocabgen&aws_region=us-east-1&default_source_language=nl&default_target_language=hu",
+			envVars:    map[string]string{"AWS_PROFILE": "vocabgen"},
+			wantStatus: http.StatusOK,
+			wantSubstr: "Configuration saved",
+		},
+	}
+
+	envKeys := []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_SESSION_TOKEN", "GCP_PROJECT"}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, k := range envKeys {
+				t.Setenv(k, "")
+			}
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			srv := newTestServer()
+			req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(tc.form))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d; body: %s", tc.wantStatus, w.Code, w.Body.String())
+			}
+			if tc.wantSubstr != "" && !strings.Contains(w.Body.String(), tc.wantSubstr) {
+				t.Fatalf("expected body to contain %q, got %q", tc.wantSubstr, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/web/handlers_lookup.go
+++ b/internal/web/handlers_lookup.go
@@ -17,7 +17,6 @@ type lookupRequest struct {
 	Context        string `json:"context"`
 	TargetLanguage string `json:"target_language"`
 	Tags           string `json:"tags"`
-	APIKey         string `json:"api_key"`
 }
 
 // resolveRequest is the JSON body for POST /api/lookup/resolve.
@@ -31,17 +30,17 @@ type resolveRequest struct {
 	Tags           string        `json:"tags"`
 }
 
-func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, string, error) {
+func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, error) {
 	var req lookupRequest
 
 	if r.Header.Get("Content-Type") == "application/json" {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			return service.LookupParams{}, "", fmt.Errorf("invalid JSON: %w", err)
+			return service.LookupParams{}, fmt.Errorf("invalid JSON: %w", err)
 		}
 	} else {
 		// Form-encoded (HTMX)
 		if err := r.ParseForm(); err != nil {
-			return service.LookupParams{}, "", fmt.Errorf("invalid form: %w", err)
+			return service.LookupParams{}, fmt.Errorf("invalid form: %w", err)
 		}
 		req = lookupRequest{
 			SourceLanguage: r.FormValue("source_language"),
@@ -50,12 +49,11 @@ func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, strin
 			Context:        r.FormValue("context"),
 			TargetLanguage: r.FormValue("target_language"),
 			Tags:           r.FormValue("tags"),
-			APIKey:         r.FormValue("api_key"),
 		}
 	}
 
 	if req.Text == "" {
-		return service.LookupParams{}, "", fmt.Errorf("text is required")
+		return service.LookupParams{}, fmt.Errorf("text is required")
 	}
 	if req.SourceLanguage == "" {
 		req.SourceLanguage = s.cfg.DefaultSourceLanguage
@@ -67,9 +65,9 @@ func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, strin
 		req.LookupType = "word"
 	}
 
-	provider, err := s.createProvider(req.APIKey)
+	provider, err := s.createProvider()
 	if err != nil {
-		return service.LookupParams{}, "", fmt.Errorf("provider error: %w", err)
+		return service.LookupParams{}, fmt.Errorf("provider error: %w", err)
 	}
 
 	return service.LookupParams{
@@ -81,12 +79,12 @@ func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, strin
 		Context:    req.Context,
 		TargetLang: req.TargetLanguage,
 		Tags:       req.Tags,
-	}, req.APIKey, nil
+	}, nil
 }
 
 // handleLookupJSON handles POST /api/lookup — JSON endpoint.
 func (s *Server) handleLookupJSON(w http.ResponseWriter, r *http.Request) {
-	params, _, err := s.parseLookupParams(r)
+	params, err := s.parseLookupParams(r)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
@@ -104,7 +102,7 @@ func (s *Server) handleLookupJSON(w http.ResponseWriter, r *http.Request) {
 
 // handleLookupHTML handles POST /api/lookup/html — HTMX endpoint.
 func (s *Server) handleLookupHTML(w http.ResponseWriter, r *http.Request) {
-	params, _, err := s.parseLookupParams(r)
+	params, err := s.parseLookupParams(r)
 	if err != nil {
 		renderPartial(w, "lookup_result", map[string]any{"Error": err.Error()})
 		return

--- a/internal/web/integration_test.go
+++ b/internal/web/integration_test.go
@@ -92,6 +92,7 @@ func TestIntegration_GetConfig(t *testing.T) {
 // --- Test 4: PUT /api/config with form-encoded body updates config ---
 
 func TestIntegration_PutConfig_FormEncoded(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
 	srv := newTestServer()
 
 	form := "provider=openai&model_id=gpt-4o&default_source_language=hu&default_target_language=en"

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/user/vocabgen/internal/config"
@@ -153,18 +154,34 @@ func (s *Server) handleLanguages(w http.ResponseWriter, r *http.Request) {
 }
 
 // createProvider creates an LLM provider from the current config.
-// apiKey is optional and used for OpenAI/Anthropic providers.
-func (s *Server) createProvider(apiKey string) (llm.Provider, error) {
+// API keys are resolved from environment variables, matching the CLI pattern.
+func (s *Server) createProvider() (llm.Provider, error) {
 	constructor, ok := llm.Registry[s.cfg.Provider]
 	if !ok {
 		return nil, &llm.ProviderError{Provider: s.cfg.Provider, Message: "unknown provider"}
 	}
+
+	// Resolve API key from env vars (same logic as cmd/vocabgen/main.go).
+	var apiKey string
+	switch s.cfg.Provider {
+	case "openai":
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	case "anthropic":
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+
+	// Resolve GCP project from config or env var.
+	gcpProject := s.cfg.GCPProject
+	if gcpProject == "" {
+		gcpProject = os.Getenv("GCP_PROJECT")
+	}
+
 	return constructor(llm.ProviderOptions{
 		APIKey:     apiKey,
 		BaseURL:    s.cfg.BaseURL,
 		Region:     s.cfg.AWSRegion,
 		Profile:    s.cfg.AWSProfile,
-		GCPProject: s.cfg.GCPProject,
+		GCPProject: gcpProject,
 	})
 }
 

--- a/internal/web/templates/partials/config_form.html
+++ b/internal/web/templates/partials/config_form.html
@@ -14,6 +14,9 @@
   </div>
 
   {{if eq .Config.Provider "bedrock"}}
+  <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
+    Requires AWS credentials via <code class="font-mono bg-blue-100 px-1 rounded">~/.aws/credentials</code>, environment variables, or IAM role.
+  </div>
   <div>
     <label for="aws_profile" class="block text-sm font-medium text-gray-700 mb-1">AWS Profile</label>
     <input type="text" id="aws_profile" name="aws_profile" value="{{.Config.AWSProfile}}"
@@ -27,11 +30,9 @@
   {{end}}
 
   {{if eq .Config.Provider "openai"}}
-  <div>
-    <label for="api_key" class="block text-sm font-medium text-gray-700 mb-1">API Key (runtime only, not saved)</label>
-    <input type="password" id="api_key" name="api_key"
-           class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-           placeholder="sk-...">
+  <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
+    Set <code class="font-mono bg-blue-100 px-1 rounded">OPENAI_API_KEY</code> environment variable before starting the server.
+    Not required when using a local server (Ollama, LM Studio) via Base URL.
   </div>
   <div>
     <label for="base_url" class="block text-sm font-medium text-gray-700 mb-1">Base URL (optional)</label>
@@ -42,15 +43,16 @@
   {{end}}
 
   {{if eq .Config.Provider "anthropic"}}
-  <div>
-    <label for="api_key" class="block text-sm font-medium text-gray-700 mb-1">API Key (runtime only, not saved)</label>
-    <input type="password" id="api_key" name="api_key"
-           class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-           placeholder="sk-ant-...">
+  <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
+    Set <code class="font-mono bg-blue-100 px-1 rounded">ANTHROPIC_API_KEY</code> environment variable before starting the server.
   </div>
   {{end}}
 
   {{if eq .Config.Provider "vertexai"}}
+  <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
+    Requires Google Application Default Credentials and a GCP Project ID
+    (set <code class="font-mono bg-blue-100 px-1 rounded">GCP_PROJECT</code> env var or fill in below).
+  </div>
   <div>
     <label for="gcp_project" class="block text-sm font-medium text-gray-700 mb-1">GCP Project</label>
     <input type="text" id="gcp_project" name="gcp_project" value="{{.Config.GCPProject}}"
@@ -109,6 +111,7 @@
     </button>
     <button type="button"
             hx-post="/api/test-connection"
+            hx-include="#config-save-form"
             hx-target="#connection-status"
             hx-swap="innerHTML"
             class="border border-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">


### PR DESCRIPTION
Fixes #6
Fixes #7
Fixes #8

## Changes

- Remove API key form fields from web UI — credentials are now read exclusively from environment variables
- Add provider credential validation with clear warnings per provider (OpenAI, Anthropic, Bedrock, Vertex AI)
- Expand user guide configuration docs (provider credentials table, Web UI setup, CLI flag overrides)
- Correct Bedrock model IDs in docs and add cross-region inference profile note
- Add Windows and macOS Intel installation instructions