### PR TITLE
fix: strip conjugation parentheticals before CSV parsing

### DIFF
--- a/internal/parsing/csv.go
+++ b/internal/parsing/csv.go
@@ -1,6 +1,7 @@
 package parsing
 
 import (
+	"bufio"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -17,6 +18,8 @@ type TokenWithContext struct {
 
 // ReadInputFile reads a CSV file and returns (token, context) pairs.
 // Skips empty/whitespace-only lines. All non-empty lines are treated as data.
+// Parenthetical conjugation annotations like "(woog af, heeft afgewogen)" are
+// stripped before CSV parsing so their internal commas don't cause field splits.
 // Returns error for file not found or empty file (after skipping blanks).
 func ReadInputFile(path string) ([]TokenWithContext, error) {
 	f, err := os.Open(path)
@@ -25,7 +28,21 @@ func ReadInputFile(path string) ([]TokenWithContext, error) {
 	}
 	defer func() { _ = f.Close() }()
 
-	reader := csv.NewReader(f)
+	// Pre-process: strip conjugation parentheticals from each line before
+	// CSV parsing so commas inside e.g. "(greep in, heeft ingrepen)" don't
+	// cause spurious field splits.
+	var cleaned strings.Builder
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := conjugationInfo.ReplaceAllString(scanner.Text(), " ")
+		_, _ = cleaned.WriteString(line)
+		_, _ = cleaned.WriteString("\n")
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading input file: %w", err)
+	}
+
+	reader := csv.NewReader(strings.NewReader(cleaned.String()))
 	reader.FieldsPerRecord = -1 // variable number of fields
 	reader.LazyQuotes = true
 	reader.TrimLeadingSpace = true

--- a/internal/parsing/parsing_test.go
+++ b/internal/parsing/parsing_test.go
@@ -219,6 +219,38 @@ func TestReadInputFileSkipsWhitespaceLines(t *testing.T) {
 	}
 }
 
+// TestReadInputFileStripsConjugationInfo verifies that parenthetical
+// conjugation annotations (containing commas) are stripped before CSV
+// parsing so they don't cause spurious field splits.
+func TestReadInputFileStripsConjugationInfo(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "conj.csv")
+	content := "afwegen tegen (woog af, heeft afgewogen)\ningrijpen (greep in, heeft ingrepen)\ngewoon woord,context zin\n"
+	_ = os.WriteFile(p, []byte(content), 0644)
+
+	results, err := ReadInputFile(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d: %+v", len(results), results)
+	}
+	// Conjugation info stripped, token is the clean word/expression.
+	if results[0].Token != "afwegen tegen" {
+		t.Errorf("result[0].Token = %q, want %q", results[0].Token, "afwegen tegen")
+	}
+	if results[0].Context != "" {
+		t.Errorf("result[0].Context = %q, want empty", results[0].Context)
+	}
+	if results[1].Token != "ingrijpen" {
+		t.Errorf("result[1].Token = %q, want %q", results[1].Token, "ingrijpen")
+	}
+	// Normal CSV with real comma delimiter still works.
+	if results[2].Token != "gewoon woord" || results[2].Context != "context zin" {
+		t.Errorf("result[2] = %+v, want {Token:gewoon woord Context:context zin}", results[2])
+	}
+}
+
 // TestNormalizeWordEdgeCases tests specific normalization behaviors.
 //
 // Validates: Requirements 15.1–15.4


### PR DESCRIPTION
## Summary

Fix CSV parsing to strip conjugation parentheticals (e.g., `(ik kom, kwam, gekomen)`) before splitting on commas. Previously these parentheticals caused incorrect field splitting.

## Related Issue

None

## Changes

- Strip conjugation parentheticals from input before CSV parsing
- Add tests for the new stripping behavior

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [ ] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
