### PR TITLE
docs: add doc.go files and godoc comments across all packages

### DIFF
--- a/cmd/vocabgen/doc.go
+++ b/cmd/vocabgen/doc.go
@@ -1,0 +1,5 @@
+// Package main is the entry point for the vocabgen CLI. It registers Cobra
+// subcommands (lookup, batch, serve, backup, restore, version, update),
+// loads configuration, and wires together the provider, database, and service
+// layers.
+package main

--- a/cmd/vocabgen/main.go
+++ b/cmd/vocabgen/main.go
@@ -1,4 +1,3 @@
-// Package main is the entry point for the vocabgen CLI.
 package main
 
 import (
@@ -33,6 +32,7 @@ var (
 // appConfig holds the loaded config after PersistentPreRun.
 var appConfig config.Config
 
+// main executes the root Cobra command and exits with code 1 on error.
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -119,6 +119,8 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+// init configures the root command's version template, persistent flags, and
+// registers all subcommands.
 func init() {
 	// Custom version template to include build date
 	rootCmd.SetVersionTemplate(fmt.Sprintf("vocabgen %s (%s, built %s)\n", version, runtime.Version(), buildDate))

--- a/docs/doc.go
+++ b/docs/doc.go
@@ -1,0 +1,4 @@
+// Package docs embeds the project's markdown documentation files and renders
+// them as HTML via goldmark. It provides slug-based access to architecture,
+// deployment, user guide, and changelog pages.
+package docs

--- a/docs/embed.go
+++ b/docs/embed.go
@@ -29,8 +29,10 @@ var Available = []DocInfo{
 	{Slug: "changelog", Title: "Changelog", File: "changelog.md"},
 }
 
+// slugToFile maps URL slugs to their DocInfo for O(1) lookup in Render.
 var slugToFile map[string]DocInfo
 
+// init builds the slugToFile lookup map from the Available slice.
 func init() {
 	slugToFile = make(map[string]DocInfo, len(Available))
 	for _, d := range Available {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,3 @@
-// Package config manages application settings persisted to ~/.vocabgen/config.yaml.
 package config
 
 import (

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,4 @@
+// Package config manages application configuration, including YAML persistence,
+// multi-profile support, and CLI flag overrides. Config files are stored at
+// ~/.vocabgen/config.yaml.
+package config

--- a/internal/db/doc.go
+++ b/internal/db/doc.go
@@ -1,0 +1,4 @@
+// Package db provides the SQLite-backed persistence layer for vocabulary entries.
+// It defines the Store interface, row types for words and expressions, schema
+// migrations, and bulk operations (import, export, backup, restore).
+package db

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -1,5 +1,3 @@
-// Package db provides SQLite-based storage for vocabulary entries, including
-// schema migrations, CRUD operations, pagination, import/export, and backup/restore.
 package db
 
 import (

--- a/internal/language/doc.go
+++ b/internal/language/doc.go
@@ -1,0 +1,5 @@
+// Package language provides the language registry, prompt templates, and LLM
+// response validation. It maps language codes to display names, builds
+// mode-specific prompts (words vs expressions), and validates JSON responses
+// against the expected schema.
+package language

--- a/internal/language/registry.go
+++ b/internal/language/registry.go
@@ -1,6 +1,3 @@
-// Package language provides prompt templates, JSON validation, and a language
-// registry for the vocabulary generator. All templates are language-agnostic,
-// parameterized by {source_language}.
 package language
 
 // SupportedLanguages maps language codes to full names.

--- a/internal/llm/doc.go
+++ b/internal/llm/doc.go
@@ -1,0 +1,5 @@
+// Package llm defines the Provider interface and implementations for LLM
+// providers (AWS Bedrock, OpenAI, Anthropic, Vertex AI). The provider registry
+// maps provider names to constructors, enabling runtime selection via config
+// or CLI flags.
+package llm

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -1,4 +1,3 @@
-// Package llm defines the Provider interface and registry for LLM API backends.
 package llm
 
 import (

--- a/internal/output/doc.go
+++ b/internal/output/doc.go
@@ -1,0 +1,4 @@
+// Package output provides field mapping, translation flattening, and Excel export
+// for vocabulary entries. It converts validated LLM responses into Entry structs
+// and supports XLSX export with separate sheets for words and expressions.
+package output

--- a/internal/output/excel.go
+++ b/internal/output/excel.go
@@ -1,5 +1,3 @@
-// Package output provides field mapping, translation flattening, and Excel export
-// for vocabulary entries.
 package output
 
 import (
@@ -79,6 +77,7 @@ func ExportBothToExcel(words []Entry, expressions []Entry) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// writeSheet writes column headers and entry rows to the named sheet in the Excel file.
 func writeSheet(f *excelize.File, sheet string, cols []string, entries []Entry, mode string) {
 	for i, h := range cols {
 		cell, _ := excelize.CoordinatesToCellName(i+1, 1)

--- a/internal/parsing/csv.go
+++ b/internal/parsing/csv.go
@@ -1,4 +1,3 @@
-// Package parsing provides CSV reading and token normalization for vocabulary input files.
 package parsing
 
 import (

--- a/internal/parsing/doc.go
+++ b/internal/parsing/doc.go
@@ -1,0 +1,4 @@
+// Package parsing handles input normalization and CSV reading for vocabulary
+// tokens. It provides word and expression normalization, input file parsing,
+// and token-with-context extraction.
+package parsing

--- a/internal/service/conflict.go
+++ b/internal/service/conflict.go
@@ -1,5 +1,3 @@
-// Package service implements the business logic for vocabulary lookups and
-// batch processing, shared by both the CLI and web UI layers.
 package service
 
 import "fmt"
@@ -8,6 +6,7 @@ import "fmt"
 // conflicts with an existing database entry.
 type ConflictStrategy string
 
+// Supported conflict resolution strategies.
 const (
 	// ConflictReplace updates the existing entry in-place.
 	ConflictReplace ConflictStrategy = "replace"

--- a/internal/service/doc.go
+++ b/internal/service/doc.go
@@ -1,0 +1,5 @@
+// Package service implements the business logic for vocabulary lookups and
+// batch processing, shared by both the CLI and web UI layers. It orchestrates
+// normalization, cache checks, LLM invocation, quality checks, conflict
+// resolution, and database persistence.
+package service

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -319,6 +319,7 @@ func Lookup(ctx context.Context, store db.Store, params LookupParams) (*LookupRe
 	return lookupExpression(ctx, store, params, m, normalized, sourceLang, targetLang)
 }
 
+// lookupWord handles the cache-check and LLM invocation flow for a single word lookup.
 func lookupWord(ctx context.Context, store db.Store, params LookupParams, m, normalized, sourceLang, targetLang string) (*LookupResult, error) {
 	existing, err := store.FindWords(ctx, normalized, params.SourceLang)
 	if err != nil {
@@ -407,6 +408,7 @@ func lookupWord(ctx context.Context, store db.Store, params LookupParams, m, nor
 	return result, nil
 }
 
+// lookupExpression handles the cache-check and LLM invocation flow for a single expression lookup.
 func lookupExpression(ctx context.Context, store db.Store, params LookupParams, m, normalized, sourceLang, targetLang string) (*LookupResult, error) {
 	existing, err := store.FindExpressions(ctx, normalized, params.SourceLang)
 	if err != nil {
@@ -638,6 +640,8 @@ func ProcessBatch(ctx context.Context, store db.Store, params BatchParams) (*Bat
 	return result, nil
 }
 
+// processBatchWord processes a single word within a batch: checks the cache,
+// invokes the LLM on miss, and applies the configured conflict strategy.
 func processBatchWord(ctx context.Context, store db.Store, params BatchParams, sourceLang, targetLang, normalized, ctxSentence string, result *BatchResult, newCount *int) {
 	if ctx.Err() != nil {
 		return
@@ -716,6 +720,8 @@ func processBatchWord(ctx context.Context, store db.Store, params BatchParams, s
 	*newCount++
 }
 
+// processBatchExpression processes a single expression within a batch: checks the cache,
+// invokes the LLM on miss, and applies the configured conflict strategy.
 func processBatchExpression(ctx context.Context, store db.Store, params BatchParams, sourceLang, targetLang, normalized, ctxSentence string, result *BatchResult, newCount *int) {
 	if ctx.Err() != nil {
 		return

--- a/internal/update/doc.go
+++ b/internal/update/doc.go
@@ -1,0 +1,4 @@
+// Package update provides shared update-checking logic for both the web UI and
+// CLI. It queries the GitHub Releases API, compares semver versions, builds
+// OS/arch-aware download URLs, and renders delta changelogs.
+package update

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,6 +1,3 @@
-// Package update provides shared update-checking logic for both the web UI and CLI.
-// It queries the GitHub Releases API, compares semver versions, and builds
-// download URLs and delta changelogs.
 package update
 
 import (
@@ -19,6 +16,7 @@ import (
 	"github.com/yuin/goldmark/extension"
 )
 
+// GitHub API and download URL constants for the VocabGen release repository.
 const (
 	// GithubReleasesURL is the GitHub Releases API endpoint for VocabGen.
 	GithubReleasesURL = "https://api.github.com/repos/npozs77/VocabGen/releases"

--- a/internal/web/doc.go
+++ b/internal/web/doc.go
@@ -1,0 +1,5 @@
+// Package web provides the embedded HTTP server and HTMX-driven web UI for
+// VocabGen. It registers routes for lookup, batch processing, config management,
+// database browsing, documentation, and update checking, all rendered via
+// Go html/template with server-side rendering.
+package web

--- a/internal/web/handlers_batch.go
+++ b/internal/web/handlers_batch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/user/vocabgen/internal/service"
 )
 
+// maxUploadSize is the maximum allowed size for file uploads (10 MB).
 const maxUploadSize = 10 << 20 // 10 MB
 
 // parseTextList splits a plain-text word list (one token per line) into

--- a/internal/web/handlers_db.go
+++ b/internal/web/handlers_db.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xuri/excelize/v2"
 )
 
+// parseListParams extracts pagination and filter parameters from the request URL query string.
 func parseListParams(r *http.Request) (db.ListFilter, error) {
 	filter := db.ListFilter{
 		SourceLang: r.URL.Query().Get("source_lang"),
@@ -233,6 +234,8 @@ func (s *Server) handleUpdateWord(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
 }
+
+// handleEditWord handles GET /api/words/{id}/edit — renders the inline edit form partial.
 func (s *Server) handleEditWord(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
 	if err != nil {
@@ -252,6 +255,7 @@ func (s *Server) handleEditWord(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleEditExpression handles GET /api/expressions/{id}/edit — renders the inline edit form partial.
 func (s *Server) handleEditExpression(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
 	if err != nil {

--- a/internal/web/handlers_lookup.go
+++ b/internal/web/handlers_lookup.go
@@ -30,6 +30,8 @@ type resolveRequest struct {
 	Tags           string        `json:"tags"`
 }
 
+// parseLookupParams decodes lookup parameters from JSON or form-encoded request bodies
+// and resolves defaults from the server config.
 func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, error) {
 	var req lookupRequest
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,4 +1,3 @@
-// Package web implements the embedded HTTP server and web UI handlers.
 package web
 
 import (


### PR DESCRIPTION
## Summary

Add `doc.go` files and godoc comments across all packages to meet project documentation standards. Every Go package now has a canonical package-level comment in `doc.go`, and all exported symbols have godoc comments.

## Related Issue

Fixes #36

## Changes

- Added `doc.go` with package-level comments to: `cmd/vocabgen`, `docs`, `internal/config`, `internal/db`, `internal/language`, `internal/llm`, `internal/output`, `internal/parsing`, `internal/service`, `internal/update`, `internal/web`
- Added godoc comments to exported functions, types, and methods across all packages
- Removed duplicate `// Package` comments from non-doc.go source files

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change) — N/A, docs-only change
- [x] New tests added for new functionality — N/A, no functional changes
