### PR TITLE
feat: normalize LLM-generated POS labels for Dutch

### DIFF
--- a/internal/parsing/pos.go
+++ b/internal/parsing/pos.go
@@ -1,0 +1,116 @@
+package parsing
+
+import "strings"
+
+// nlPOSCanonical maps lowercased LLM-generated Dutch POS labels to their
+// canonical abbreviation. Applied only when source language is Dutch.
+var nlPOSCanonical = map[string]string{
+	// wederkerend werkwoord → wed. ww.
+	"wederkerend werkwoord":   "wed. ww.",
+	"ww (wederkerend)":        "wed. ww.",
+	"werkwoord (wederkerend)": "wed. ww.",
+	"wed. ww":                 "wed. ww.",
+	"wed.ww.":                 "wed. ww.",
+	"wed.ww":                  "wed. ww.",
+
+	// scheidbaar werkwoord → sch. ww.
+	"scheidbaar werkwoord": "sch. ww.",
+	"scheidbaar ww.":       "sch. ww.",
+	"scheidbaar ww":        "sch. ww.",
+	"ww. (scheidbaar)":     "sch. ww.",
+	"ww (scheidbaar)":      "sch. ww.",
+	"sch. ww":              "sch. ww.",
+	"sch.ww.":              "sch. ww.",
+	"sch.ww":               "sch. ww.",
+
+	// sterk werkwoord
+	"sterk werkwoord": "ww. (sterk)",
+	"ww (sterk)":      "ww. (sterk)",
+
+	// werkwoord → ww.
+	"werkwoord": "ww.",
+	"ww":        "ww.",
+	"werkw.":    "ww.",
+	"werkw":     "ww.",
+
+	// werkwoordelijke uitdrukking
+	"werkwoordelijke uitdrukking": "ww. uitdr.",
+	"ww. uitdr":                   "ww. uitdr.",
+	"ww uitdr.":                   "ww. uitdr.",
+
+	// zelfstandig naamwoord → zn. (all gender/number variants collapse)
+	"zelfst. nw.":           "zn.",
+	"zelfst.nw.":            "zn.",
+	"zelfst. nw":            "zn.",
+	"zelfstandig naamwoord": "zn.",
+	"naamwoord":             "zn.",
+	"znw.":                  "zn.",
+	"znw":                   "zn.",
+	"zn":                    "zn.",
+	"nw.":                   "zn.",
+	"nw":                    "zn.",
+	"zn (de)":               "zn.",
+	"zn. (de)":              "zn.",
+	"zelfst. nw. (de)":      "zn.",
+	"zn (het)":              "zn.",
+	"zn. (het)":             "zn.",
+	"zelfst. nw. (het)":     "zn.",
+	"zelfst. nw. (mv.)":     "zn.",
+	"zn (mv.)":              "zn.",
+	"zn. (mv.)":             "zn.",
+	"znw. (mv.)":            "zn.",
+	"znw. (o.)":             "zn.",
+	"zn (o.)":               "zn.",
+	"zn. (o.)":              "zn.",
+	"zelfst. nw. (o.)":      "zn.",
+
+	// bijvoeglijk naamwoord → bijv. nw.
+	"bijvoeglijk naamwoord": "bijv. nw.",
+	"bijv.nw.":              "bijv. nw.",
+	"bijv.nw":               "bijv. nw.",
+	"bijv. nw":              "bijv. nw.",
+	"bn.":                   "bijv. nw.",
+	"bn":                    "bijv. nw.",
+
+	// bijwoord → bijw.
+	"bijwoord": "bijw.",
+	"bijw":     "bijw.",
+	"bw.":      "bijw.",
+	"bw":       "bijw.",
+
+	// bijw./bijv. nw. (dual — kept as-is)
+	"bijw./bn.":      "bijw./bijv. nw.",
+	"bijw./bn":       "bijw./bijv. nw.",
+	"bijw/bn.":       "bijw./bijv. nw.",
+	"bijw./bijv.nw.": "bijw./bijv. nw.",
+	"bijw./bijv. nw": "bijw./bijv. nw.",
+
+	// uitdrukking → uitdr.
+	"uitdrukking": "uitdr.",
+	"uitdr":       "uitdr.",
+}
+
+// dutchLangCodes are the source language codes that trigger Dutch POS normalization.
+var dutchLangCodes = map[string]bool{
+	"nl":    true,
+	"dutch": true,
+	"nld":   true,
+}
+
+// NormalizePOS maps an LLM-generated part-of-speech label to its canonical
+// abbreviation. Only applies Dutch normalization when sourceLang is Dutch.
+// Returns the input unchanged for non-Dutch languages or unknown labels.
+func NormalizePOS(pos, sourceLang string) string {
+	trimmed := strings.TrimSpace(pos)
+	if trimmed == "" {
+		return trimmed
+	}
+	if !dutchLangCodes[strings.ToLower(strings.TrimSpace(sourceLang))] {
+		return trimmed
+	}
+	key := strings.ToLower(trimmed)
+	if canonical, ok := nlPOSCanonical[key]; ok {
+		return canonical
+	}
+	return trimmed
+}

--- a/internal/parsing/pos_test.go
+++ b/internal/parsing/pos_test.go
@@ -1,0 +1,108 @@
+package parsing
+
+import "testing"
+
+func TestNormalizePOS_Dutch(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// werkwoord variants
+		{"werkwoord", "ww."},
+		{"ww", "ww."},
+		{"ww.", "ww."},
+		{"werkw.", "ww."},
+		{"Werkwoord", "ww."},
+
+		// scheidbaar
+		{"scheidbaar werkwoord", "sch. ww."},
+		{"scheidbaar ww.", "sch. ww."},
+		{"ww. (scheidbaar)", "sch. ww."},
+
+		// wederkerend
+		{"wederkerend werkwoord", "wed. ww."},
+		{"ww (wederkerend)", "wed. ww."},
+
+		// zelfstandig naamwoord — all collapse to zn.
+		{"naamwoord", "zn."},
+		{"zn", "zn."},
+		{"zn.", "zn."},
+		{"zelfst. nw.", "zn."},
+		{"znw.", "zn."},
+		{"nw.", "zn."},
+		{"zn (de)", "zn."},
+		{"zn. (de)", "zn."},
+		{"zn. (het)", "zn."},
+		{"zn. (mv.)", "zn."},
+		{"znw. (o.)", "zn."},
+
+		// bijvoeglijk naamwoord
+		{"bijv.nw.", "bijv. nw."},
+		{"bijv. nw.", "bijv. nw."},
+		{"bn.", "bijv. nw."},
+
+		// bijwoord
+		{"bijwoord", "bijw."},
+		{"bijw.", "bijw."},
+
+		// dual — kept
+		{"bijw./bn.", "bijw./bijv. nw."},
+
+		// uitdrukking
+		{"uitdrukking", "uitdr."},
+
+		// passthrough unknown
+		{"voorzetsel", "voorzetsel"},
+
+		// whitespace
+		{"  ww  ", "ww."},
+		{"", ""},
+
+		// already canonical
+		{"ww.", "ww."},
+		{"zn.", "zn."},
+		{"bijv. nw.", "bijv. nw."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := NormalizePOS(tt.input, "nl")
+			if got != tt.want {
+				t.Errorf("NormalizePOS(%q, \"nl\") = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePOS_NonDutch_Passthrough(t *testing.T) {
+	tests := []struct {
+		pos        string
+		sourceLang string
+	}{
+		{"werkwoord", "de"},
+		{"naamwoord", "fr"},
+		{"verb", "en"},
+		{"ww.", "es"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sourceLang+"/"+tt.pos, func(t *testing.T) {
+			got := NormalizePOS(tt.pos, tt.sourceLang)
+			if got != tt.pos {
+				t.Errorf("NormalizePOS(%q, %q) = %q, want passthrough %q", tt.pos, tt.sourceLang, got, tt.pos)
+			}
+		})
+	}
+}
+
+func TestNormalizePOS_DutchLangVariants(t *testing.T) {
+	// All Dutch language code variants should trigger normalization.
+	for _, lang := range []string{"nl", "NL", "dutch", "Dutch", "nld"} {
+		t.Run(lang, func(t *testing.T) {
+			got := NormalizePOS("werkwoord", lang)
+			if got != "ww." {
+				t.Errorf("NormalizePOS(\"werkwoord\", %q) = %q, want \"ww.\"", lang, got)
+			}
+		})
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -216,7 +216,7 @@ func entryToWordRow(e *output.Entry, sourceLang, targetLang, tags string) *db.Wo
 	}
 	return &db.WordRow{
 		Word:              e.Word,
-		PartOfSpeech:      e.Type,
+		PartOfSpeech:      parsing.NormalizePOS(e.Type, sourceLang),
 		Article:           e.Article,
 		Definition:        e.Definition,
 		EnglishDefinition: e.EnglishDefinition,

--- a/scripts/normalize-pos.sh
+++ b/scripts/normalize-pos.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# normalize-pos.sh — Consolidate LLM-generated POS labels to standard abbreviations.
+# Usage: ./scripts/normalize-pos.sh [path/to/vocabgen.db]
+# Default DB: ~/.vocabgen/vocabgen.db
+
+set -euo pipefail
+
+DB="${1:-$HOME/.vocabgen/vocabgen.db}"
+
+if [ ! -f "$DB" ]; then
+  echo "ERROR: database not found at $DB" >&2
+  exit 1
+fi
+
+echo "=== POS values BEFORE normalization ==="
+sqlite3 "$DB" "SELECT part_of_speech, COUNT(*) FROM words GROUP BY part_of_speech ORDER BY COUNT(*) DESC;"
+echo ""
+
+# Each UPDATE maps verbose/inconsistent LLM labels to the canonical abbreviation.
+# Ordering matters: specific patterns first, then general catch-alls.
+
+sqlite3 "$DB" <<'SQL'
+BEGIN;
+
+-- wederkerend werkwoord → wed. ww.
+UPDATE words SET part_of_speech = 'wed. ww.'
+  WHERE LOWER(part_of_speech) IN (
+    'wederkerend werkwoord',
+    'ww (wederkerend)',
+    'werkwoord (wederkerend)',
+    'wed. ww',
+    'wed.ww.',
+    'wed.ww'
+  );
+
+-- scheidbaar werkwoord → sch. ww.
+UPDATE words SET part_of_speech = 'sch. ww.'
+  WHERE LOWER(part_of_speech) IN (
+    'scheidbaar werkwoord',
+    'scheidbaar ww.',
+    'scheidbaar ww',
+    'ww. (scheidbaar)',
+    'ww (scheidbaar)',
+    'sch. ww',
+    'sch.ww.',
+    'sch.ww'
+  );
+
+-- sterk werkwoord → ww. (sterk)
+UPDATE words SET part_of_speech = 'ww. (sterk)'
+  WHERE LOWER(part_of_speech) IN (
+    'sterk werkwoord',
+    'ww (sterk)'
+  );
+
+-- werkwoord (all remaining variants) → ww.
+UPDATE words SET part_of_speech = 'ww.'
+  WHERE LOWER(part_of_speech) IN (
+    'werkwoord',
+    'ww',
+    'werkw.',
+    'werkw'
+  );
+
+-- werkwoordelijke uitdrukking → ww. uitdr.
+UPDATE words SET part_of_speech = 'ww. uitdr.'
+  WHERE LOWER(part_of_speech) IN (
+    'werkwoordelijke uitdrukking',
+    'ww. uitdr',
+    'ww uitdr.'
+  );
+
+-- zelfstandig naamwoord → zn.
+UPDATE words SET part_of_speech = 'zn.'
+  WHERE LOWER(part_of_speech) IN (
+    'zelfst. nw.',
+    'zelfst.nw.',
+    'zelfst. nw',
+    'zelfstandig naamwoord',
+    'naamwoord',
+    'znw.',
+    'znw',
+    'zn',
+    'nw.',
+    'nw'
+  );
+
+-- zn. with gender preserved
+UPDATE words SET part_of_speech = 'zn. (de)'
+  WHERE LOWER(part_of_speech) IN (
+    'zn (de)',
+    'zn. (de)',
+    'zelfst. nw. (de)'
+  );
+
+UPDATE words SET part_of_speech = 'zn. (het)'
+  WHERE LOWER(part_of_speech) IN (
+    'zn (het)',
+    'zn. (het)',
+    'zelfst. nw. (het)'
+  );
+
+UPDATE words SET part_of_speech = 'zn. (mv.)'
+  WHERE LOWER(part_of_speech) IN (
+    'zelfst. nw. (mv.)',
+    'zn (mv.)',
+    'zn. (mv.)',
+    'znw. (mv.)'
+  );
+
+UPDATE words SET part_of_speech = 'zn. (o.)'
+  WHERE LOWER(part_of_speech) IN (
+    'znw. (o.)',
+    'zn (o.)',
+    'zelfst. nw. (o.)'
+  );
+
+-- bijvoeglijk naamwoord → bijv. nw.
+UPDATE words SET part_of_speech = 'bijv. nw.'
+  WHERE LOWER(part_of_speech) IN (
+    'bijvoeglijk naamwoord',
+    'bijv.nw.',
+    'bijv.nw',
+    'bijv. nw',
+    'bn.',
+    'bn'
+  );
+
+-- bijwoord → bijw.
+UPDATE words SET part_of_speech = 'bijw.'
+  WHERE LOWER(part_of_speech) IN (
+    'bijwoord',
+    'bijw',
+    'bw.',
+    'bw'
+  );
+
+-- bijw./bn. (dual) — normalize spacing
+UPDATE words SET part_of_speech = 'bijw./bijv. nw.'
+  WHERE LOWER(part_of_speech) IN (
+    'bijw./bn.',
+    'bijw./bn',
+    'bijw/bn.',
+    'bijw./bijv.nw.',
+    'bijw./bijv. nw'
+  );
+
+-- uitdrukking → uitdr.
+UPDATE words SET part_of_speech = 'uitdr.'
+  WHERE LOWER(part_of_speech) IN (
+    'uitdrukking',
+    'uitdr'
+  );
+
+COMMIT;
+SQL
+
+echo "=== POS values AFTER normalization ==="
+sqlite3 "$DB" "SELECT part_of_speech, COUNT(*) FROM words GROUP BY part_of_speech ORDER BY COUNT(*) DESC;"


### PR DESCRIPTION
Adds POS normalization for Dutch source language to consolidate inconsistent LLM output (werkwoord→ww., naamwoord→zn., etc.). All zn. gender variants collapse to plain zn. Only applies when source is NL. Includes one-off shell script for existing DB data.