### PR TITLE
v1.2.1: bulk delete, batch cancellation, profile save fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2026-04-18
+
+### Added
+
+- Bulk delete for database entries — select individual entries or use select-all, then delete in one action (#33, #34)
+- Batch processing cancellation — cancel a running batch from the Web UI with partial results preserved (#32)
+
+### Fixed
+
+- Config profile switching now correctly refreshes the form and saves to the selected profile (#28)
+
 ## [1.2.0] - 2026-04-05
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,7 +192,7 @@ Server-side rendering with Go `html/template` + HTMX + Tailwind CSS (CDN). All t
 
 **HTMX pattern**: Forms use `hx-post` to send requests; server returns HTML fragments that HTMX swaps into the page. No JSON parsing on the client side for UI interactions.
 
-**Batch progress**: Server-Sent Events (SSE) stream real-time progress via `http.Flusher`. Client uses HTMX SSE extension.
+**Batch progress**: Server-Sent Events (SSE) stream real-time progress via `http.Flusher`. Client uses HTMX SSE extension. Supports cancellation — client aborts the fetch via `AbortController`, server detects context cancellation and emits a `cancelled` event with partial results.
 
 **Conflict resolution UI**: When a lookup with context finds existing entries, the server returns a `lookup_conflict.html` partial showing existing entries side-by-side with the new result, plus resolve buttons (replace/add/skip).
 
@@ -396,6 +396,7 @@ Forms use `hx-post`/`hx-put`/`hx-delete` to send requests. Server returns HTML f
 | Search database | GET /api/words?search=... | `entry_table.html` |
 | Edit entry | PUT /api/words/{id} | Updated row HTML |
 | Delete entry | DELETE /api/words/{id} | Empty (row removed) |
+| Bulk delete | DELETE /api/words/bulk | Updated table HTML |
 | Import CSV | POST /api/import | Import summary |
 | Export Excel | GET /api/export | .xlsx file download |
 
@@ -420,6 +421,8 @@ Forms use `hx-post`/`hx-put`/`hx-delete` to send requests. Server returns HTML f
 | PUT | /api/expressions/{id} | Update expression entry |
 | DELETE | /api/words/{id} | Delete word entry |
 | DELETE | /api/expressions/{id} | Delete expression entry |
+| DELETE | /api/words/bulk | Bulk delete word entries |
+| DELETE | /api/expressions/bulk | Bulk delete expression entries |
 | POST | /api/import | CSV import (multipart) |
 | GET | /api/export | Excel export |
 | GET | /api/health | Health check |
@@ -437,7 +440,7 @@ Dual approach: property-based tests (rapid) for universal invariants + table-dri
 
 19 correctness properties validated via `pgregory.net/rapid` (100+ iterations each). Integration tests with mocked LLM providers and real SQLite. Web API tests via `httptest`.
 
-See the design document for the full list of correctness properties (P1–P25).
+See the design document for the full list of correctness properties (P1–P32).
 
 ## Key Design Decisions
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -273,9 +273,9 @@ Open `http://localhost:8080` in your browser.
 ### Pages
 
 - **Lookup** (`/`): Enter a word or expression, select source/target language, optionally provide context. Results display inline. Conflict resolution UI appears when an existing entry is found with a new context.
-- **Batch** (`/batch`): Upload a CSV file, select mode and languages, set conflict strategy. Progress streams via SSE. Summary shows processed/cached/failed/replaced/added counts.
+- **Batch** (`/batch`): Upload a CSV file, select mode and languages, set conflict strategy. Progress streams via SSE. Cancel a running batch at any time — partial results are preserved. Summary shows processed/cached/failed/replaced/added counts.
 - **Config** (`/config`): View and edit provider settings, test connection to the LLM provider. Credential env var hints are shown per provider; API keys are read from environment variables automatically. On first launch, the "default" profile is shown — edit the fields and click Save to configure your provider. Use "Add new profile…" in the profile dropdown to create additional setups (e.g., a "local" profile for Ollama and a "prod" profile for Bedrock).
-- **Database** (`/database`): Browse, search, edit, delete vocabulary entries. Import CSV, export to Excel. Filter by language, search text, or tags.
+- **Database** (`/database`): Browse, search, edit, delete vocabulary entries. Select individual entries or use select-all to bulk delete. Import CSV, export to Excel. Filter by language, search text, or tags.
 
 ### Help Menu
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -278,8 +278,9 @@ func ListProfiles() (profiles []string, defaultProfile string, err error) {
 // Creates the directory if it doesn't exist.
 // Never writes API keys to the file.
 // If the existing config file uses multi-profile format, SaveConfig preserves
-// that structure by updating the default profile within the FileConfig.
-func SaveConfig(cfg Config) error {
+// that structure by updating the specified activeProfile within the FileConfig.
+// If activeProfile is empty, it falls back to the file's default_profile.
+func SaveConfig(cfg Config, activeProfile string) error {
 	dir, err := getConfigDir()
 	if err != nil {
 		return err
@@ -294,7 +295,10 @@ func SaveConfig(cfg Config) error {
 	if existing != nil && isMultiProfile(existing) {
 		var fc FileConfig
 		if err := yaml.Unmarshal(existing, &fc); err == nil {
-			profileName := fc.DefaultProfile
+			profileName := activeProfile
+			if profileName == "" {
+				profileName = fc.DefaultProfile
+			}
 			if profileName == "" {
 				for k := range fc.Profiles {
 					profileName = k

--- a/internal/config/config_profiles_test.go
+++ b/internal/config/config_profiles_test.go
@@ -361,7 +361,7 @@ func TestListProfiles_TableDriven(t *testing.T) {
 
 	t.Run("flat config", func(t *testing.T) {
 		configDir = t.TempDir()
-		if err := SaveConfig(DefaultConfig()); err != nil {
+		if err := SaveConfig(DefaultConfig(), ""); err != nil {
 			t.Fatalf("SaveConfig: %v", err)
 		}
 		profiles, def, err := ListProfiles()
@@ -445,7 +445,7 @@ func TestSaveConfigPreservesMultiProfile(t *testing.T) {
 		DefaultTargetLanguage: "en",
 		DBPath:                "~/.vocabgen/vocabgen.db",
 	}
-	if err := SaveConfig(updated); err != nil {
+	if err := SaveConfig(updated, "prod"); err != nil {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,7 +33,7 @@ func TestPropertyConfigRoundTrip(t *testing.T) {
 			DBPath:                rapid.StringMatching(`[a-zA-Z0-9_./-]+`).Draw(t, "DBPath"),
 		}
 
-		if err := SaveConfig(cfg); err != nil {
+		if err := SaveConfig(cfg, ""); err != nil {
 			t.Fatalf("SaveConfig failed: %v", err)
 		}
 
@@ -85,7 +85,7 @@ func TestSaveConfigNoAPIKey(t *testing.T) {
 		DBPath:                "/tmp/test.db",
 	}
 
-	if err := SaveConfig(cfg); err != nil {
+	if err := SaveConfig(cfg, ""); err != nil {
 		t.Fatalf("SaveConfig failed: %v", err)
 	}
 
@@ -109,7 +109,7 @@ func TestSaveConfigCreatesDirectory(t *testing.T) {
 	t.Cleanup(func() { configDir = origDir })
 
 	cfg := DefaultConfig()
-	if err := SaveConfig(cfg); err != nil {
+	if err := SaveConfig(cfg, ""); err != nil {
 		t.Fatalf("SaveConfig failed: %v", err)
 	}
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -519,3 +519,153 @@ func TestGetExpression_ByID(t *testing.T) {
 		t.Errorf("got %q, want %q", got.Expression, "op de hoogte")
 	}
 }
+
+func TestDeleteWords_BulkDelete(t *testing.T) {
+	tests := []struct {
+		name      string
+		insertN   int
+		deleteIDs func(ids []int64) []int64
+		wantAfter int
+		wantErr   bool
+	}{
+		{
+			name:    "delete all",
+			insertN: 3,
+			deleteIDs: func(ids []int64) []int64 {
+				return ids
+			},
+			wantAfter: 0,
+		},
+		{
+			name:    "delete subset",
+			insertN: 3,
+			deleteIDs: func(ids []int64) []int64 {
+				return ids[:2]
+			},
+			wantAfter: 1,
+		},
+		{
+			name:    "empty slice is no-op",
+			insertN: 2,
+			deleteIDs: func(_ []int64) []int64 {
+				return []int64{}
+			},
+			wantAfter: 2,
+		},
+		{
+			name:    "non-existent IDs are ignored",
+			insertN: 2,
+			deleteIDs: func(_ []int64) []int64 {
+				return []int64{99998, 99999}
+			},
+			wantAfter: 2,
+		},
+		{
+			name:    "mixed valid and non-existent",
+			insertN: 3,
+			deleteIDs: func(ids []int64) []int64 {
+				return []int64{ids[0], 99999}
+			},
+			wantAfter: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestStore(t)
+			ctx := context.Background()
+
+			var ids []int64
+			for i := 0; i < tc.insertN; i++ {
+				row := makeWordRow("bulk"+string(rune('A'+i)), "nl")
+				if err := store.InsertWord(ctx, row); err != nil {
+					t.Fatalf("insert %d: %v", i, err)
+				}
+				ids = append(ids, row.ID)
+			}
+
+			err := store.DeleteWords(ctx, tc.deleteIDs(ids))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("DeleteWords error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			all, _, err := store.ListWords(ctx, ListFilter{SourceLang: "nl", Page: 1, PageSize: 100})
+			if err != nil {
+				t.Fatalf("ListWords: %v", err)
+			}
+			if len(all) != tc.wantAfter {
+				t.Errorf("got %d entries, want %d", len(all), tc.wantAfter)
+			}
+		})
+	}
+}
+
+func TestDeleteExpressions_BulkDelete(t *testing.T) {
+	tests := []struct {
+		name      string
+		insertN   int
+		deleteIDs func(ids []int64) []int64
+		wantAfter int
+	}{
+		{
+			name:    "delete all",
+			insertN: 3,
+			deleteIDs: func(ids []int64) []int64 {
+				return ids
+			},
+			wantAfter: 0,
+		},
+		{
+			name:    "delete subset",
+			insertN: 3,
+			deleteIDs: func(ids []int64) []int64 {
+				return ids[:1]
+			},
+			wantAfter: 2,
+		},
+		{
+			name:    "empty slice is no-op",
+			insertN: 2,
+			deleteIDs: func(_ []int64) []int64 {
+				return []int64{}
+			},
+			wantAfter: 2,
+		},
+		{
+			name:    "non-existent IDs are ignored",
+			insertN: 1,
+			deleteIDs: func(_ []int64) []int64 {
+				return []int64{99999}
+			},
+			wantAfter: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestStore(t)
+			ctx := context.Background()
+
+			var ids []int64
+			for i := 0; i < tc.insertN; i++ {
+				row := makeExpressionRow("bulk expr "+string(rune('A'+i)), "nl")
+				if err := store.InsertExpression(ctx, row); err != nil {
+					t.Fatalf("insert %d: %v", i, err)
+				}
+				ids = append(ids, row.ID)
+			}
+
+			if err := store.DeleteExpressions(ctx, tc.deleteIDs(ids)); err != nil {
+				t.Fatalf("DeleteExpressions: %v", err)
+			}
+
+			all, _, err := store.ListExpressions(ctx, ListFilter{SourceLang: "nl", Page: 1, PageSize: 100})
+			if err != nil {
+				t.Fatalf("ListExpressions: %v", err)
+			}
+			if len(all) != tc.wantAfter {
+				t.Errorf("got %d entries, want %d", len(all), tc.wantAfter)
+			}
+		})
+	}
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -279,6 +279,40 @@ func (s *SQLiteStore) DeleteExpression(ctx context.Context, id int64) error {
 	return err
 }
 
+// DeleteWords removes multiple word entries by their IDs using a single query
+// with parameterized placeholders.
+func (s *SQLiteStore) DeleteWords(ctx context.Context, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := fmt.Sprintf(`DELETE FROM words WHERE id IN (%s)`, strings.Join(placeholders, ","))
+	_, err := s.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+// DeleteExpressions removes multiple expression entries by their IDs using a
+// single query with parameterized placeholders.
+func (s *SQLiteStore) DeleteExpressions(ctx context.Context, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := fmt.Sprintf(`DELETE FROM expressions WHERE id IN (%s)`, strings.Join(placeholders, ","))
+	_, err := s.db.ExecContext(ctx, query, args...)
+	return err
+}
+
 // --- List with pagination and filtering ---
 
 // ListWords returns paginated word entries with optional filters.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -48,8 +48,14 @@ type Store interface {
 	// DeleteWord removes a word entry by ID.
 	DeleteWord(ctx context.Context, id int64) error
 
+	// DeleteWords removes multiple word entries by their IDs.
+	DeleteWords(ctx context.Context, ids []int64) error
+
 	// DeleteExpression removes an expression entry by ID.
 	DeleteExpression(ctx context.Context, id int64) error
+
+	// DeleteExpressions removes multiple expression entries by their IDs.
+	DeleteExpressions(ctx context.Context, ids []int64) error
 
 	// ImportWords bulk-inserts word rows, skipping duplicates.
 	ImportWords(ctx context.Context, rows []WordRow) (imported, skipped, failed int, err error)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -571,6 +571,11 @@ func ProcessBatch(ctx context.Context, store db.Store, params BatchParams) (*Bat
 	total := len(params.Tokens)
 
 	for i, tc := range params.Tokens {
+		// Check for context cancellation (e.g. client disconnect)
+		if ctx.Err() != nil {
+			break
+		}
+
 		// Normalize
 		var normalized string
 		if params.Mode == "words" {
@@ -634,6 +639,10 @@ func ProcessBatch(ctx context.Context, store db.Store, params BatchParams) (*Bat
 }
 
 func processBatchWord(ctx context.Context, store db.Store, params BatchParams, sourceLang, targetLang, normalized, ctxSentence string, result *BatchResult, newCount *int) {
+	if ctx.Err() != nil {
+		return
+	}
+
 	existing, err := store.FindWords(ctx, normalized, params.SourceLang)
 	if err != nil {
 		slog.Error("batch: database lookup failed", slog.String("word", normalized), slog.String("error", err.Error()))
@@ -708,6 +717,10 @@ func processBatchWord(ctx context.Context, store db.Store, params BatchParams, s
 }
 
 func processBatchExpression(ctx context.Context, store db.Store, params BatchParams, sourceLang, targetLang, normalized, ctxSentence string, result *BatchResult, newCount *int) {
+	if ctx.Err() != nil {
+		return
+	}
+
 	existing, err := store.FindExpressions(ctx, normalized, params.SourceLang)
 	if err != nil {
 		slog.Error("batch: database lookup failed", slog.String("expression", normalized), slog.String("error", err.Error()))

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1057,3 +1057,78 @@ func TestLookup_RejectsInvalidToken(t *testing.T) {
 		t.Errorf("expected 'invalid input' error, got: %v", err)
 	}
 }
+
+func TestProcessBatch_CancelledContext(t *testing.T) {
+	store := newTestStore(t)
+	provider := &mockProvider{}
+
+	tokens := []parsing.TokenWithContext{
+		{Token: "woord"},
+		{Token: "huis"},
+		{Token: "boek"},
+		{Token: "tafel"},
+		{Token: "stoel"},
+	}
+
+	// Pre-cancel the context before calling ProcessBatch
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := ProcessBatch(ctx, store, BatchParams{
+		SourceLang: "nl",
+		Mode:       "words",
+		Tokens:     tokens,
+		Provider:   provider,
+		ModelID:    "test",
+		TargetLang: "hu",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// With a pre-cancelled context, the loop should break immediately
+	total := result.Processed + result.Cached + result.Failed + result.Skipped + result.Replaced + result.Added
+	if total >= len(tokens) {
+		t.Errorf("expected fewer than %d items processed with cancelled context, got %d", len(tokens), total)
+	}
+
+	// Provider should not have been invoked (context was already cancelled)
+	if provider.invocations.Load() != 0 {
+		t.Errorf("expected 0 provider invocations with pre-cancelled context, got %d", provider.invocations.Load())
+	}
+}
+
+func TestProcessBatch_CancelledContextExpressions(t *testing.T) {
+	store := newTestStore(t)
+	provider := &mockExprProvider{}
+
+	tokens := []parsing.TokenWithContext{
+		{Token: "aan het licht komen"},
+		{Token: "er de brui aan geven"},
+		{Token: "vandaag de dag"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := ProcessBatch(ctx, store, BatchParams{
+		SourceLang: "nl",
+		Mode:       "expressions",
+		Tokens:     tokens,
+		Provider:   provider,
+		ModelID:    "test",
+		TargetLang: "hu",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	total := result.Processed + result.Cached + result.Failed + result.Skipped + result.Replaced + result.Added
+	if total >= len(tokens) {
+		t.Errorf("expected fewer than %d items processed with cancelled context, got %d", len(tokens), total)
+	}
+
+	if provider.invocations.Load() != 0 {
+		t.Errorf("expected 0 provider invocations with pre-cancelled context, got %d", provider.invocations.Load())
+	}
+}

--- a/internal/web/handlers_batch.go
+++ b/internal/web/handlers_batch.go
@@ -303,6 +303,22 @@ func (s *Server) handleBatchStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if processing was cancelled (client disconnected or abort)
+	if r.Context().Err() != nil {
+		data, _ := json.Marshal(map[string]any{
+			"processed": result.Processed,
+			"cached":    result.Cached,
+			"failed":    result.Failed,
+			"skipped":   result.Skipped,
+			"replaced":  result.Replaced,
+			"added":     result.Added,
+			"errors":    result.Errors,
+		})
+		_, _ = fmt.Fprintf(w, "event: cancelled\ndata: %s\n\n", data)
+		flusher.Flush()
+		return
+	}
+
 	// Send final complete event with summary
 	data, _ := json.Marshal(map[string]any{
 		"processed": result.Processed,

--- a/internal/web/handlers_config.go
+++ b/internal/web/handlers_config.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"html/template"
 	"net/http"
 	"os"
 	"strings"
@@ -64,8 +65,24 @@ func (s *Server) handleSwitchProfile(w http.ResponseWriter, r *http.Request) {
 	s.activeProfile = req.Profile
 	s.logger.Info("switched config profile", "profile", req.Profile)
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte(`<p class="text-green-600 text-sm mt-1">Switched to profile "` + req.Profile + `".</p>`))
+	// Re-render the full config form with the new profile's values.
+	// This replaces the two-step approach (PUT then GET) that was prone to
+	// stale form values leaking into the re-render request (#28).
+	profiles, _, _ := config.ListProfiles()
+	data := struct {
+		Config        *config.Config
+		Languages     []service.LanguageInfo
+		Profiles      []string
+		ActiveProfile string
+		StatusMessage template.HTML
+	}{
+		Config:        &cfg,
+		Languages:     service.GetSupportedLanguages(),
+		Profiles:      profiles,
+		ActiveProfile: s.activeProfile,
+		StatusMessage: template.HTML(`<p class="text-green-600 text-sm mt-1">Switched to profile "` + req.Profile + `".</p>`),
+	}
+	_ = renderPartial(w, "config_form", data)
 }
 
 // handleCreateProfile handles POST /api/profiles — create a new profile by copying an existing one.
@@ -158,7 +175,7 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := config.SaveConfig(updated); err != nil {
+	if err := config.SaveConfig(updated, s.activeProfile); err != nil {
 		s.logger.Error("save config failed", "error", err)
 		writeJSONError(w, http.StatusInternalServerError, "failed to save config: "+err.Error())
 		return
@@ -167,8 +184,10 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	// Update in-memory config
 	*s.cfg = updated
 
+	s.logger.Info("config saved", "profile", s.activeProfile, "provider", updated.Provider)
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte(`<p class="text-green-600 text-sm mt-1">Configuration saved.</p>`))
+	_, _ = w.Write([]byte(`<p class="text-green-600 text-sm mt-1">Configuration saved to profile "` + s.activeProfile + `".</p>`))
 }
 
 // handleConfigHTML handles GET /api/config/html — render config form partial.
@@ -195,6 +214,7 @@ func (s *Server) handleConfigHTML(w http.ResponseWriter, r *http.Request) {
 		Languages     []service.LanguageInfo
 		Profiles      []string
 		ActiveProfile string
+		StatusMessage template.HTML
 	}{
 		Config:        &cfg,
 		Languages:     service.GetSupportedLanguages(),

--- a/internal/web/handlers_config_test.go
+++ b/internal/web/handlers_config_test.go
@@ -333,8 +333,9 @@ func TestSwitchProfile_ChangesActiveConfig(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "Switched to profile") {
-		t.Fatalf("expected success message, got: %s", w.Body.String())
+	// The response is now the full re-rendered config form HTML.
+	if !strings.Contains(w.Body.String(), "config-save-form") {
+		t.Fatalf("expected config form HTML in response, got: %s", w.Body.String())
 	}
 
 	// Verify in-memory config was updated.
@@ -442,7 +443,7 @@ func TestConfigFormAlwaysShowsProfileSelector(t *testing.T) {
 	})
 
 	cfg := config.DefaultConfig()
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := config.SaveConfig(cfg, ""); err != nil {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
@@ -613,7 +614,7 @@ func TestProfileSwitch_ConfigHTMLReflectsNewProfile(t *testing.T) {
 
 	srv := newTestServer()
 
-	// Step 1: Switch to "local" profile.
+	// Switch to "local" profile — response now contains the re-rendered form.
 	body := `{"profile":"local"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/profile/switch", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -622,15 +623,6 @@ func TestProfileSwitch_ConfigHTMLReflectsNewProfile(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("switch: expected 200, got %d; body: %s", w.Code, w.Body.String())
-	}
-
-	// Step 2: GET /api/config/html WITHOUT any form params (clean request).
-	req = httptest.NewRequest(http.MethodGet, "/api/config/html", nil)
-	w = httptest.NewRecorder()
-	srv.mux.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("config/html: expected 200, got %d", w.Code)
 	}
 
 	html := w.Body.String()

--- a/internal/web/handlers_db.go
+++ b/internal/web/handlers_db.go
@@ -411,6 +411,63 @@ func (s *Server) handleDeleteExpression(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
+// bulkDeleteRequest is the JSON body for bulk delete endpoints.
+type bulkDeleteRequest struct {
+	IDs []int64 `json:"ids"`
+}
+
+// handleBulkDeleteWords handles DELETE /api/words/bulk.
+func (s *Server) handleBulkDeleteWords(w http.ResponseWriter, r *http.Request) {
+	var req bulkDeleteRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "ids must not be empty")
+		return
+	}
+
+	if err := s.store.DeleteWords(r.Context(), req.IDs); err != nil {
+		s.logger.Error("bulk delete words failed", "count", len(req.IDs), "error", err)
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	s.logger.Info("bulk deleted words", "count", len(req.IDs))
+	if r.Header.Get("HX-Request") == "true" {
+		s.handleListWords(w, r)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "count": strconv.Itoa(len(req.IDs))})
+}
+
+// handleBulkDeleteExpressions handles DELETE /api/expressions/bulk.
+func (s *Server) handleBulkDeleteExpressions(w http.ResponseWriter, r *http.Request) {
+	var req bulkDeleteRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "ids must not be empty")
+		return
+	}
+
+	if err := s.store.DeleteExpressions(r.Context(), req.IDs); err != nil {
+		s.logger.Error("bulk delete expressions failed", "count", len(req.IDs), "error", err)
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	s.logger.Info("bulk deleted expressions", "count", len(req.IDs))
+	if r.Header.Get("HX-Request") == "true" {
+		s.handleListExpressions(w, r)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "count": strconv.Itoa(len(req.IDs))})
+}
+
 // handleImport handles POST /api/import — CSV import.
 func (s *Server) handleImport(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)

--- a/internal/web/integration_test.go
+++ b/internal/web/integration_test.go
@@ -877,3 +877,57 @@ func TestPropertyP32_ReportAnIssueOpensInNewTabSecurely(t *testing.T) {
 		}
 	})
 }
+
+func TestIntegration_BulkDeleteWords(t *testing.T) {
+	srv := newTestServer()
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{"valid IDs", `{"ids":[1,2,3]}`, http.StatusOK},
+		{"empty IDs", `{"ids":[]}`, http.StatusBadRequest},
+		{"invalid JSON", `not json`, http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodDelete, "/api/words/bulk", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d; body: %s", tc.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestIntegration_BulkDeleteExpressions(t *testing.T) {
+	srv := newTestServer()
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{"valid IDs", `{"ids":[1,2,3]}`, http.StatusOK},
+		{"empty IDs", `{"ids":[]}`, http.StatusBadRequest},
+		{"invalid JSON", `{bad}`, http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodDelete, "/api/expressions/bulk", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d; body: %s", tc.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -136,6 +136,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("PUT /api/expressions/{id}", s.handleUpdateExpression)
 	s.mux.HandleFunc("DELETE /api/words/{id}", s.handleDeleteWord)
 	s.mux.HandleFunc("DELETE /api/expressions/{id}", s.handleDeleteExpression)
+	s.mux.HandleFunc("DELETE /api/words/bulk", s.handleBulkDeleteWords)
+	s.mux.HandleFunc("DELETE /api/expressions/bulk", s.handleBulkDeleteExpressions)
 	s.mux.HandleFunc("POST /api/import", s.handleImport)
 	s.mux.HandleFunc("GET /api/export", s.handleExport)
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -66,6 +66,10 @@ func (s *stubStore) UpdateExpression(ctx context.Context, id int64, row *db.Expr
 }
 func (s *stubStore) DeleteWord(ctx context.Context, id int64) error       { return nil }
 func (s *stubStore) DeleteExpression(ctx context.Context, id int64) error { return nil }
+func (s *stubStore) DeleteWords(ctx context.Context, ids []int64) error   { return nil }
+func (s *stubStore) DeleteExpressions(ctx context.Context, ids []int64) error {
+	return nil
+}
 func (s *stubStore) ImportWords(ctx context.Context, rows []db.WordRow) (int, int, int, error) {
 	return 0, 0, 0, nil
 }
@@ -216,6 +220,8 @@ func TestAPIRoutesRegistered(t *testing.T) {
 		{"put-expression", http.MethodPut, "/api/expressions/1", http.StatusOK},
 		{"delete-word", http.MethodDelete, "/api/words/1", http.StatusOK},
 		{"delete-expression", http.MethodDelete, "/api/expressions/1", http.StatusOK},
+		{"bulk-delete-words", http.MethodDelete, "/api/words/bulk", http.StatusBadRequest},
+		{"bulk-delete-expressions", http.MethodDelete, "/api/expressions/bulk", http.StatusBadRequest},
 		// Export with empty store → 200 (empty xlsx)
 		{"export", http.MethodGet, "/api/export", http.StatusOK},
 		// Config update with empty body

--- a/internal/web/templates/batch.html
+++ b/internal/web/templates/batch.html
@@ -2,30 +2,30 @@
 {{define "content"}}
 <h1 class="text-2xl font-bold mb-6">Batch Processing</h1>
 
-<form id="batch-form" class="space-y-4 max-w-lg"
-      enctype="multipart/form-data">
+<form id="batch-form" class="space-y-4 max-w-lg" enctype="multipart/form-data"
+  onkeydown="if(event.key==='Enter'&&event.target.tagName!=='BUTTON'){event.preventDefault();}">
   <div>
     <label for="file" class="block text-sm font-medium text-gray-700 mb-1">CSV File</label>
     <input type="file" id="file" name="file" accept=".csv" required
-           class="w-full border border-gray-300 rounded px-3 py-2 text-sm file:mr-3 file:py-1 file:px-3 file:rounded file:border-0 file:bg-blue-50 file:text-blue-700 file:font-medium">
+      class="w-full border border-gray-300 rounded px-3 py-2 text-sm file:mr-3 file:py-1 file:px-3 file:rounded file:border-0 file:bg-blue-50 file:text-blue-700 file:font-medium">
   </div>
 
   <div class="grid grid-cols-2 gap-4">
     <div>
       <label for="source_language" class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
       <select id="source_language" name="source_language"
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         {{range .Languages}}
-        <option value="{{.Code}}"{{if eq $.Config.DefaultSourceLanguage .Code}} selected{{end}}>{{.Name}}</option>
+        <option value="{{.Code}}" {{if eq $.Config.DefaultSourceLanguage .Code}} selected{{end}}>{{.Name}}</option>
         {{end}}
       </select>
     </div>
     <div>
       <label for="target_language" class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
       <select id="target_language" name="target_language"
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         {{range .Languages}}
-        <option value="{{.Code}}"{{if eq $.Config.DefaultTargetLanguage .Code}} selected{{end}}>{{.Name}}</option>
+        <option value="{{.Code}}" {{if eq $.Config.DefaultTargetLanguage .Code}} selected{{end}}>{{.Name}}</option>
         {{end}}
       </select>
     </div>
@@ -35,7 +35,7 @@
     <div>
       <label for="mode" class="block text-sm font-medium text-gray-700 mb-1">Mode</label>
       <select id="mode" name="mode"
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         <option value="words">Words</option>
         <option value="expressions">Expressions</option>
       </select>
@@ -43,7 +43,7 @@
     <div>
       <label for="on_conflict" class="block text-sm font-medium text-gray-700 mb-1">On Conflict</label>
       <select id="on_conflict" name="on_conflict"
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         <option value="skip" selected>Skip</option>
         <option value="replace">Replace</option>
         <option value="add">Add</option>
@@ -54,12 +54,12 @@
   <div>
     <label for="tags" class="block text-sm font-medium text-gray-700 mb-1">Tags (optional)</label>
     <input type="text" id="tags" name="tags"
-           class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-           placeholder="e.g. chapter-1, B2">
+      class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      placeholder="e.g. chapter-1, B2">
   </div>
 
   <button type="submit" id="batch-submit"
-          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+    class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
     Process Batch
   </button>
 </form>
@@ -72,6 +72,10 @@
       <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
     </svg>
     <span id="progress-text" class="text-sm text-gray-700">Starting batch processing...</span>
+    <button type="button" id="batch-cancel"
+      class="ml-auto bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500">
+      Cancel
+    </button>
   </div>
   <div class="w-full bg-gray-200 rounded-full h-2.5">
     <div id="progress-bar" class="bg-blue-600 h-2.5 rounded-full transition-all duration-300" style="width: 0%"></div>
@@ -82,156 +86,182 @@
 <div id="batch-result" class="mt-8"></div>
 
 <script>
-(function() {
-  var form = document.getElementById('batch-form');
-  var submitBtn = document.getElementById('batch-submit');
-  var progressDiv = document.getElementById('batch-progress');
-  var progressText = document.getElementById('progress-text');
-  var progressBar = document.getElementById('progress-bar');
-  var progressToken = document.getElementById('progress-token');
-  var resultDiv = document.getElementById('batch-result');
+  (function () {
+    var form = document.getElementById('batch-form');
+    var submitBtn = document.getElementById('batch-submit');
+    var cancelBtn = document.getElementById('batch-cancel');
+    var progressDiv = document.getElementById('batch-progress');
+    var progressText = document.getElementById('progress-text');
+    var progressBar = document.getElementById('progress-bar');
+    var progressToken = document.getElementById('progress-token');
+    var resultDiv = document.getElementById('batch-result');
+    var abortController = null;
 
-  form.addEventListener('submit', function(e) {
-    e.preventDefault();
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
 
-    var fileInput = document.getElementById('file');
-    if (!fileInput.files.length) return;
+      var fileInput = document.getElementById('file');
+      if (!fileInput.files.length) return;
 
-    // Reset UI
-    resultDiv.innerHTML = '';
-    progressDiv.classList.remove('hidden');
-    progressText.textContent = 'Starting batch processing...';
-    progressBar.style.width = '0%';
-    progressToken.textContent = '';
-    submitBtn.disabled = true;
-    submitBtn.classList.add('opacity-50', 'cursor-not-allowed');
+      // Reset UI
+      resultDiv.innerHTML = '';
+      progressDiv.classList.remove('hidden');
+      progressText.textContent = 'Starting batch processing...';
+      progressBar.style.width = '0%';
+      progressToken.textContent = '';
+      submitBtn.disabled = true;
+      submitBtn.classList.add('opacity-50', 'cursor-not-allowed');
 
-    var formData = new FormData(form);
+      abortController = new AbortController();
+      var formData = new FormData(form);
 
-    // Use fetch with ReadableStream to process SSE from POST
-    fetch('/api/batch/stream', {
-      method: 'POST',
-      body: formData
-    }).then(function(response) {
-      if (!response.ok) {
-        throw new Error('Server error: ' + response.status);
-      }
-      var reader = response.body.getReader();
-      var decoder = new TextDecoder();
-      var buffer = '';
-
-      function processChunk(result) {
-        if (result.done) {
-          onDone();
-          return;
+      // Use fetch with ReadableStream to process SSE from POST
+      fetch('/api/batch/stream', {
+        method: 'POST',
+        body: formData,
+        signal: abortController.signal
+      }).then(function (response) {
+        if (!response.ok) {
+          throw new Error('Server error: ' + response.status);
         }
-        buffer += decoder.decode(result.value, {stream: true});
-        var lines = buffer.split('\n');
-        buffer = lines.pop() || '';
+        var reader = response.body.getReader();
+        var decoder = new TextDecoder();
+        var buffer = '';
 
-        var eventType = '';
-        var dataStr = '';
-        for (var i = 0; i < lines.length; i++) {
-          var line = lines[i];
-          if (line.indexOf('event: ') === 0) {
-            eventType = line.substring(7);
-          } else if (line.indexOf('data: ') === 0) {
-            dataStr = line.substring(6);
-            if (eventType && dataStr) {
-              handleEvent(eventType, dataStr);
-              eventType = '';
-              dataStr = '';
+        function processChunk(result) {
+          if (result.done) {
+            onDone();
+            return;
+          }
+          buffer += decoder.decode(result.value, { stream: true });
+          var lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+
+          var eventType = '';
+          var dataStr = '';
+          for (var i = 0; i < lines.length; i++) {
+            var line = lines[i];
+            if (line.indexOf('event: ') === 0) {
+              eventType = line.substring(7);
+            } else if (line.indexOf('data: ') === 0) {
+              dataStr = line.substring(6);
+              if (eventType && dataStr) {
+                handleEvent(eventType, dataStr);
+                eventType = '';
+                dataStr = '';
+              }
             }
           }
+          return reader.read().then(processChunk);
         }
+
         return reader.read().then(processChunk);
-      }
-
-      return reader.read().then(processChunk);
-    }).catch(function(err) {
-      progressDiv.classList.add('hidden');
-      resultDiv.innerHTML = '<div class="bg-red-50 border border-red-200 text-red-700 rounded p-4">' + escapeHtml(err.message) + '</div>';
-      resetButton();
+      }).catch(function (err) {
+        if (err.name === 'AbortError') {
+          progressDiv.classList.add('hidden');
+          if (!resultDiv.innerHTML) {
+            resultDiv.innerHTML = '<div class="bg-yellow-50 border border-yellow-200 text-yellow-700 rounded p-4">Batch processing cancelled.</div>';
+          }
+          resetButton();
+          return;
+        }
+        progressDiv.classList.add('hidden');
+        resultDiv.innerHTML = '<div class="bg-red-50 border border-red-200 text-red-700 rounded p-4">' + escapeHtml(err.message) + '</div>';
+        resetButton();
+      });
     });
-  });
 
-  function handleEvent(type, dataStr) {
-    try {
-      var data = JSON.parse(dataStr);
-    } catch(e) {
-      return;
-    }
-
-    if (type === 'progress') {
-      var pct = Math.round((data.current / data.total) * 100);
-      progressBar.style.width = pct + '%';
-      progressText.textContent = 'Processing ' + data.current + '/' + data.total + '...';
-      progressToken.textContent = data.token + ' \u2014 ' + data.status;
-    } else if (type === 'complete') {
-      progressDiv.classList.add('hidden');
-      renderSummary(data);
-      resetButton();
-    } else if (type === 'error') {
-      progressDiv.classList.add('hidden');
-      resultDiv.innerHTML = '<div class="bg-red-50 border border-red-200 text-red-700 rounded p-4">' + escapeHtml(data.message || 'Unknown error') + '</div>';
-      resetButton();
-    }
-  }
-
-  function onDone() {
-    // Stream ended — if progress is still showing, hide it
-    if (!progressDiv.classList.contains('hidden')) {
-      progressDiv.classList.add('hidden');
-    }
-    resetButton();
-  }
-
-  function resetButton() {
-    submitBtn.disabled = false;
-    submitBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-  }
-
-  function renderSummary(data) {
-    var html = '<div class="space-y-4">';
-    html += '<div class="grid grid-cols-3 gap-4 text-center">';
-    html += statCard(data.processed || 0, 'Processed', 'green');
-    html += statCard(data.cached || 0, 'Cached', 'gray');
-    html += statCard(data.failed || 0, 'Failed', 'red');
-    html += '</div>';
-    if ((data.replaced || 0) > 0) {
-      html += '<div class="bg-orange-50 border border-orange-200 rounded p-3 text-center">';
-      html += '<div class="text-lg font-bold text-orange-700">' + data.replaced + '</div>';
-      html += '<div class="text-sm text-orange-600">Replaced</div></div>';
-    }
-    if ((data.added || 0) > 0) {
-      html += '<div class="bg-blue-50 border border-blue-200 rounded p-3 text-center">';
-      html += '<div class="text-lg font-bold text-blue-700">' + data.added + '</div>';
-      html += '<div class="text-sm text-blue-600">Added</div></div>';
-    }
-    if (data.errors && data.errors.length > 0) {
-      html += '<div><h3 class="font-medium text-gray-700 mb-2">Failed Items</h3>';
-      html += '<ul class="bg-red-50 border border-red-200 rounded divide-y divide-red-100">';
-      for (var i = 0; i < data.errors.length; i++) {
-        html += '<li class="px-4 py-2 text-sm"><span class="font-medium text-red-800">' + escapeHtml(data.errors[i].Token || data.errors[i].token || '') + '</span>';
-        html += ' <span class="text-red-600">\u2014 ' + escapeHtml(data.errors[i].Message || data.errors[i].message || '') + '</span></li>';
+    cancelBtn.addEventListener('click', function () {
+      if (abortController) {
+        abortController.abort();
+        abortController = null;
       }
-      html += '</ul></div>';
+    });
+
+    function handleEvent(type, dataStr) {
+      try {
+        var data = JSON.parse(dataStr);
+      } catch (e) {
+        return;
+      }
+
+      if (type === 'progress') {
+        var pct = Math.round((data.current / data.total) * 100);
+        progressBar.style.width = pct + '%';
+        progressText.textContent = 'Processing ' + data.current + '/' + data.total + '...';
+        progressToken.textContent = data.token + ' \u2014 ' + data.status;
+      } else if (type === 'complete') {
+        progressDiv.classList.add('hidden');
+        renderSummary(data, false);
+        resetButton();
+      } else if (type === 'cancelled') {
+        progressDiv.classList.add('hidden');
+        renderSummary(data, true);
+        resetButton();
+      } else if (type === 'error') {
+        progressDiv.classList.add('hidden');
+        resultDiv.innerHTML = '<div class="bg-red-50 border border-red-200 text-red-700 rounded p-4">' + escapeHtml(data.message || 'Unknown error') + '</div>';
+        resetButton();
+      }
     }
-    html += '</div>';
-    resultDiv.innerHTML = html;
-  }
 
-  function statCard(value, label, color) {
-    return '<div class="bg-' + color + '-50 border border-' + color + '-200 rounded p-3">'
-      + '<div class="text-2xl font-bold text-' + color + '-700">' + value + '</div>'
-      + '<div class="text-sm text-' + color + '-600">' + label + '</div></div>';
-  }
+    function onDone() {
+      if (!progressDiv.classList.contains('hidden')) {
+        progressDiv.classList.add('hidden');
+      }
+      resetButton();
+    }
 
-  function escapeHtml(str) {
-    var div = document.createElement('div');
-    div.appendChild(document.createTextNode(str));
-    return div.innerHTML;
-  }
-})();
+    function resetButton() {
+      submitBtn.disabled = false;
+      submitBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+      abortController = null;
+    }
+
+    function renderSummary(data, wasCancelled) {
+      var html = '<div class="space-y-4">';
+      if (wasCancelled) {
+        html += '<div class="bg-yellow-50 border border-yellow-200 text-yellow-700 rounded p-3 text-sm font-medium">Processing was cancelled. Partial results shown below.</div>';
+      }
+      html += '<div class="grid grid-cols-3 gap-4 text-center">';
+      html += statCard(data.processed || 0, 'Processed', 'green');
+      html += statCard(data.cached || 0, 'Cached', 'gray');
+      html += statCard(data.failed || 0, 'Failed', 'red');
+      html += '</div>';
+      if ((data.replaced || 0) > 0) {
+        html += '<div class="bg-orange-50 border border-orange-200 rounded p-3 text-center">';
+        html += '<div class="text-lg font-bold text-orange-700">' + data.replaced + '</div>';
+        html += '<div class="text-sm text-orange-600">Replaced</div></div>';
+      }
+      if ((data.added || 0) > 0) {
+        html += '<div class="bg-blue-50 border border-blue-200 rounded p-3 text-center">';
+        html += '<div class="text-lg font-bold text-blue-700">' + data.added + '</div>';
+        html += '<div class="text-sm text-blue-600">Added</div></div>';
+      }
+      if (data.errors && data.errors.length > 0) {
+        html += '<div><h3 class="font-medium text-gray-700 mb-2">Failed Items</h3>';
+        html += '<ul class="bg-red-50 border border-red-200 rounded divide-y divide-red-100">';
+        for (var i = 0; i < data.errors.length; i++) {
+          html += '<li class="px-4 py-2 text-sm"><span class="font-medium text-red-800">' + escapeHtml(data.errors[i].Token || data.errors[i].token || '') + '</span>';
+          html += ' <span class="text-red-600">\u2014 ' + escapeHtml(data.errors[i].Message || data.errors[i].message || '') + '</span></li>';
+        }
+        html += '</ul></div>';
+      }
+      html += '</div>';
+      resultDiv.innerHTML = html;
+    }
+
+    function statCard(value, label, color) {
+      return '<div class="bg-' + color + '-50 border border-' + color + '-200 rounded p-3">'
+        + '<div class="text-2xl font-bold text-' + color + '-700">' + value + '</div>'
+        + '<div class="text-sm text-' + color + '-600">' + label + '</div></div>';
+    }
+
+    function escapeHtml(str) {
+      var div = document.createElement('div');
+      div.appendChild(document.createTextNode(str));
+      return div.innerHTML;
+    }
+  })();
 </script>
 {{end}}

--- a/internal/web/templates/config.html
+++ b/internal/web/templates/config.html
@@ -2,10 +2,8 @@
 {{define "content"}}
 <h1 class="text-2xl font-bold mb-6">Configuration</h1>
 
-<div id="config-form" hx-get="/api/config/html" hx-trigger="load" hx-swap="innerHTML"
-     class="max-w-lg">
+<div id="config-form" hx-get="/api/config/html" hx-trigger="load" hx-swap="innerHTML" class="max-w-lg">
   <p class="text-gray-500">Loading configuration…</p>
 </div>
 
-<div id="connection-status" class="mt-4 max-w-lg"></div>
 {{end}}

--- a/internal/web/templates/database.html
+++ b/internal/web/templates/database.html
@@ -6,10 +6,9 @@
   <div class="flex flex-wrap gap-4 items-end">
     <div>
       <label for="db-source-lang" class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
-      <select id="db-source-lang" name="source_lang"
-              hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
-              hx-include="#db-filters"
-              class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      <select id="db-source-lang" name="source_lang" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
+        hx-include="#db-filters"
+        class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         <option value="">All</option>
         {{range .Languages}}
         <option value="{{.Code}}">{{.Name}}</option>
@@ -18,10 +17,9 @@
     </div>
     <div>
       <label for="db-target-lang" class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
-      <select id="db-target-lang" name="target_lang"
-              hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
-              hx-include="#db-filters"
-              class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      <select id="db-target-lang" name="target_lang" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
+        hx-include="#db-filters"
+        class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         <option value="">All</option>
         {{range .Languages}}
         <option value="{{.Code}}">{{.Name}}</option>
@@ -30,31 +28,25 @@
     </div>
     <fieldset id="db-type-filter">
       <legend class="block text-sm font-medium text-gray-700 mb-1">Type</legend>
-      <select name="type"
-              hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
-              hx-include="#db-filters"
-              class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      <select name="type" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML" hx-include="#db-filters"
+        class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         <option value="words" selected>Words</option>
         <option value="expressions">Expressions</option>
       </select>
     </fieldset>
     <div>
       <label for="db-tags" class="block text-sm font-medium text-gray-700 mb-1">Tags</label>
-      <input type="text" id="db-tags" name="tags"
-             hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
-             hx-trigger="keyup changed delay:300ms"
-             hx-include="#db-filters"
-             class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 w-32"
-             placeholder="e.g. HS2.2">
+      <input type="text" id="db-tags" name="tags" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
+        hx-trigger="keyup changed delay:300ms" hx-include="#db-filters"
+        class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 w-32"
+        placeholder="e.g. HS2.2">
     </div>
     <div class="flex-1 min-w-[200px]">
       <label for="db-search" class="block text-sm font-medium text-gray-700 mb-1">Search</label>
-      <input type="text" id="db-search" name="search"
-             hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
-             hx-trigger="keyup changed delay:300ms"
-             hx-include="#db-filters"
-             class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-             placeholder="Search entries...">
+      <input type="text" id="db-search" name="search" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
+        hx-trigger="keyup changed delay:300ms" hx-include="#db-filters"
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        placeholder="Search entries...">
     </div>
   </div>
 
@@ -64,23 +56,22 @@
 
   <div class="flex gap-3">
     <a id="export-btn" href="#" target="_blank"
-       onclick="this.href='/api/export?source_lang='+encodeURIComponent(document.getElementById('db-source-lang').value)+'&target_lang='+encodeURIComponent(document.getElementById('db-target-lang').value)+'&search='+encodeURIComponent(document.getElementById('db-search').value)+'&tags='+encodeURIComponent((document.getElementById('db-tags')||{}).value||'')"
-       class="border border-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-50 text-sm">
+      onclick="this.href='/api/export?source_lang='+encodeURIComponent(document.getElementById('db-source-lang').value)+'&target_lang='+encodeURIComponent(document.getElementById('db-target-lang').value)+'&search='+encodeURIComponent(document.getElementById('db-search').value)+'&tags='+encodeURIComponent((document.getElementById('db-tags')||{}).value||'')"
+      class="border border-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-50 text-sm">
       Export XLSX
     </a>
     <button type="button" onclick="document.getElementById('import-dialog').classList.toggle('hidden')"
-            class="border border-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-50 text-sm">
+      class="border border-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-50 text-sm">
       Import CSV/XLSX
     </button>
   </div>
 
   <div id="import-dialog" class="hidden bg-white border border-gray-200 rounded p-4 max-w-md">
-    <form hx-post="/api/import" hx-target="#import-result" hx-swap="innerHTML"
-          hx-encoding="multipart/form-data" class="space-y-3">
+    <form hx-post="/api/import" hx-target="#import-result" hx-swap="innerHTML" hx-encoding="multipart/form-data"
+      class="space-y-3">
       <div>
         <label for="import-file" class="block text-sm font-medium text-gray-700 mb-1">CSV File</label>
-        <input type="file" id="import-file" name="file" accept=".csv,.xlsx" required
-               class="w-full text-sm">
+        <input type="file" id="import-file" name="file" accept=".csv,.xlsx" required class="w-full text-sm">
       </div>
       <div class="grid grid-cols-2 gap-3">
         <div>
@@ -112,9 +103,64 @@
     <div id="import-result" class="mt-2"></div>
   </div>
 
-  <div id="entry-table"
-       hx-get="/api/words" hx-trigger="load" hx-swap="innerHTML">
+  <div id="entry-table" hx-get="/api/words" hx-trigger="load" hx-swap="innerHTML">
     <p class="text-gray-500">Loading entries…</p>
   </div>
 </div>
+
+<script>
+  function toggleSelectAll(el) {
+    var cbs = document.querySelectorAll('.entry-cb');
+    for (var i = 0; i < cbs.length; i++) {
+      cbs[i].checked = el.checked;
+    }
+    updateBulkActions();
+  }
+
+  function updateBulkActions() {
+    var checked = document.querySelectorAll('.entry-cb:checked');
+    var actions = document.getElementById('bulk-actions');
+    var count = document.getElementById('selected-count');
+    if (checked.length > 0) {
+      actions.classList.remove('hidden');
+      count.textContent = checked.length + ' selected';
+    } else {
+      actions.classList.add('hidden');
+    }
+    var selectAll = document.getElementById('select-all');
+    var allCbs = document.querySelectorAll('.entry-cb');
+    if (selectAll && allCbs.length > 0) {
+      selectAll.checked = checked.length === allCbs.length;
+    }
+  }
+
+  function bulkDeleteSelected() {
+    var checked = document.querySelectorAll('.entry-cb:checked');
+    if (checked.length === 0) return;
+    if (!confirm('Delete ' + checked.length + ' selected entries? This cannot be undone.')) return;
+
+    var ids = [];
+    for (var i = 0; i < checked.length; i++) {
+      ids.push(parseInt(checked[i].value, 10));
+    }
+
+    var typeSelect = document.querySelector('#db-type-filter select');
+    var isExpressions = typeSelect && typeSelect.value === 'expressions';
+    var url = isExpressions ? '/api/expressions/bulk' : '/api/words/bulk';
+
+    fetch(url, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', 'HX-Request': 'true' },
+      body: JSON.stringify({ ids: ids })
+    }).then(function (resp) {
+      if (!resp.ok) throw new Error('Delete failed: ' + resp.status);
+      return resp.text();
+    }).then(function (html) {
+      document.getElementById('entry-table').innerHTML = html;
+      htmx.process(document.getElementById('entry-table'));
+    }).catch(function (err) {
+      alert(err.message);
+    });
+  }
+</script>
 {{end}}

--- a/internal/web/templates/partials/config_form.html
+++ b/internal/web/templates/partials/config_form.html
@@ -158,5 +158,7 @@
   </div>
 </form>
 
+<div id="connection-status" class="mt-4"></div>
+
 {{template "setup_local_llm" .}}
 {{end}}

--- a/internal/web/templates/partials/config_form.html
+++ b/internal/web/templates/partials/config_form.html
@@ -3,7 +3,7 @@
   <div>
     <label for="profile_selector" class="block text-sm font-medium text-gray-700 mb-1">Profile</label>
     <select id="profile_selector" name="profile_selector"
-      onchange="if(this.value==='__new__'){document.getElementById('new-profile-form').style.display='block';this.dataset.prev=this.dataset.prev||'{{.ActiveProfile}}'}else{document.getElementById('new-profile-form').style.display='none';var profileVal=this.value;htmx.ajax('PUT','/api/profile/switch',{target:'#save-status',swap:'innerHTML',values:{profile:profileVal}}).then(function(){setTimeout(function(){var d=document.createElement('div');htmx.ajax('GET','/api/config/html',{source:d,target:'#config-form',swap:'innerHTML'})},300)})}"
+      onchange="if(this.value==='__new__'){document.getElementById('new-profile-form').style.display='block';this.dataset.prev=this.dataset.prev||'{{.ActiveProfile}}'}else{document.getElementById('new-profile-form').style.display='none';var profileVal=this.value;htmx.ajax('PUT','/api/profile/switch',{target:'#config-form',swap:'innerHTML',values:{profile:profileVal}})}"
       class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
       {{range .Profiles}}
       <option value="{{.}}" {{if eq . $.ActiveProfile}} selected{{end}}>{{.}}</option>
@@ -142,7 +142,7 @@
       class="w-full border border-gray-200 rounded px-3 py-2 bg-gray-100 text-gray-500">
   </div>
 
-  <div id="save-status"></div>
+  <div id="save-status">{{if .StatusMessage}}{{.StatusMessage}}{{end}}</div>
 
   <div class="flex gap-3">
     <button type="button" hx-put="/api/config" hx-include="#config-save-form" hx-target="#save-status"

--- a/internal/web/templates/partials/entry_table.html
+++ b/internal/web/templates/partials/entry_table.html
@@ -1,10 +1,22 @@
 {{define "entry_table"}}
-<div class="text-sm text-gray-500 mb-2">{{.Total}} entries found (page {{.Page}} of {{.TotalPages}})</div>
+<div class="flex items-center justify-between mb-2">
+  <div class="text-sm text-gray-500">{{.Total}} entries found (page {{.Page}} of {{.TotalPages}})</div>
+  <div id="bulk-actions" class="hidden flex items-center gap-2">
+    <span id="selected-count" class="text-sm text-gray-600"></span>
+    <button type="button" id="bulk-delete-btn"
+      class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+      onclick="bulkDeleteSelected()">
+      Delete Selected
+    </button>
+  </div>
+</div>
 
 {{if .IsWords}}
 <table class="w-full text-sm border border-gray-200 rounded">
   <thead class="bg-gray-50">
     <tr>
+      <th class="px-2 py-2 w-8"><input type="checkbox" id="select-all" onchange="toggleSelectAll(this)" class="rounded">
+      </th>
       <th class="px-3 py-2 text-left text-gray-600 font-medium">Word</th>
       <th class="px-3 py-2 text-left text-gray-600 font-medium">POS</th>
       <th class="px-3 py-2 text-left text-gray-600 font-medium">Article</th>
@@ -16,9 +28,12 @@
   </thead>
   <tbody class="divide-y divide-gray-100">
     {{range .Words}}
-    <tr class="hover:bg-gray-50 cursor-pointer"
-        hx-get="/api/words/{{.ID}}/edit" hx-target="this" hx-swap="afterend">
-      <td class="px-3 py-2 font-medium text-gray-800">{{.Word}}</td>
+    <tr class="hover:bg-gray-50">
+      <td class="px-2 py-2" onclick="event.stopPropagation()">
+        <input type="checkbox" class="entry-cb rounded" value="{{.ID}}" onchange="updateBulkActions()">
+      </td>
+      <td class="px-3 py-2 font-medium text-gray-800 cursor-pointer" hx-get="/api/words/{{.ID}}/edit"
+        hx-target="closest tr" hx-swap="afterend">{{.Word}}</td>
       <td class="px-3 py-2"><span class="text-xs bg-gray-100 text-gray-600 px-1 rounded">{{.PartOfSpeech}}</span></td>
       <td class="px-3 py-2 text-gray-600">{{.Article}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.Definition}}</td>
@@ -28,7 +43,9 @@
     </tr>
     {{end}}
     {{if not .Words}}
-    <tr><td colspan="7" class="px-3 py-4 text-center text-gray-500">No entries found</td></tr>
+    <tr>
+      <td colspan="8" class="px-3 py-4 text-center text-gray-500">No entries found</td>
+    </tr>
     {{end}}
   </tbody>
 </table>
@@ -36,6 +53,8 @@
 <table class="w-full text-sm border border-gray-200 rounded">
   <thead class="bg-gray-50">
     <tr>
+      <th class="px-2 py-2 w-8"><input type="checkbox" id="select-all" onchange="toggleSelectAll(this)" class="rounded">
+      </th>
       <th class="px-3 py-2 text-left text-gray-600 font-medium">Expression</th>
       <th class="px-3 py-2 text-left text-gray-600 font-medium">Definition</th>
       <th class="px-3 py-2 text-left text-gray-600 font-medium">English</th>
@@ -45,9 +64,12 @@
   </thead>
   <tbody class="divide-y divide-gray-100">
     {{range .Expressions}}
-    <tr class="hover:bg-gray-50 cursor-pointer"
-        hx-get="/api/expressions/{{.ID}}/edit" hx-target="this" hx-swap="afterend">
-      <td class="px-3 py-2 font-medium text-gray-800">{{.Expression}}</td>
+    <tr class="hover:bg-gray-50">
+      <td class="px-2 py-2" onclick="event.stopPropagation()">
+        <input type="checkbox" class="entry-cb rounded" value="{{.ID}}" onchange="updateBulkActions()">
+      </td>
+      <td class="px-3 py-2 font-medium text-gray-800 cursor-pointer" hx-get="/api/expressions/{{.ID}}/edit"
+        hx-target="closest tr" hx-swap="afterend">{{.Expression}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.Definition}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.English}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.TargetTranslation}}</td>
@@ -55,7 +77,9 @@
     </tr>
     {{end}}
     {{if not .Expressions}}
-    <tr><td colspan="5" class="px-3 py-4 text-center text-gray-500">No entries found</td></tr>
+    <tr>
+      <td colspan="6" class="px-3 py-4 text-center text-gray-500">No entries found</td>
+    </tr>
     {{end}}
   </tbody>
 </table>
@@ -64,15 +88,17 @@
 {{if gt .TotalPages 1}}
 <div class="flex gap-2 mt-4 justify-center">
   {{if gt .Page 1}}
-  <button hx-get="{{.BaseURL}}?page={{.PrevPage}}&page_size={{.PageSize}}&source_lang={{.SourceLang}}&target_lang={{.TargetLang}}&search={{.Search}}&tags={{.Tags}}"
-          hx-target="#entry-table" hx-swap="innerHTML"
-          class="border border-gray-300 px-3 py-1 rounded text-sm hover:bg-gray-50">← Prev</button>
+  <button
+    hx-get="{{.BaseURL}}?page={{.PrevPage}}&page_size={{.PageSize}}&source_lang={{.SourceLang}}&target_lang={{.TargetLang}}&search={{.Search}}&tags={{.Tags}}"
+    hx-target="#entry-table" hx-swap="innerHTML"
+    class="border border-gray-300 px-3 py-1 rounded text-sm hover:bg-gray-50">← Prev</button>
   {{end}}
   <span class="px-3 py-1 text-sm text-gray-600">Page {{.Page}} of {{.TotalPages}}</span>
   {{if lt .Page .TotalPages}}
-  <button hx-get="{{.BaseURL}}?page={{.NextPage}}&page_size={{.PageSize}}&source_lang={{.SourceLang}}&target_lang={{.TargetLang}}&search={{.Search}}&tags={{.Tags}}"
-          hx-target="#entry-table" hx-swap="innerHTML"
-          class="border border-gray-300 px-3 py-1 rounded text-sm hover:bg-gray-50">Next →</button>
+  <button
+    hx-get="{{.BaseURL}}?page={{.NextPage}}&page_size={{.PageSize}}&source_lang={{.SourceLang}}&target_lang={{.TargetLang}}&search={{.Search}}&tags={{.Tags}}"
+    hx-target="#entry-table" hx-swap="innerHTML"
+    class="border border-gray-300 px-3 py-1 rounded text-sm hover:bg-gray-50">Next →</button>
   {{end}}
 </div>
 {{end}}


### PR DESCRIPTION
## Summary

v1.2.1 release with three user-facing changes: bulk delete for database entries, batch processing cancellation, and a fix for config profile switching saving to the wrong profile.

## Related Issue

Fixes #28, Fixes #32, Fixes #33, Fixes #34

## Changes

- Bulk delete for database entries — select individual entries or use select-all, then delete in one action (#33, #34)
- Batch processing cancellation — cancel a running batch from the Web UI with partial results preserved (#32)
- Config profile switching now correctly refreshes the form and saves to the selected profile (#28)
- Updated changelog and documentation for v1.2.1

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
