### PR TITLE
fix: use CHANGELOG.md for GitHub release notes instead of commit log

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,4 +28,7 @@ archives:
 checksum:
   name_template: checksums.txt
 changelog:
-  sort: asc
+  disable: true
+
+release:
+  header: "{{ .TagBody }}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -93,7 +93,13 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 0
 fi
 
-git tag -a "$VERSION" -m "Release $VERSION"
+RELEASE_NOTES=$(awk "/^## \[${CHANGELOG_VER}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+if [ -z "$RELEASE_NOTES" ]; then
+    echo "WARNING: Could not extract release notes from CHANGELOG.md. Using default message."
+    RELEASE_NOTES="Release $VERSION"
+fi
+
+git tag -a "$VERSION" -m "Release $VERSION" -m "$RELEASE_NOTES"
 git push origin "$VERSION"
 
 echo ""


### PR DESCRIPTION
Fixes #37

**Problem**: GitHub release pages showed raw commit hashes instead of curated CHANGELOG.md content because goreleaser auto-generated a changelog from git commits between tags.

**Fix**:
- Disabled goreleaser's auto-changelog and added `release.header: {{ .TagBody }}` so it uses the annotated tag body
- Updated `scripts/release.sh` to extract the changelog section for the version and embed it as a second `-m` in the annotated git tag
- Retroactively updated all existing releases (v1.0.1–v1.2.0) with curated CHANGELOG.md content via `gh release edit`