### PR TITLE
feat: add nav-bar profile switcher with HTMX partial. Fixes #44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [1.2.2] - 2026-04-19
+
+### Added
+
+- Nav-bar profile switcher — active config profile visible and switchable from any page (#44)
+
+### Fixed
+
+- Enter key no longer submits the batch form when typing in the paste list textarea
+
 ## [1.2.1] - 2026-04-18
 
 ### Added

--- a/internal/web/handlers_config.go
+++ b/internal/web/handlers_config.go
@@ -34,6 +34,7 @@ func (s *Server) handleGetProfiles(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSwitchProfile(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Profile string `json:"profile"`
+		Source  string `json:"source"`
 	}
 
 	ct := r.Header.Get("Content-Type")
@@ -48,6 +49,7 @@ func (s *Server) handleSwitchProfile(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		req.Profile = r.FormValue("profile")
+		req.Source = r.FormValue("source")
 	}
 
 	if req.Profile == "" {
@@ -64,6 +66,21 @@ func (s *Server) handleSwitchProfile(w http.ResponseWriter, r *http.Request) {
 	*s.cfg = cfg
 	s.activeProfile = req.Profile
 	s.logger.Info("switched config profile", "profile", req.Profile)
+
+	// When switched from the nav-bar profile switcher, return just the
+	// updated switcher partial so HTMX can swap it in-place.
+	if req.Source == "nav" {
+		profiles, _, _ := config.ListProfiles()
+		data := struct {
+			ActiveProfile string
+			Profiles      []string
+		}{
+			ActiveProfile: s.activeProfile,
+			Profiles:      profiles,
+		}
+		_ = renderPartial(w, "profile_switcher", data)
+		return
+	}
 
 	// Re-render the full config form with the new profile's values.
 	// This replaces the two-step approach (PUT then GET) that was prone to
@@ -296,4 +313,18 @@ func checkOllamaReachable() string {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	return ""
+}
+
+// handleProfileSwitcherPartial renders the profile switcher partial for the nav bar.
+// Used by HTMX to refresh the switcher after a profile switch.
+func (s *Server) handleProfileSwitcherPartial(w http.ResponseWriter, _ *http.Request) {
+	profiles, _, _ := config.ListProfiles()
+	data := struct {
+		ActiveProfile string
+		Profiles      []string
+	}{
+		ActiveProfile: s.activeProfile,
+		Profiles:      profiles,
+	}
+	_ = renderPartial(w, "profile_switcher", data)
 }

--- a/internal/web/handlers_profile_switcher_test.go
+++ b/internal/web/handlers_profile_switcher_test.go
@@ -1,0 +1,271 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/user/vocabgen/internal/config"
+)
+
+// TestProfileSwitcher_VisibleOnPages verifies that the active profile name
+// appears in the rendered HTML on lookup, batch, and other pages.
+//
+// Validates: Issue #44 — Active profile name is visible on lookup, batch pages.
+func TestProfileSwitcher_VisibleOnPages(t *testing.T) {
+	srv := newTestServer()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"lookup", "/"},
+		{"batch", "/batch"},
+		{"config", "/config"},
+		{"database", "/database"},
+		{"about", "/about"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+
+			body := w.Body.String()
+
+			// The profile switcher should be present in the nav bar.
+			if !strings.Contains(body, "profile-switcher") {
+				t.Fatal("response does not contain profile-switcher element")
+			}
+
+			// The active profile name should appear.
+			if !strings.Contains(body, srv.activeProfile) {
+				t.Fatalf("response does not contain active profile name %q", srv.activeProfile)
+			}
+		})
+	}
+}
+
+// TestProfileSwitcher_NavSwitch verifies that switching profiles via the nav-bar
+// switcher (source=nav) returns the profile_switcher partial, not the config form.
+//
+// Validates: Issue #44 — Profile switch takes effect immediately for subsequent lookups.
+func TestProfileSwitcher_NavSwitch(t *testing.T) {
+	fc := config.FileConfig{
+		DefaultProfile: "prod",
+		Profiles: map[string]config.ProfileConfig{
+			"prod":  {Provider: "bedrock", AWSRegion: "us-east-1", ModelID: "claude-v1"},
+			"local": {Provider: "openai", BaseURL: "http://localhost:11434/v1", ModelID: "translategemma"},
+		},
+		DefaultSourceLanguage: "nl",
+		DefaultTargetLanguage: "hu",
+		DBPath:                "~/.vocabgen/vocabgen.db",
+	}
+	if err := config.SaveFileConfig(fc); err != nil {
+		t.Fatalf("SaveFileConfig: %v", err)
+	}
+
+	srv := newTestServer()
+
+	// Switch to "local" via nav-bar context.
+	body := `{"profile":"local","source":"nav"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/profile/switch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	respBody := w.Body.String()
+
+	// Should return the profile_switcher partial, not the config form.
+	if strings.Contains(respBody, "config-save-form") {
+		t.Fatal("nav switch should return profile_switcher partial, not config form")
+	}
+	if !strings.Contains(respBody, "profile-switcher") {
+		t.Fatal("response does not contain profile-switcher element")
+	}
+
+	// The new active profile should be highlighted.
+	if !strings.Contains(respBody, "local") {
+		t.Fatal("response does not contain the switched profile name 'local'")
+	}
+
+	// Verify in-memory state was updated.
+	if srv.activeProfile != "local" {
+		t.Fatalf("expected activeProfile 'local', got %q", srv.activeProfile)
+	}
+	if srv.cfg.Provider != "openai" {
+		t.Fatalf("expected provider 'openai' after switch, got %q", srv.cfg.Provider)
+	}
+}
+
+// TestProfileSwitcher_ConfigSwitch verifies that switching profiles without
+// source=nav still returns the config form (backward compatibility).
+//
+// Validates: Issue #44 — Regression prevention for config page profile switching.
+func TestProfileSwitcher_ConfigSwitch(t *testing.T) {
+	fc := config.FileConfig{
+		DefaultProfile: "prod",
+		Profiles: map[string]config.ProfileConfig{
+			"prod":  {Provider: "bedrock", AWSRegion: "us-east-1", ModelID: "claude-v1"},
+			"local": {Provider: "openai", BaseURL: "http://localhost:11434/v1", ModelID: "translategemma"},
+		},
+		DefaultSourceLanguage: "nl",
+		DefaultTargetLanguage: "hu",
+		DBPath:                "~/.vocabgen/vocabgen.db",
+	}
+	if err := config.SaveFileConfig(fc); err != nil {
+		t.Fatalf("SaveFileConfig: %v", err)
+	}
+
+	srv := newTestServer()
+
+	// Switch without source=nav (config page behavior).
+	body := `{"profile":"local"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/profile/switch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	// Should return the config form, not the profile switcher partial.
+	if !strings.Contains(w.Body.String(), "config-save-form") {
+		t.Fatal("config switch should return config form HTML")
+	}
+}
+
+// TestProfileSwitcherPartial_Route verifies that GET /api/profile/switcher
+// returns the profile switcher partial with the current active profile.
+//
+// Validates: Issue #44 — Profile switcher partial endpoint.
+func TestProfileSwitcherPartial_Route(t *testing.T) {
+	srv := newTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/profile/switcher", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "text/html; charset=utf-8" {
+		t.Fatalf("expected text/html; charset=utf-8, got %q", ct)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "profile-switcher") {
+		t.Fatal("response does not contain profile-switcher element")
+	}
+	if !strings.Contains(body, srv.activeProfile) {
+		t.Fatalf("response does not contain active profile name %q", srv.activeProfile)
+	}
+}
+
+// TestProfileSwitcher_AllProfilesListed verifies that the profile switcher
+// lists all available profiles with the active one highlighted.
+//
+// Validates: Issue #44 — Current profile is visually highlighted/distinguished.
+func TestProfileSwitcher_AllProfilesListed(t *testing.T) {
+	fc := config.FileConfig{
+		DefaultProfile: "prod",
+		Profiles: map[string]config.ProfileConfig{
+			"prod":    {Provider: "bedrock", AWSRegion: "us-east-1", ModelID: "claude-v1"},
+			"local":   {Provider: "openai", BaseURL: "http://localhost:11434/v1", ModelID: "translategemma"},
+			"sandbox": {Provider: "anthropic", ModelID: "claude-3"},
+		},
+		DefaultSourceLanguage: "nl",
+		DefaultTargetLanguage: "hu",
+		DBPath:                "~/.vocabgen/vocabgen.db",
+	}
+	if err := config.SaveFileConfig(fc); err != nil {
+		t.Fatalf("SaveFileConfig: %v", err)
+	}
+
+	srv := newTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+
+	// All profiles should be listed in the switcher.
+	for _, profile := range []string{"prod", "local", "sandbox"} {
+		if !strings.Contains(body, profile) {
+			t.Fatalf("response does not contain profile %q", profile)
+		}
+	}
+
+	// The active profile should have the highlighted class.
+	if !strings.Contains(body, "text-blue-600 font-medium bg-blue-50") {
+		t.Fatal("response does not contain highlighted active profile styling")
+	}
+}
+
+// TestProfileSwitcher_ReflectsAfterSwitch verifies that after switching profiles
+// via the nav switcher, subsequent page renders show the new active profile.
+//
+// Validates: Issue #44 — Profile switch takes effect immediately.
+func TestProfileSwitcher_ReflectsAfterSwitch(t *testing.T) {
+	fc := config.FileConfig{
+		DefaultProfile: "prod",
+		Profiles: map[string]config.ProfileConfig{
+			"prod":  {Provider: "bedrock", AWSRegion: "us-east-1", ModelID: "claude-v1"},
+			"local": {Provider: "openai", BaseURL: "http://localhost:11434/v1", ModelID: "translategemma"},
+		},
+		DefaultSourceLanguage: "nl",
+		DefaultTargetLanguage: "hu",
+		DBPath:                "~/.vocabgen/vocabgen.db",
+	}
+	if err := config.SaveFileConfig(fc); err != nil {
+		t.Fatalf("SaveFileConfig: %v", err)
+	}
+
+	srv := newTestServer()
+
+	// Switch to "local" via nav.
+	switchBody := `{"profile":"local","source":"nav"}`
+	switchReq := httptest.NewRequest(http.MethodPut, "/api/profile/switch", strings.NewReader(switchBody))
+	switchReq.Header.Set("Content-Type", "application/json")
+	switchW := httptest.NewRecorder()
+	srv.mux.ServeHTTP(switchW, switchReq)
+
+	if switchW.Code != http.StatusOK {
+		t.Fatalf("switch: expected 200, got %d", switchW.Code)
+	}
+
+	// Now render the lookup page — it should show "local" as active.
+	pageReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	pageW := httptest.NewRecorder()
+	srv.mux.ServeHTTP(pageW, pageReq)
+
+	if pageW.Code != http.StatusOK {
+		t.Fatalf("page: expected 200, got %d", pageW.Code)
+	}
+
+	body := pageW.Body.String()
+	if !strings.Contains(body, "profile-active-name") {
+		t.Fatal("page does not contain profile-active-name element")
+	}
+	// The active profile name span should contain "local".
+	if !strings.Contains(body, ">local<") {
+		t.Fatal("page does not show 'local' as the active profile after switch")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -37,6 +37,8 @@ type pageData struct {
 	GoVersion       string
 	UpdateAvailable bool
 	LatestVersion   string
+	ActiveProfile   string
+	Profiles        []string
 }
 
 // NewServer creates a Server with all routes registered.
@@ -125,6 +127,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/profiles", s.handleGetProfiles)
 	s.mux.HandleFunc("POST /api/profiles", s.handleCreateProfile)
 	s.mux.HandleFunc("PUT /api/profile/switch", s.handleSwitchProfile)
+	s.mux.HandleFunc("GET /api/profile/switcher", s.handleProfileSwitcherPartial)
 
 	// Database API
 	s.mux.HandleFunc("GET /api/words", s.handleListWords)
@@ -161,13 +164,16 @@ func (s *Server) handlePage(name string) http.HandlerFunc {
 
 // newPageData creates a pageData populated with common fields including update status.
 func (s *Server) newPageData(activePage string) pageData {
+	profiles, _, _ := config.ListProfiles()
 	pd := pageData{
-		ActivePage: activePage,
-		Languages:  service.GetSupportedLanguages(),
-		Config:     s.cfg,
-		Version:    s.version,
-		BuildDate:  s.buildDate,
-		GoVersion:  s.goVersion,
+		ActivePage:    activePage,
+		Languages:     service.GetSupportedLanguages(),
+		Config:        s.cfg,
+		Version:       s.version,
+		BuildDate:     s.buildDate,
+		GoVersion:     s.goVersion,
+		ActiveProfile: s.activeProfile,
+		Profiles:      profiles,
 	}
 	if info := s.updater.cached(); info != nil && info.HasUpdate && !s.updater.isDismissed() {
 		pd.UpdateAvailable = true

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -231,6 +231,7 @@ func TestAPIRoutesRegistered(t *testing.T) {
 		// Profile endpoints
 		{"get-profiles", http.MethodGet, "/api/profiles", http.StatusOK},
 		{"switch-profile", http.MethodPut, "/api/profile/switch", http.StatusBadRequest},
+		{"profile-switcher", http.MethodGet, "/api/profile/switcher", http.StatusOK},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -30,11 +30,12 @@ var funcMap = template.FuncMap{
 func init() {
 	templates = make(map[string]*template.Template)
 
-	// Parse page templates — each page combines base.html + its own template.
+	// Parse page templates — each page combines base.html + profile_switcher partial + its own template.
 	pages := []string{"lookup", "batch", "config", "database", "about", "docs", "update", "changelog"}
 	for _, page := range pages {
 		t, err := template.New("").Funcs(funcMap).ParseFS(templateFS,
 			"templates/base.html",
+			"templates/partials/profile_switcher.html",
 			fmt.Sprintf("templates/%s.html", page),
 		)
 		if err != nil {
@@ -43,10 +44,11 @@ func init() {
 		templates[page] = t
 	}
 
-	// Parse docs_page separately (also uses base.html).
+	// Parse docs_page separately (also uses base.html + profile_switcher).
 	{
 		t, err := template.New("").Funcs(funcMap).ParseFS(templateFS,
 			"templates/base.html",
+			"templates/partials/profile_switcher.html",
 			"templates/docs_page.html",
 		)
 		if err != nil {
@@ -59,7 +61,7 @@ func init() {
 	partials := []string{
 		"lookup_result", "lookup_conflict", "batch_summary",
 		"entry_edit", "entry_table", "update_result",
-		"setup_local_llm",
+		"setup_local_llm", "profile_switcher",
 	}
 	for _, partial := range partials {
 		t, err := template.ParseFS(templateFS,

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -1,6 +1,7 @@
 {{define "base"}}
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,23 +9,30 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
 </head>
+
 <body class="bg-gray-50 min-h-screen">
   <nav class="bg-white shadow">
     <div class="max-w-7xl mx-auto px-4 py-3 flex items-center gap-6">
       <span class="font-semibold text-lg text-gray-800">VocabGen</span>
-      <a href="/" class="{{if eq .ActivePage "lookup"}}text-blue-600 font-medium{{else}}text-gray-600 hover:text-blue-600{{end}}">Lookup</a>
-      <a href="/batch" class="{{if eq .ActivePage "batch"}}text-blue-600 font-medium{{else}}text-gray-600 hover:text-blue-600{{end}}">Batch</a>
-      <a href="/config" class="{{if eq .ActivePage "config"}}text-blue-600 font-medium{{else}}text-gray-600 hover:text-blue-600{{end}}">Config</a>
-      <a href="/database" class="{{if eq .ActivePage "database"}}text-blue-600 font-medium{{else}}text-gray-600 hover:text-blue-600{{end}}">Database</a>
+      <a href="/" class="{{if eq .ActivePage " lookup"}}text-blue-600 font-medium{{else}}text-gray-600
+        hover:text-blue-600{{end}}">Lookup</a>
+      <a href="/batch" class="{{if eq .ActivePage " batch"}}text-blue-600 font-medium{{else}}text-gray-600
+        hover:text-blue-600{{end}}">Batch</a>
+      <a href="/config" class="{{if eq .ActivePage " config"}}text-blue-600 font-medium{{else}}text-gray-600
+        hover:text-blue-600{{end}}">Config</a>
+      <a href="/database" class="{{if eq .ActivePage " database"}}text-blue-600 font-medium{{else}}text-gray-600
+        hover:text-blue-600{{end}}">Database</a>
       <div class="flex-1"></div>
+      {{template "profile_switcher" .}}
       <div class="relative" id="help-menu">
         <button onclick="document.getElementById('help-dropdown').classList.toggle('hidden')"
-                class="text-sm {{if isHelpPage .ActivePage}}text-blue-600 font-medium{{else}}text-gray-500 hover:text-blue-600{{end}}">
+          class="text-sm {{if isHelpPage .ActivePage}}text-blue-600 font-medium{{else}}text-gray-500 hover:text-blue-600{{end}}">
           Help ▾
         </button>
         <div id="help-dropdown" class="hidden absolute right-0 mt-1 w-48 bg-white rounded shadow-lg border z-50">
           <a href="/about" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">About</a>
-          <a href="https://github.com/npozs77/VocabGen/issues" target="_blank" rel="noopener noreferrer" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Report an Issue ↗</a>
+          <a href="https://github.com/npozs77/VocabGen/issues" target="_blank" rel="noopener noreferrer"
+            class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Report an Issue ↗</a>
           <a href="/docs" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Documentation</a>
           <a href="/changelog" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Changelog</a>
           <a href="/update" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Check for Update</a>
@@ -33,9 +41,12 @@
     </div>
   </nav>
   {{if .UpdateAvailable}}
-  <div id="update-banner" class="bg-blue-50 border-b border-blue-200 px-4 py-2 text-sm text-blue-800 flex items-center justify-between max-w-7xl mx-auto">
-    <span>A new version (v{{.LatestVersion}}) is available. <a href="/update" class="underline font-medium">View details</a></span>
-    <button hx-post="/api/update/dismiss" hx-swap="outerHTML" hx-target="#update-banner" class="text-blue-600 hover:text-blue-800 ml-4">✕</button>
+  <div id="update-banner"
+    class="bg-blue-50 border-b border-blue-200 px-4 py-2 text-sm text-blue-800 flex items-center justify-between max-w-7xl mx-auto">
+    <span>A new version (v{{.LatestVersion}}) is available. <a href="/update" class="underline font-medium">View
+        details</a></span>
+    <button hx-post="/api/update/dismiss" hx-swap="outerHTML" hx-target="#update-banner"
+      class="text-blue-600 hover:text-blue-800 ml-4">✕</button>
   </div>
   {{end}}
   <main class="max-w-7xl mx-auto px-4 py-8">
@@ -44,17 +55,24 @@
   <footer class="max-w-7xl mx-auto px-4 py-4 mt-8 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
     <a href="/docs" class="hover:text-blue-500">Documentation</a>
     <span>·</span>
-    <a href="https://github.com/npozs77/VocabGen/issues" target="_blank" rel="noopener noreferrer" class="hover:text-blue-500">Report an Issue ↗</a>
+    <a href="https://github.com/npozs77/VocabGen/issues" target="_blank" rel="noopener noreferrer"
+      class="hover:text-blue-500">Report an Issue ↗</a>
   </footer>
   <script>
-  document.addEventListener('click', function(e) {
-    var menu = document.getElementById('help-menu');
-    var dd = document.getElementById('help-dropdown');
-    if (menu && dd && !menu.contains(e.target)) {
-      dd.classList.add('hidden');
-    }
-  });
+    document.addEventListener('click', function (e) {
+      var menu = document.getElementById('help-menu');
+      var dd = document.getElementById('help-dropdown');
+      if (menu && dd && !menu.contains(e.target)) {
+        dd.classList.add('hidden');
+      }
+      var ps = document.getElementById('profile-switcher');
+      var pd = document.getElementById('profile-dropdown');
+      if (ps && pd && !ps.contains(e.target)) {
+        pd.classList.add('hidden');
+      }
+    });
   </script>
 </body>
+
 </html>
 {{end}}

--- a/internal/web/templates/batch.html
+++ b/internal/web/templates/batch.html
@@ -3,7 +3,7 @@
 <h1 class="text-2xl font-bold mb-6">Batch Processing</h1>
 
 <form id="batch-form" class="space-y-4 max-w-lg" enctype="multipart/form-data"
-  onkeydown="if(event.key==='Enter'&&event.target.tagName!=='BUTTON'){event.preventDefault();}">
+  onkeydown="if(event.key==='Enter'&&event.target.tagName!=='BUTTON'&&event.target.tagName!=='TEXTAREA'){event.preventDefault();}">
   <fieldset>
     <legend class="block text-sm font-medium text-gray-700 mb-2">Input Method</legend>
     <div class="flex gap-4 mb-3">

--- a/internal/web/templates/partials/profile_switcher.html
+++ b/internal/web/templates/partials/profile_switcher.html
@@ -1,0 +1,22 @@
+{{define "profile_switcher"}}
+<div class="relative" id="profile-switcher">
+    <button onclick="document.getElementById('profile-dropdown').classList.toggle('hidden')"
+        class="inline-flex items-center gap-1.5 text-sm text-gray-600 hover:text-blue-600 border border-gray-300 rounded px-2.5 py-1">
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+        <span id="profile-active-name">{{.ActiveProfile}}</span>
+        <span class="text-xs">▾</span>
+    </button>
+    <div id="profile-dropdown" class="hidden absolute right-0 mt-1 w-44 bg-white rounded shadow-lg border z-50">
+        {{range .Profiles}}
+        <button hx-put="/api/profile/switch" hx-vals='{"profile":"{{.}}","source":"nav"}' hx-target="#profile-switcher"
+            hx-swap="outerHTML"
+            class="block w-full text-left px-4 py-2 text-sm {{if eq . $.ActiveProfile}}text-blue-600 font-medium bg-blue-50{{else}}text-gray-700 hover:bg-gray-100{{end}}">
+            {{.}}
+        </button>
+        {{end}}
+    </div>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

Add a nav-bar profile switcher so the active config profile is visible and switchable from any page. The switcher uses an HTMX partial for seamless updates and includes click-outside-to-close behavior. Also fixes Enter key submission in the batch paste list textarea.

## Related Issue

Fixes #44

## Changes

- Add profile switcher dropdown to `base.html` nav bar showing active profile name and all available profiles
- Create `partials/profile_switcher.html` HTMX partial for the switcher component
- Add `GET /api/profile/switcher` route returning the partial
- Extend `PUT /api/profile/switch` to support `source=nav` returning the switcher partial instead of the config form
- Add `activeProfile`, `profiles`, and `allProfiles` to `pageData` so all pages render the switcher
- Add comprehensive tests: visibility on all pages, nav switch, config switch backward compat, partial route, all profiles listed, reflects after switch
- Fix Enter key in batch page paste textarea (prevent form submit on Enter in non-button/textarea elements)

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [ ] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
