### PR TITLE
fix: migrate goreleaser from deprecated dockers to dockers_v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,33 +30,15 @@ checksum:
 changelog:
   disable: true
 
-dockers:
-  - image_templates:
-      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-amd64"
-    use: buildx
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/amd64"
-    goarch: amd64
-    goos: linux
-  - image_templates:
-      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-arm64"
-    use: buildx
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/arm64"
-    goarch: arm64
-    goos: linux
-
-docker_manifests:
-  - name_template: "ghcr.io/npozs77/vocabgen:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-amd64"
-      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/npozs77/vocabgen:latest"
-    image_templates:
-      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-amd64"
-      - "ghcr.io/npozs77/vocabgen:{{ .Version }}-arm64"
+dockers_v2:
+  - images:
+      - "ghcr.io/npozs77/vocabgen"
+    tags:
+      - "{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
 
 release:
   header: "{{ .TagBody }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/distroless/static:nonroot
 
-COPY vocabgen /vocabgen
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/vocabgen /vocabgen
 
 # Data directory for config.yaml and vocabgen.db
 VOLUME /home/nonroot/.vocabgen


### PR DESCRIPTION
Replaces deprecated `dockers` + `docker_manifests` keys with `dockers_v2` in `.goreleaser.yaml`. Updates Dockerfile to use `ARG TARGETPLATFORM` for the new build context layout.

Fixes #47