### PR TITLE
fix: add missing changelog entries for v1.0.1, update release hook for protected main

### DIFF
--- a/.kiro/hooks/trigger-release.kiro.hook
+++ b/.kiro/hooks/trigger-release.kiro.hook
@@ -1,0 +1,15 @@
+{
+  "enabled": true,
+  "name": "6. Release",
+  "description": "Validates changes since last tag (commit/PR count), suggests next version, updates CHANGELOG.md via a release branch + PR, then runs scripts/release.sh after merge.",
+  "version": "2",
+  "when": {
+    "type": "userTriggered"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "The user wants to create a release. Main is protected — all changes go through PRs. Follow these steps:\n\n1. FIND LATEST TAG: Run `git tag --list 'v*' --sort=-v:refname | head -1`.\n\n2. RELEASE VALIDATION:\n   - Run `git log {latest_tag}..origin/main --oneline` to list commits since last tag.\n   - Run `git log {latest_tag}..origin/main --merges --oneline` to count merged PRs.\n   - Display: 'Since {latest_tag}: X commits, Y pull requests'.\n   - If ZERO commits, tell the user there's nothing to release and STOP.\n\n3. SUGGEST VERSION: Calculate next patch version (increment last number). Ask: 'Since {latest_tag}: X commits, Y PRs. Suggested next version: {next}. What tag would you like to use?'\n\n4. UPDATE CHANGELOG: Once user confirms a tag:\n   - Make sure you're on main and it's up to date: `git checkout main` then `git pull origin main`.\n   - Create a release branch: `git checkout -b release/{tag}`.\n   - Read CHANGELOG.md.\n   - If `## [Unreleased]` section exists: replace `## [Unreleased]` with `## [{version_without_v}] - {today YYYY-MM-DD}`.\n   - If NO `## [Unreleased]` section exists: generate entries from commit messages since last tag. Run `git log {latest_tag}..HEAD --oneline --no-merges` and categorize commits by prefix (feat/fix/docs/chore). Create a new section `## [{version_without_v}] - {today}` with ### Added (feat), ### Changed, ### Fixed (fix), ### Docs (docs) subsections. Insert it above the previous release heading.\n   - Commit: `git add CHANGELOG.md` then `git commit -m 'docs: update changelog for {tag}'`.\n   - Push: `git push origin release/{tag}`.\n   - Tell the user: 'Pushed release/{tag}. Create a PR, merge it, then run hook 6 again or run `./scripts/release.sh {tag}` on main after merge.'\n   - STOP here — do not run release.sh yet.\n\n5. IF ALREADY ON MAIN WITH CHANGELOG READY: If the user says the PR is merged, or if we're on main and the changelog already has the version heading (not [Unreleased]):\n   - `git checkout main` then `git pull origin main`.\n   - Run `./scripts/release.sh {tag}` with executeBash and timeout 300s."
+  },
+  "workspaceFolderName": "VocabGen",
+  "shortName": "trigger-release"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Web UI config page reads API keys from environment variables instead of form fields, matching CLI behavior
+- Provider credential hints shown per provider on config page (env var names, setup instructions)
+
+### Fixed
+
+- Web UI test-connection and batch endpoints no longer require API key in request body
+- Added provider credential validation on config save — warns if required env vars are missing
+- Corrected Bedrock model IDs in docs, added cross-region inference profile note
+- Added Windows and macOS Intel installation instructions to user guide
+
+### Docs
+
+- Expanded user guide with Configuration section, Quick Setup via Web UI, CLI flag overrides, and provider credentials table
+- README links to Web UI setup instructions
+
 ## [1.0.0] - 2026-04-02
 
 ### Added


### PR DESCRIPTION
Add missing changelog entries for v1.0.1 PRs and update the release hook to handle protected main branch via release branch + PR workflow.

## Changes

- Add missing changelog entries for v1.0.1 PRs
- Update release hook to handle protected main via release branch + PR
- Correct Bedrock model IDs in docs, add cross-region inference profile note
- Add Windows and macOS Intel installation instructions
- Remove API key form fields from web UI, read credentials from env vars
- Add provider credential validation and expand user guide configuration docs