### PR TITLE
feat: add Docker multi-arch distribution with goreleaser and GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.kiro
+.vscode
+reference
+coverage.out
+*.bak
+dist/
+vocabgen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -16,6 +17,16 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,5 +30,37 @@ checksum:
 changelog:
   disable: true
 
+dockers:
+  - image_templates:
+      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{ .Version }}"
+    goarch: amd64
+    goos: linux
+
+  - image_templates:
+      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=VERSION={{ .Version }}"
+    goarch: arm64
+    goos: linux
+
+docker_manifests:
+  - name_template: "ghcr.io/npozs77/vocabgen:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-amd64"
+      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/npozs77/vocabgen:latest"
+    image_templates:
+      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-amd64"
+      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-arm64"
+
 release:
   header: "{{ .TagBody }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [1.2.2] - 2026-04-19
+
+### Added
+
+- Nav-bar profile switcher — active config profile visible and switchable from any page (#44)
+- Docker image distribution via GitHub Container Registry — `docker run ghcr.io/npozs77/vocabgen` with multi-arch support (amd64/arm64) (#47)
+
+### Fixed
+
+- Enter key no longer submits the batch form when typing in the paste list textarea
+
 ## [1.2.1] - 2026-04-18
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /src
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build
+ARG VERSION=dev
+
+COPY . .
+RUN cp CHANGELOG.md docs/changelog.md
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION} -X main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o /vocabgen ./cmd/vocabgen
+
+# Runtime stage
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder /vocabgen /vocabgen
+
+# Data directory for config.yaml and vocabgen.db
+VOLUME /home/nonroot/.vocabgen
+ENV HOME=/home/nonroot
+
+EXPOSE 8080
+
+ENTRYPOINT ["/vocabgen"]
+CMD ["serve", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -203,6 +203,18 @@ Any language name or code can be passed via `-l` — unregistered languages are 
 
 Documentation is also available in the web UI via Help → Documentation when running `vocabgen serve`.
 
+## Docker
+
+```bash
+docker run -d \
+  -p 8080:8080 \
+  -v ~/.vocabgen:/home/nonroot/.vocabgen \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  ghcr.io/npozs77/vocabgen:latest
+```
+
+The volume mount persists config and database across restarts. Pass API keys via `-e`. All CLI commands work: `docker run ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl`.
+
 ## Build from Source
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -192,24 +192,42 @@ sudo mv vocabgen /usr/local/bin/
 
 No migration steps needed — `~/.vocabgen/config.yaml` and `~/.vocabgen/vocabgen.db` are preserved across binary replacements.
 
-## Docker (Optional)
+## Docker
 
-Minimal `FROM scratch` image since vocabgen is a static binary:
+Multi-arch Docker images (amd64/arm64) are published to GitHub Container Registry on each release.
 
-```dockerfile
-FROM scratch
-COPY vocabgen /vocabgen
-VOLUME /root/.vocabgen
-EXPOSE 8080
-ENTRYPOINT ["/vocabgen"]
-```
-
-Build and run:
+### Quick Start
 
 ```bash
-CGO_ENABLED=0 go build -o vocabgen ./cmd/vocabgen
-docker build -t vocabgen .
-docker run -v ~/.vocabgen:/root/.vocabgen -p 8080:8080 vocabgen serve
+docker run -d \
+  -p 8080:8080 \
+  -v ~/.vocabgen:/home/nonroot/.vocabgen \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  ghcr.io/npozs77/vocabgen:latest
 ```
 
-The volume mount at `/root/.vocabgen` persists the config file and SQLite database between container restarts.
+### Image Tags
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Most recent release |
+| `1.2.2` | Specific version |
+
+### Volume Mount
+
+Mount `/home/nonroot/.vocabgen` to persist `config.yaml` and `vocabgen.db` across container restarts.
+
+### CLI Commands via Docker
+
+```bash
+docker run ghcr.io/npozs77/vocabgen:latest version
+docker run ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl --provider openai -e OPENAI_API_KEY=...
+docker run -v ~/.vocabgen:/home/nonroot/.vocabgen ghcr.io/npozs77/vocabgen:latest batch --input-file /data/words.csv --mode words -l nl
+```
+
+### Build Locally
+
+```bash
+docker build --build-arg VERSION=dev -t vocabgen:local .
+docker run -p 8080:8080 vocabgen:local
+```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -44,6 +44,27 @@ sudo mv vocabgen /usr/local/bin/
 # Download vocabgen_windows_amd64.zip from the Releases page, extract, and add to PATH.
 ```
 
+### Docker (alternative)
+
+Run VocabGen as a container without downloading platform-specific binaries:
+
+```bash
+docker run -d \
+  -p 8080:8080 \
+  -v ~/.vocabgen:/home/nonroot/.vocabgen \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  ghcr.io/npozs77/vocabgen:latest
+```
+
+The volume mount persists config and database across restarts. Pass API keys via `-e`. All CLI commands work via Docker:
+
+```bash
+docker run ghcr.io/npozs77/vocabgen:latest version
+docker run ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl --provider openai
+```
+
+See [Deployment — Docker](deployment.md#docker) for image tags and detailed usage.
+
 ## Configuration
 
 On first run, vocabgen creates `~/.vocabgen/config.yaml` with defaults:


### PR DESCRIPTION
## Summary

Add multi-arch Docker distribution for VocabGen. Includes a multi-stage Dockerfile, goreleaser Docker configuration, and GitHub Actions workflow for publishing images to GitHub Container Registry on each release.

## Related Issue

Fixes #47

## Changes

- Add multi-stage `Dockerfile` (build + minimal runtime with nonroot user)
- Add `.dockerignore` for lean build context
- Update `.goreleaser.yaml` with Docker image builds and manifests (amd64/arm64)
- Update `.github/workflows/release.yml` with GHCR login and Docker buildx setup
- Update `docs/deployment.md` with Docker quick-start, volume mount, and CLI usage
- Update `docs/user-guide.md` with Docker section
- Update `README.md` with Docker badge and quick-start
- Update `CHANGELOG.md` with Docker distribution entry

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [ ] New tests added for new functionality
