### PR TITLE
feat: add Flashcards study mode with difficulty rating and filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [1.3.0]
+
+### Added
+
+- Flashcards study mode — flip through vocabulary cards, filter by language/tag/difficulty, and rate cards for focused review (#39)
+
 ## [1.2.2] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VocabGen
 
-A single-binary CLI and embedded web app that generates structured vocabulary lists for language learners. It processes words and expressions through LLM providers (AWS Bedrock, OpenAI, Anthropic), validates JSON responses against English schemas, caches results in SQLite, and serves a browser-based HTMX interface — all compiled into one executable with zero runtime dependencies.
+A single-binary CLI and embedded web app that generates structured vocabulary lists for language learners. It processes words and expressions through LLM providers (AWS Bedrock, OpenAI, Anthropic), validates JSON responses against English schemas, caches results in SQLite, and serves a browser-based HTMX interface with lookup, batch processing, database management, and flashcard-based study mode — all compiled into one executable with zero runtime dependencies.
 
 ## Prerequisites
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,11 +138,13 @@ The service layer sits between the interface layers (CLI, web) and the infrastru
 
 SQLite database at a configurable path (default `~/.vocabgen/vocabgen.db`). Pure-Go driver (`modernc.org/sqlite`) for cross-compilation.
 
-**Schema**: `words` and `expressions` tables with no unique constraint on (source_language, word/expression) — multiple rows allowed for multi-version entries. Indexes on (source_language, word) and (source_language, expression) for query performance. `metadata` table tracks schema version for migrations.
+**Schema**: `words` and `expressions` tables with no unique constraint on (source_language, word/expression) — multiple rows allowed for multi-version entries. Indexes on (source_language, word) and (source_language, expression) for query performance. `metadata` table tracks schema version for migrations. The V2 migration adds a `difficulty TEXT DEFAULT 'natural'` column to both tables for flashcard study tracking (valid values: `easy`, `hard`, `natural`). SQLite's `ALTER TABLE ADD COLUMN` with a `DEFAULT` backfills existing rows automatically.
 
 **CRUD**: `FindWord`/`FindExpression` return first match or nil. `FindWords`/`FindExpressions` return all matches as a slice (for conflict-aware lookups). `InsertWord`/`InsertExpression` set timestamps. `UpdateWord`/`UpdateExpression` target by ID. All queries use parameterized `?` placeholders.
 
-**Pagination**: `ListWords`/`ListExpressions` support filtering by source_language, target_language, search text (LIKE match), and pagination (default 50 per page).
+**Pagination**: `ListWords`/`ListExpressions` support filtering by source_language, target_language, search text (LIKE match), difficulty (IN clause), and pagination (default 50 per page).
+
+**Flashcard support**: `FlashcardItem` is a view model struct (not a DB table) that combines fields from `WordRow` or `ExpressionRow` into a unified card representation (ID, Type, Text, Definition, English, TargetTranslation, Difficulty). `ListDistinctTags` queries both tables and returns sorted, deduplicated tags. `UpdateWordDifficulty`/`UpdateExpressionDifficulty` persist difficulty ratings.
 
 **Import/Export**: `ImportWords`/`ImportExpressions` bulk-insert, skipping duplicates. `BackupTo` copies the DB file. `RestoreFrom` verifies the backup is valid SQLite, creates a safety backup, then replaces.
 
@@ -186,13 +188,15 @@ The web package wraps this with an `updateChecker` struct that adds mutex-protec
 
 Server-side rendering with Go `html/template` + HTMX + Tailwind CSS (CDN). All templates embedded via `go:embed`. No JavaScript build step.
 
-**Pages**: Lookup (`/`), Batch (`/batch`), Config (`/config`), Database (`/database`), Help dropdown (About `/about`, Documentation `/docs`, Changelog `/changelog`, Check for Update `/update`).
+**Pages**: Lookup (`/`), Batch (`/batch`), Config (`/config`), Database (`/database`), Flashcards (`/flashcards`), Help dropdown (About `/about`, Documentation `/docs`, Changelog `/changelog`, Check for Update `/update`).
 
 **Help menu**: A dropdown in the nav bar groups help-related pages. `isHelpPage` template function highlights the Help item when any subpage is active. Documentation pages render embedded `docs/*.md` via goldmark. The update page queries GitHub Releases via HTMX on load. A dismissible update banner appears on all pages when a newer version is detected at startup.
 
 **HTMX pattern**: Forms use `hx-post` to send requests; server returns HTML fragments that HTMX swaps into the page. No JSON parsing on the client side for UI interactions.
 
 **Batch progress**: Server-Sent Events (SSE) stream real-time progress via `http.Flusher`. Client uses HTMX SSE extension. Supports cancellation — client aborts the fetch via `AbortController`, server detects context cancellation and emits a `cancelled` event with partial results.
+
+**Flashcards**: The `/flashcards` page provides a study mode for reviewing vocabulary. `handlers_flashcards.go` implements two endpoints: `GET /api/flashcards/html` assembles a filtered deck by querying `ListWords` + `ListExpressions` with difficulty/language/tag filters and returns the `flashcard_card` partial with a `data-deck` JSON attribute; `PUT /api/flashcards/rate` persists a difficulty rating (easy/hard/natural) for a word or expression. Inline JavaScript in `flashcards.html` handles card flip (CSS `rotateY` with `perspective` and `backface-visibility`), prev/next deck navigation, display mode toggle (word-first vs detail-first), and difficulty rating via `fetch`. No external JS libraries.
 
 **Conflict resolution UI**: When a lookup with context finds existing entries, the server returns a `lookup_conflict.html` partial showing existing entries side-by-side with the new result, plus resolve buttons (replace/add/skip).
 
@@ -326,7 +330,7 @@ Plain string form: validator normalizes to `{"primary": "the string", "alternati
 
 Words and expressions tables with no unique constraint on (source_language, word/expression) — multiple rows allowed for multi-version entries. Indexes for query performance, not uniqueness.
 
-Tables: `metadata` (schema versioning), `words` (20 columns), `expressions` (16 columns). Timestamps in RFC3339 format.
+Tables: `metadata` (schema versioning), `words` (21 columns incl. `difficulty`), `expressions` (17 columns incl. `difficulty`). Timestamps in RFC3339 format. Schema version tracked in `metadata` — V1 creates tables, V2 adds the `difficulty` column.
 
 ## Error Handling
 
@@ -366,6 +370,7 @@ internal/web/templates/
 ├── batch.html             # Batch upload page
 ├── config.html            # Settings page
 ├── database.html          # Browse/edit/import/export page
+├── flashcards.html        # Flashcard study mode (flip, navigate, rate, filter)
 ├── about.html             # About page (version, build info, links)
 ├── docs.html              # Documentation index (Table of Contents)
 ├── docs_page.html         # Documentation content page (rendered markdown)
@@ -378,6 +383,7 @@ internal/web/templates/
     ├── config_form.html       # Config form with conditional provider fields
     ├── entry_edit.html        # Edit form for a single entry
     ├── entry_table.html       # Paginated table rows
+    ├── flashcard_card.html    # Flashcard deck partial (data-deck JSON + card markup)
     ├── setup_local_llm.html   # Local LLM setup progress (SSE-driven)
     └── update_result.html     # Update check result (up-to-date / update available / error)
 ```
@@ -399,6 +405,8 @@ Forms use `hx-post`/`hx-put`/`hx-delete` to send requests. Server returns HTML f
 | Bulk delete | DELETE /api/words/bulk | Updated table HTML |
 | Import CSV | POST /api/import | Import summary |
 | Export Excel | GET /api/export | .xlsx file download |
+| Load flashcard deck | GET /api/flashcards/html | `flashcard_card.html` partial (filtered deck) |
+| Rate flashcard | PUT /api/flashcards/rate | JSON `{"status":"ok","difficulty":"..."}` |
 
 ### API Routes
 
@@ -432,6 +440,8 @@ Forms use `hx-post`/`hx-put`/`hx-delete` to send requests. Server returns HTML f
 | GET | /changelog | Changelog page |
 | GET | /update | Check for Update page |
 | GET | /api/update/check | HTMX partial: update check result |
+| GET | /api/flashcards/html | Flashcard deck partial (filtered) |
+| PUT | /api/flashcards/rate | Rate a flashcard (difficulty) |
 | POST | /api/update/dismiss | Dismiss update banner |
 
 ## Testing Strategy

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -296,6 +296,7 @@ Open `http://localhost:8080` in your browser.
 - **Lookup** (`/`): Enter a word or expression, select source/target language, optionally provide context. Results display inline. Conflict resolution UI appears when an existing entry is found with a new context.
 - **Batch** (`/batch`): Upload a CSV file, select mode and languages, set conflict strategy. Progress streams via SSE. Cancel a running batch at any time — partial results are preserved. Summary shows processed/cached/failed/replaced/added counts.
 - **Config** (`/config`): View and edit provider settings, test connection to the LLM provider. Credential env var hints are shown per provider; API keys are read from environment variables automatically. On first launch, the "default" profile is shown — edit the fields and click Save to configure your provider. Use "Add new profile…" in the profile dropdown to create additional setups (e.g., a "local" profile for Ollama and a "prod" profile for Bedrock).
+- **Flashcards** (`/flashcards`): Study vocabulary with a flip-card interface. Filter by language, tags, and difficulty. Rate cards as easy/hard/natural to focus future sessions. See [Flashcards](#flashcards) below.
 - **Database** (`/database`): Browse, search, edit, delete vocabulary entries. Select individual entries or use select-all to bulk delete. Import CSV, export to Excel. Filter by language, search text, or tags.
 
 ### Help Menu
@@ -309,6 +310,63 @@ The navigation bar includes a Help dropdown with:
 - **Check for Update** (`/update`): Displays the current version, build date, and OS/architecture. On page load, queries the GitHub Releases API to check for newer versions. If an update is available, shows the latest version, a direct download link for your platform, and a delta changelog covering all releases between your version and the latest. If the API is unreachable, displays a fallback message with a manual link to GitHub Releases.
 
 When the web server starts, it performs a background update check. If a newer version is detected, a dismissible banner appears below the navigation bar on all pages with a link to the update page. The banner does not reappear after dismissal until the server is restarted.
+
+## Flashcards
+
+The Flashcards page (`/flashcards`) lets you study vocabulary entries as flip cards. Click "Flashcards" in the navigation bar or go to `http://localhost:8080/flashcards`.
+
+### Filter Controls
+
+Five dropdowns at the top of the page control which cards appear:
+
+| Filter | Options | Default |
+|--------|---------|---------|
+| Source Language | All supported languages, or "All" | All |
+| Target Language | All supported languages, or "All" | All |
+| Tags | All tags present in the database, or "All" | All |
+| Difficulty | Hard + Natural, Hard only, All, Easy only | Hard + Natural |
+| Display Mode | Word first, Detail first | Word first |
+
+Changing any filter reloads the deck automatically (no page refresh). The default difficulty filter hides easy cards so you focus on words that still need practice.
+
+### Card Flip
+
+- Click the card to flip between front and back
+- In "Word first" mode (default): front shows the source-language word, back shows definition, English translation, and target translation
+- In "Detail first" mode: front shows definition and translations, back shows the word
+- Flipping is instant (client-side animation, no server call)
+
+### Navigation
+
+- Use the **Prev** and **Next** buttons below the card to move through the deck
+- The status bar between the buttons shows your position as "N / T" (e.g., "3 / 47")
+- Prev is disabled on the first card; Next is disabled on the last card
+- Navigating to a new card always shows the front face
+
+### Difficulty Rating
+
+Three buttons below the card let you rate each entry:
+
+| Button | Meaning |
+|--------|---------|
+| Easy | Mastered — hidden by default filter |
+| Natural | Normal — included by default |
+| Hard | Needs practice — included by default |
+
+Ratings persist in the database across sessions. The active rating is highlighted on the current card. Rating a card does not advance to the next card or flip it.
+
+### Display Mode
+
+Toggle between "Word first" and "Detail first" in the Display Mode dropdown:
+
+- **Word first**: See the source-language word, then flip to reveal the definition and translations
+- **Detail first**: See the definition and translations, then flip to reveal the word
+
+Changing the mode keeps your position in the deck and resets the card to the front face.
+
+### Empty State
+
+If no entries match your filters, the card area shows: "No flashcards match your filters. Try adjusting your filters or add vocabulary via Lookup or Batch."
 
 ## Tags
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2,7 +2,11 @@ package db
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"unicode"
 
@@ -668,4 +672,870 @@ func TestDeleteExpressions_BulkDelete(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Migration V2 tests ---
+
+func TestMigrationV2_AddsDifficultyColumn(t *testing.T) {
+	// Requirements: 9.1, 9.3
+	// Verifies the V2 migration adds the difficulty column to both tables,
+	// sets schema version to '2', and defaults fresh inserts to 'natural'.
+
+	tests := []struct {
+		name  string
+		table string
+	}{
+		{"words table has difficulty column", "words"},
+		{"expressions table has difficulty column", "expressions"},
+	}
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Sub-test: verify difficulty column exists on both tables.
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// PRAGMA table_info returns columns; check that 'difficulty' is present.
+			rows, err := store.db.QueryContext(ctx,
+				fmt.Sprintf("PRAGMA table_info(%s)", tc.table))
+			if err != nil {
+				t.Fatalf("PRAGMA table_info(%s): %v", tc.table, err)
+			}
+			defer func() { _ = rows.Close() }()
+
+			found := false
+			for rows.Next() {
+				var cid int
+				var name, colType string
+				var notNull int
+				var dfltValue sql.NullString
+				var pk int
+				if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+					t.Fatalf("scan column info: %v", err)
+				}
+				if name == "difficulty" {
+					found = true
+					if !dfltValue.Valid || dfltValue.String != "'natural'" {
+						t.Errorf("difficulty default = %v, want 'natural'", dfltValue)
+					}
+				}
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows iteration: %v", err)
+			}
+			if !found {
+				t.Errorf("table %q missing difficulty column", tc.table)
+			}
+		})
+	}
+
+	// Sub-test: verify schema version is '2'.
+	t.Run("schema version is 2", func(t *testing.T) {
+		var version string
+		err := store.db.QueryRowContext(ctx,
+			`SELECT value FROM metadata WHERE key = 'schema_version'`,
+		).Scan(&version)
+		if err != nil {
+			t.Fatalf("query schema_version: %v", err)
+		}
+		if version != "2" {
+			t.Errorf("schema_version = %q, want %q", version, "2")
+		}
+	})
+
+	// Sub-test: verify fresh inserts default to 'natural'.
+	t.Run("word insert defaults difficulty to natural", func(t *testing.T) {
+		row := makeWordRow("testwoord", "nl")
+		if err := store.InsertWord(ctx, row); err != nil {
+			t.Fatalf("InsertWord: %v", err)
+		}
+		got, err := store.FindWord(ctx, "testwoord", "nl")
+		if err != nil {
+			t.Fatalf("FindWord: %v", err)
+		}
+		if got == nil {
+			t.Fatal("FindWord returned nil")
+		}
+		if got.Difficulty != "natural" {
+			t.Errorf("word difficulty = %q, want %q", got.Difficulty, "natural")
+		}
+	})
+
+	t.Run("expression insert defaults difficulty to natural", func(t *testing.T) {
+		row := makeExpressionRow("test uitdrukking", "nl")
+		if err := store.InsertExpression(ctx, row); err != nil {
+			t.Fatalf("InsertExpression: %v", err)
+		}
+		got, err := store.FindExpression(ctx, "test uitdrukking", "nl")
+		if err != nil {
+			t.Fatalf("FindExpression: %v", err)
+		}
+		if got == nil {
+			t.Fatal("FindExpression returned nil")
+		}
+		if got.Difficulty != "natural" {
+			t.Errorf("expression difficulty = %q, want %q", got.Difficulty, "natural")
+		}
+	})
+}
+
+// --- Property Test P13: Migration preserves data and defaults difficulty ---
+
+// Feature: flashcards, Property 4: Migration preserves data and defaults difficulty
+// **Validates: Requirements 9.2**
+func TestPropertyP13_MigrationPreservesData(t *testing.T) {
+	// Counter for unique DB file names across rapid iterations.
+	dir := t.TempDir()
+	var iterCount int64
+
+	rapid.Check(t, func(t *rapid.T) {
+		iterCount++
+
+		// 1. Create a V1-only database: open raw SQLite, run only migrateV1.
+		dbPath := filepath.Join(dir, fmt.Sprintf("migration_test_%d.db", iterCount))
+
+		rawDB, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = rawDB.Close() }()
+
+		if _, err := rawDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+			t.Fatalf("set WAL: %v", err)
+		}
+
+		store := &SQLiteStore{db: rawDB, dbPath: dbPath}
+
+		// Create metadata table and run V1 migration only.
+		if _, err := rawDB.Exec(`CREATE TABLE IF NOT EXISTS metadata (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL
+		)`); err != nil {
+			t.Fatalf("create metadata: %v", err)
+		}
+		if err := store.migrateV1(); err != nil {
+			t.Fatalf("migrateV1: %v", err)
+		}
+
+		// 2. Generate and insert random words via raw SQL (V1 schema, no difficulty column).
+		type wordSnapshot struct {
+			Word              string
+			PartOfSpeech      string
+			Article           string
+			Definition        string
+			EnglishDefinition string
+			Example           string
+			English           string
+			TargetTranslation string
+			Notes             string
+			Connotation       string
+			Register          string
+			Collocations      string
+			ContrastiveNotes  string
+			SecondaryMeanings string
+			Tags              string
+			SourceLanguage    string
+			TargetLanguage    string
+			CreatedAt         string
+			UpdatedAt         string
+		}
+		type exprSnapshot struct {
+			Expression        string
+			Definition        string
+			EnglishDefinition string
+			Example           string
+			English           string
+			TargetTranslation string
+			Notes             string
+			Connotation       string
+			Register          string
+			ContrastiveNotes  string
+			Tags              string
+			SourceLanguage    string
+			TargetLanguage    string
+			CreatedAt         string
+			UpdatedAt         string
+		}
+
+		safeStr := rapid.StringOfN(rapid.RuneFrom(nil, &unicode.RangeTable{
+			R16: []unicode.Range16{{Lo: 0x20, Hi: 0x7E, Stride: 1}},
+		}), 1, 30, -1)
+
+		numWords := rapid.IntRange(1, 5).Draw(t, "numWords")
+		var insertedWords []wordSnapshot
+		for i := 0; i < numWords; i++ {
+			w := wordSnapshot{
+				Word:              safeStr.Draw(t, fmt.Sprintf("word_%d", i)),
+				PartOfSpeech:      safeStr.Draw(t, fmt.Sprintf("pos_%d", i)),
+				Article:           safeStr.Draw(t, fmt.Sprintf("article_%d", i)),
+				Definition:        safeStr.Draw(t, fmt.Sprintf("def_%d", i)),
+				EnglishDefinition: safeStr.Draw(t, fmt.Sprintf("endef_%d", i)),
+				Example:           safeStr.Draw(t, fmt.Sprintf("example_%d", i)),
+				English:           safeStr.Draw(t, fmt.Sprintf("english_%d", i)),
+				TargetTranslation: safeStr.Draw(t, fmt.Sprintf("target_%d", i)),
+				Notes:             safeStr.Draw(t, fmt.Sprintf("notes_%d", i)),
+				Connotation:       safeStr.Draw(t, fmt.Sprintf("connotation_%d", i)),
+				Register:          safeStr.Draw(t, fmt.Sprintf("register_%d", i)),
+				Collocations:      safeStr.Draw(t, fmt.Sprintf("collocations_%d", i)),
+				ContrastiveNotes:  safeStr.Draw(t, fmt.Sprintf("contrastive_%d", i)),
+				SecondaryMeanings: safeStr.Draw(t, fmt.Sprintf("secondary_%d", i)),
+				Tags:              safeStr.Draw(t, fmt.Sprintf("tags_%d", i)),
+				SourceLanguage:    "nl",
+				TargetLanguage:    "hu",
+				CreatedAt:         "2025-01-01T00:00:00Z",
+				UpdatedAt:         "2025-01-01T00:00:00Z",
+			}
+			_, err := rawDB.Exec(
+				`INSERT INTO words (word, part_of_speech, article, definition, english_definition,
+					example, english, target_translation, notes, connotation, register,
+					collocations, contrastive_notes, secondary_meanings, tags,
+					source_language, target_language, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				w.Word, w.PartOfSpeech, w.Article, w.Definition, w.EnglishDefinition,
+				w.Example, w.English, w.TargetTranslation, w.Notes, w.Connotation, w.Register,
+				w.Collocations, w.ContrastiveNotes, w.SecondaryMeanings, w.Tags,
+				w.SourceLanguage, w.TargetLanguage, w.CreatedAt, w.UpdatedAt,
+			)
+			if err != nil {
+				t.Fatalf("insert word %d: %v", i, err)
+			}
+			insertedWords = append(insertedWords, w)
+		}
+
+		numExprs := rapid.IntRange(1, 5).Draw(t, "numExprs")
+		var insertedExprs []exprSnapshot
+		for i := 0; i < numExprs; i++ {
+			e := exprSnapshot{
+				Expression:        safeStr.Draw(t, fmt.Sprintf("expr_%d", i)),
+				Definition:        safeStr.Draw(t, fmt.Sprintf("exprdef_%d", i)),
+				EnglishDefinition: safeStr.Draw(t, fmt.Sprintf("exprendef_%d", i)),
+				Example:           safeStr.Draw(t, fmt.Sprintf("exprexample_%d", i)),
+				English:           safeStr.Draw(t, fmt.Sprintf("exprenglish_%d", i)),
+				TargetTranslation: safeStr.Draw(t, fmt.Sprintf("exprtarget_%d", i)),
+				Notes:             safeStr.Draw(t, fmt.Sprintf("exprnotes_%d", i)),
+				Connotation:       safeStr.Draw(t, fmt.Sprintf("exprconnotation_%d", i)),
+				Register:          safeStr.Draw(t, fmt.Sprintf("exprregister_%d", i)),
+				ContrastiveNotes:  safeStr.Draw(t, fmt.Sprintf("exprcontrastive_%d", i)),
+				Tags:              safeStr.Draw(t, fmt.Sprintf("exprtags_%d", i)),
+				SourceLanguage:    "nl",
+				TargetLanguage:    "hu",
+				CreatedAt:         "2025-01-01T00:00:00Z",
+				UpdatedAt:         "2025-01-01T00:00:00Z",
+			}
+			_, err := rawDB.Exec(
+				`INSERT INTO expressions (expression, definition, english_definition, example, english,
+					target_translation, notes, connotation, register, contrastive_notes, tags,
+					source_language, target_language, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				e.Expression, e.Definition, e.EnglishDefinition, e.Example, e.English,
+				e.TargetTranslation, e.Notes, e.Connotation, e.Register, e.ContrastiveNotes, e.Tags,
+				e.SourceLanguage, e.TargetLanguage, e.CreatedAt, e.UpdatedAt,
+			)
+			if err != nil {
+				t.Fatalf("insert expression %d: %v", i, err)
+			}
+			insertedExprs = append(insertedExprs, e)
+		}
+
+		// 3. Run migrateV2.
+		if err := store.migrateV2(); err != nil {
+			t.Fatalf("migrateV2: %v", err)
+		}
+
+		// 4. Read back all words and verify fields unchanged + difficulty = 'natural'.
+		wordRows, err := rawDB.Query(
+			`SELECT word, part_of_speech, article, definition, english_definition,
+				example, english, target_translation, notes, connotation, register,
+				collocations, contrastive_notes, secondary_meanings, tags,
+				source_language, target_language, difficulty, created_at, updated_at
+			FROM words ORDER BY id`)
+		if err != nil {
+			t.Fatalf("query words: %v", err)
+		}
+		defer func() { _ = wordRows.Close() }()
+
+		idx := 0
+		for wordRows.Next() {
+			var w, pos, art, def, endef, ex, eng, tgt, notes, conn, reg, coll, contr, sec, tags, sl, tl, diff, ca, ua string
+			if err := wordRows.Scan(&w, &pos, &art, &def, &endef, &ex, &eng, &tgt, &notes, &conn, &reg, &coll, &contr, &sec, &tags, &sl, &tl, &diff, &ca, &ua); err != nil {
+				t.Fatalf("scan word row %d: %v", idx, err)
+			}
+			if idx >= len(insertedWords) {
+				t.Fatalf("more word rows than inserted (%d)", idx)
+			}
+			orig := insertedWords[idx]
+			if diff != "natural" {
+				t.Fatalf("word %d: difficulty = %q, want %q", idx, diff, "natural")
+			}
+			if w != orig.Word || pos != orig.PartOfSpeech || art != orig.Article ||
+				def != orig.Definition || endef != orig.EnglishDefinition ||
+				ex != orig.Example || eng != orig.English || tgt != orig.TargetTranslation ||
+				notes != orig.Notes || conn != orig.Connotation || reg != orig.Register ||
+				coll != orig.Collocations || contr != orig.ContrastiveNotes || sec != orig.SecondaryMeanings ||
+				tags != orig.Tags || sl != orig.SourceLanguage || tl != orig.TargetLanguage ||
+				ca != orig.CreatedAt || ua != orig.UpdatedAt {
+				t.Fatalf("word %d: fields changed after migration\ngot:  %+v\nwant: %+v", idx,
+					[]string{w, pos, art, def, endef, ex, eng, tgt, notes, conn, reg, coll, contr, sec, tags, sl, tl, ca, ua},
+					[]string{orig.Word, orig.PartOfSpeech, orig.Article, orig.Definition, orig.EnglishDefinition,
+						orig.Example, orig.English, orig.TargetTranslation, orig.Notes, orig.Connotation, orig.Register,
+						orig.Collocations, orig.ContrastiveNotes, orig.SecondaryMeanings, orig.Tags,
+						orig.SourceLanguage, orig.TargetLanguage, orig.CreatedAt, orig.UpdatedAt})
+			}
+			idx++
+		}
+		if err := wordRows.Err(); err != nil {
+			t.Fatalf("word rows iteration: %v", err)
+		}
+		if idx != len(insertedWords) {
+			t.Fatalf("expected %d word rows, got %d", len(insertedWords), idx)
+		}
+
+		// 5. Read back all expressions and verify fields unchanged + difficulty = 'natural'.
+		exprRows, err := rawDB.Query(
+			`SELECT expression, definition, english_definition, example, english,
+				target_translation, notes, connotation, register, contrastive_notes, tags,
+				source_language, target_language, difficulty, created_at, updated_at
+			FROM expressions ORDER BY id`)
+		if err != nil {
+			t.Fatalf("query expressions: %v", err)
+		}
+		defer func() { _ = exprRows.Close() }()
+
+		idx = 0
+		for exprRows.Next() {
+			var expr, def, endef, ex, eng, tgt, notes, conn, reg, contr, tags, sl, tl, diff, ca, ua string
+			if err := exprRows.Scan(&expr, &def, &endef, &ex, &eng, &tgt, &notes, &conn, &reg, &contr, &tags, &sl, &tl, &diff, &ca, &ua); err != nil {
+				t.Fatalf("scan expression row %d: %v", idx, err)
+			}
+			if idx >= len(insertedExprs) {
+				t.Fatalf("more expression rows than inserted (%d)", idx)
+			}
+			orig := insertedExprs[idx]
+			if diff != "natural" {
+				t.Fatalf("expression %d: difficulty = %q, want %q", idx, diff, "natural")
+			}
+			if expr != orig.Expression || def != orig.Definition || endef != orig.EnglishDefinition ||
+				ex != orig.Example || eng != orig.English || tgt != orig.TargetTranslation ||
+				notes != orig.Notes || conn != orig.Connotation || reg != orig.Register ||
+				contr != orig.ContrastiveNotes || tags != orig.Tags ||
+				sl != orig.SourceLanguage || tl != orig.TargetLanguage ||
+				ca != orig.CreatedAt || ua != orig.UpdatedAt {
+				t.Fatalf("expression %d: fields changed after migration\ngot:  %+v\nwant: %+v", idx,
+					[]string{expr, def, endef, ex, eng, tgt, notes, conn, reg, contr, tags, sl, tl, ca, ua},
+					[]string{orig.Expression, orig.Definition, orig.EnglishDefinition,
+						orig.Example, orig.English, orig.TargetTranslation, orig.Notes, orig.Connotation, orig.Register,
+						orig.ContrastiveNotes, orig.Tags, orig.SourceLanguage, orig.TargetLanguage, orig.CreatedAt, orig.UpdatedAt})
+			}
+			idx++
+		}
+		if err := exprRows.Err(); err != nil {
+			t.Fatalf("expression rows iteration: %v", err)
+		}
+		if idx != len(insertedExprs) {
+			t.Fatalf("expected %d expression rows, got %d", len(insertedExprs), idx)
+		}
+	})
+}
+
+// --- Property Test P14: ListDistinctTags returns sorted deduplicated tags ---
+
+// Feature: flashcards, Property 3: ListDistinctTags returns sorted deduplicated tags
+// **Validates: Requirements 4.1, 4.2, 4.3**
+func TestPropertyP14_ListDistinctTags(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	rapid.Check(t, func(t *rapid.T) {
+		// Clean tables between iterations to ensure isolation.
+		_, _ = store.db.Exec("DELETE FROM words")
+		_, _ = store.db.Exec("DELETE FROM expressions")
+
+		// Generator for a single tag segment: 1-15 printable ASCII chars, no commas.
+		tagSegment := rapid.StringOfN(rapid.RuneFrom(nil, &unicode.RangeTable{
+			R16: []unicode.Range16{{Lo: 0x21, Hi: 0x2B, Stride: 1}, {Lo: 0x2D, Hi: 0x7E, Stride: 1}},
+		}), 1, 15, -1)
+
+		// Generator for a comma-separated tag string with optional whitespace padding.
+		tagString := rapid.Custom(func(t *rapid.T) string {
+			n := rapid.IntRange(0, 5).Draw(t, "numSegments")
+			parts := make([]string, n)
+			for i := 0; i < n; i++ {
+				pad := rapid.StringOfN(rapid.Just(' '), 0, 3, -1).Draw(t, fmt.Sprintf("pad_%d", i))
+				seg := tagSegment.Draw(t, fmt.Sprintf("seg_%d", i))
+				parts[i] = pad + seg + pad
+			}
+			// Occasionally include empty segments (consecutive commas).
+			if n > 0 && rapid.Bool().Draw(t, "extraComma") {
+				idx := rapid.IntRange(0, len(parts)-1).Draw(t, "emptyIdx")
+				parts = append(parts[:idx+1], append([]string{""}, parts[idx+1:]...)...)
+			}
+			return strings.Join(parts, ",")
+		})
+
+		// Insert random words with random tag strings.
+		numWords := rapid.IntRange(0, 5).Draw(t, "numWords")
+		for i := 0; i < numWords; i++ {
+			row := makeWordRow(fmt.Sprintf("w_%d", i), "nl")
+			row.Tags = tagString.Draw(t, fmt.Sprintf("wordTags_%d", i))
+			if err := store.InsertWord(ctx, row); err != nil {
+				t.Fatalf("InsertWord %d: %v", i, err)
+			}
+		}
+
+		// Insert random expressions with random tag strings.
+		numExprs := rapid.IntRange(0, 5).Draw(t, "numExprs")
+		for i := 0; i < numExprs; i++ {
+			row := makeExpressionRow(fmt.Sprintf("e_%d", i), "nl")
+			row.Tags = tagString.Draw(t, fmt.Sprintf("exprTags_%d", i))
+			if err := store.InsertExpression(ctx, row); err != nil {
+				t.Fatalf("InsertExpression %d: %v", i, err)
+			}
+		}
+
+		// Call ListDistinctTags.
+		got, err := store.ListDistinctTags(ctx)
+		if err != nil {
+			t.Fatalf("ListDistinctTags: %v", err)
+		}
+
+		// Compute expected: collect all tags from all inserted rows, split, trim, deduplicate.
+		expected := make(map[string]bool)
+
+		// Re-read all words and expressions to get their tags (including any pre-existing from makeWordRow/makeExpressionRow defaults).
+		allWords, _, err := store.ListWords(ctx, ListFilter{Page: 1, PageSize: 10000})
+		if err != nil {
+			t.Fatalf("ListWords: %v", err)
+		}
+		for _, w := range allWords {
+			for _, tag := range strings.Split(w.Tags, ",") {
+				tag = strings.TrimSpace(tag)
+				if tag != "" {
+					expected[tag] = true
+				}
+			}
+		}
+		allExprs, _, err := store.ListExpressions(ctx, ListFilter{Page: 1, PageSize: 10000})
+		if err != nil {
+			t.Fatalf("ListExpressions: %v", err)
+		}
+		for _, e := range allExprs {
+			for _, tag := range strings.Split(e.Tags, ",") {
+				tag = strings.TrimSpace(tag)
+				if tag != "" {
+					expected[tag] = true
+				}
+			}
+		}
+
+		expectedSlice := make([]string, 0, len(expected))
+		for tag := range expected {
+			expectedSlice = append(expectedSlice, tag)
+		}
+		sort.Strings(expectedSlice)
+
+		// Verify: result is non-nil.
+		if got == nil {
+			t.Fatal("ListDistinctTags returned nil, want non-nil slice")
+		}
+
+		// Verify: result is sorted.
+		if !sort.StringsAreSorted(got) {
+			t.Fatalf("result is not sorted: %v", got)
+		}
+
+		// Verify: result has no duplicates.
+		seen := make(map[string]bool)
+		for _, tag := range got {
+			if seen[tag] {
+				t.Fatalf("duplicate tag in result: %q", tag)
+			}
+			seen[tag] = true
+		}
+
+		// Verify: result matches expected set exactly.
+		if len(got) != len(expectedSlice) {
+			t.Fatalf("length mismatch: got %d tags, want %d\ngot:  %v\nwant: %v", len(got), len(expectedSlice), got, expectedSlice)
+		}
+		for i := range got {
+			if got[i] != expectedSlice[i] {
+				t.Fatalf("tag mismatch at index %d: got %q, want %q\ngot:  %v\nwant: %v", i, got[i], expectedSlice[i], got, expectedSlice)
+			}
+		}
+	})
+}
+
+// --- Unit Test: ListDistinctTags on empty database ---
+
+func TestListDistinctTags_EmptyDB(t *testing.T) {
+	// Requirements: 4.4
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	got, err := store.ListDistinctTags(ctx)
+	if err != nil {
+		t.Fatalf("ListDistinctTags: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ListDistinctTags returned nil, want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("ListDistinctTags returned %d tags, want 0: %v", len(got), got)
+	}
+}
+
+// --- Property Test P15: Difficulty rating round-trip ---
+
+// Feature: flashcards, Property 5: Difficulty rating round-trip
+// **Validates: Requirements 10.2**
+func TestPropertyP15_DifficultyRatingRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	validDifficulties := []string{"easy", "hard", "natural"}
+
+	rapid.Check(t, func(t *rapid.T) {
+		// Pick a random difficulty value.
+		difficulty := rapid.SampledFrom(validDifficulties).Draw(t, "difficulty")
+
+		// Pick whether to test a word or an expression.
+		isWord := rapid.Bool().Draw(t, "isWord")
+
+		if isWord {
+			row := makeWordRow(
+				rapid.StringMatching(`[a-z]{1,20}`).Draw(t, "word"),
+				"nl",
+			)
+			if err := store.InsertWord(ctx, row); err != nil {
+				t.Fatalf("InsertWord: %v", err)
+			}
+
+			// Update difficulty.
+			if err := store.UpdateWordDifficulty(ctx, row.ID, difficulty); err != nil {
+				t.Fatalf("UpdateWordDifficulty: %v", err)
+			}
+
+			// Read back and verify.
+			got, err := store.GetWord(ctx, row.ID)
+			if err != nil {
+				t.Fatalf("GetWord: %v", err)
+			}
+			if got == nil {
+				t.Fatal("GetWord returned nil for inserted word")
+				return
+			}
+			if got.Difficulty != difficulty {
+				t.Fatalf("word difficulty mismatch: got %q, want %q", got.Difficulty, difficulty)
+			}
+		} else {
+			row := makeExpressionRow(
+				rapid.StringMatching(`[a-z]{1,20}`).Draw(t, "expression"),
+				"nl",
+			)
+			if err := store.InsertExpression(ctx, row); err != nil {
+				t.Fatalf("InsertExpression: %v", err)
+			}
+
+			// Update difficulty.
+			if err := store.UpdateExpressionDifficulty(ctx, row.ID, difficulty); err != nil {
+				t.Fatalf("UpdateExpressionDifficulty: %v", err)
+			}
+
+			// Read back and verify.
+			got, err := store.GetExpression(ctx, row.ID)
+			if err != nil {
+				t.Fatalf("GetExpression: %v", err)
+			}
+			if got == nil {
+				t.Fatal("GetExpression returned nil for inserted expression")
+				return
+			}
+			if got.Difficulty != difficulty {
+				t.Fatalf("expression difficulty mismatch: got %q, want %q", got.Difficulty, difficulty)
+			}
+		}
+	})
+}
+
+// --- Property Test P16: Difficulty filter ---
+
+// Feature: flashcards, Property 1: Filtered deck contains exactly the matching entries
+// **Validates: Requirements 2.1, 3.4, 11.3, 11.4**
+func TestPropertyP16_DifficultyFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	validDifficulties := []string{"easy", "hard", "natural"}
+
+	rapid.Check(t, func(t *rapid.T) {
+		// Clean tables between iterations.
+		_, _ = store.db.Exec("DELETE FROM words")
+		_, _ = store.db.Exec("DELETE FROM expressions")
+
+		// 1. Insert random words with random difficulties.
+		numWords := rapid.IntRange(1, 8).Draw(t, "numWords")
+		type wordEntry struct {
+			id         int64
+			difficulty string
+		}
+		words := make([]wordEntry, 0, numWords)
+		for i := 0; i < numWords; i++ {
+			row := makeWordRow(fmt.Sprintf("w_%d", i), "nl")
+			if err := store.InsertWord(ctx, row); err != nil {
+				t.Fatalf("InsertWord %d: %v", i, err)
+			}
+			diff := rapid.SampledFrom(validDifficulties).Draw(t, fmt.Sprintf("wordDiff_%d", i))
+			if err := store.UpdateWordDifficulty(ctx, row.ID, diff); err != nil {
+				t.Fatalf("UpdateWordDifficulty %d: %v", i, err)
+			}
+			words = append(words, wordEntry{id: row.ID, difficulty: diff})
+		}
+
+		// 2. Insert random expressions with random difficulties.
+		numExprs := rapid.IntRange(1, 8).Draw(t, "numExprs")
+		type exprEntry struct {
+			id         int64
+			difficulty string
+		}
+		exprs := make([]exprEntry, 0, numExprs)
+		for i := 0; i < numExprs; i++ {
+			row := makeExpressionRow(fmt.Sprintf("e_%d", i), "nl")
+			if err := store.InsertExpression(ctx, row); err != nil {
+				t.Fatalf("InsertExpression %d: %v", i, err)
+			}
+			diff := rapid.SampledFrom(validDifficulties).Draw(t, fmt.Sprintf("exprDiff_%d", i))
+			if err := store.UpdateExpressionDifficulty(ctx, row.ID, diff); err != nil {
+				t.Fatalf("UpdateExpressionDifficulty %d: %v", i, err)
+			}
+			exprs = append(exprs, exprEntry{id: row.ID, difficulty: diff})
+		}
+
+		// 3. Pick a random subset of difficulty values as the filter.
+		subsetMask := rapid.IntRange(0, 7).Draw(t, "subsetMask") // 3 bits for 3 values
+		var filterDiffs []string
+		for i, d := range validDifficulties {
+			if subsetMask&(1<<i) != 0 {
+				filterDiffs = append(filterDiffs, d)
+			}
+		}
+
+		// Build a set for quick lookup.
+		filterSet := make(map[string]bool, len(filterDiffs))
+		for _, d := range filterDiffs {
+			filterSet[d] = true
+		}
+
+		filter := ListFilter{
+			Page:       1,
+			PageSize:   10000,
+			Difficulty: filterDiffs,
+		}
+
+		// 4. Query words with the difficulty filter.
+		gotWords, gotWordTotal, err := store.ListWords(ctx, filter)
+		if err != nil {
+			t.Fatalf("ListWords: %v", err)
+		}
+
+		// 5. Compute expected word IDs.
+		var expectedWordIDs []int64
+		for _, w := range words {
+			if len(filterDiffs) == 0 || filterSet[w.difficulty] {
+				expectedWordIDs = append(expectedWordIDs, w.id)
+			}
+		}
+
+		// Verify word count matches.
+		if gotWordTotal != len(expectedWordIDs) {
+			t.Fatalf("word total mismatch: got %d, want %d (filter=%v)", gotWordTotal, len(expectedWordIDs), filterDiffs)
+		}
+		if len(gotWords) != len(expectedWordIDs) {
+			t.Fatalf("word rows mismatch: got %d, want %d (filter=%v)", len(gotWords), len(expectedWordIDs), filterDiffs)
+		}
+
+		gotWordIDSet := make(map[int64]bool, len(gotWords))
+		for _, w := range gotWords {
+			gotWordIDSet[w.ID] = true
+		}
+		for _, id := range expectedWordIDs {
+			if !gotWordIDSet[id] {
+				t.Fatalf("expected word ID %d not in results (filter=%v)", id, filterDiffs)
+			}
+		}
+
+		// 6. Query expressions with the difficulty filter.
+		gotExprs, gotExprTotal, err := store.ListExpressions(ctx, filter)
+		if err != nil {
+			t.Fatalf("ListExpressions: %v", err)
+		}
+
+		// Compute expected expression IDs.
+		var expectedExprIDs []int64
+		for _, e := range exprs {
+			if len(filterDiffs) == 0 || filterSet[e.difficulty] {
+				expectedExprIDs = append(expectedExprIDs, e.id)
+			}
+		}
+
+		// Verify expression count matches.
+		if gotExprTotal != len(expectedExprIDs) {
+			t.Fatalf("expression total mismatch: got %d, want %d (filter=%v)", gotExprTotal, len(expectedExprIDs), filterDiffs)
+		}
+		if len(gotExprs) != len(expectedExprIDs) {
+			t.Fatalf("expression rows mismatch: got %d, want %d (filter=%v)", len(gotExprs), len(expectedExprIDs), filterDiffs)
+		}
+
+		gotExprIDSet := make(map[int64]bool, len(gotExprs))
+		for _, e := range gotExprs {
+			gotExprIDSet[e.ID] = true
+		}
+		for _, id := range expectedExprIDs {
+			if !gotExprIDSet[id] {
+				t.Fatalf("expected expression ID %d not in results (filter=%v)", id, filterDiffs)
+			}
+		}
+
+		// 7. Verify empty filter returns all entries.
+		emptyFilter := ListFilter{Page: 1, PageSize: 10000}
+		allWords, allWordTotal, err := store.ListWords(ctx, emptyFilter)
+		if err != nil {
+			t.Fatalf("ListWords (empty filter): %v", err)
+		}
+		if allWordTotal != numWords {
+			t.Fatalf("empty filter word total: got %d, want %d", allWordTotal, numWords)
+		}
+		if len(allWords) != numWords {
+			t.Fatalf("empty filter word rows: got %d, want %d", len(allWords), numWords)
+		}
+
+		allExprs, allExprTotal, err := store.ListExpressions(ctx, emptyFilter)
+		if err != nil {
+			t.Fatalf("ListExpressions (empty filter): %v", err)
+		}
+		if allExprTotal != numExprs {
+			t.Fatalf("empty filter expression total: got %d, want %d", allExprTotal, numExprs)
+		}
+		if len(allExprs) != numExprs {
+			t.Fatalf("empty filter expression rows: got %d, want %d", len(allExprs), numExprs)
+		}
+	})
+}
+
+// --- Property Test P17: FlashcardItem mapping preserves source data ---
+
+// wordRowToFlashcardItem converts a WordRow to a FlashcardItem.
+// This is the canonical mapping used by the flashcard handler.
+func wordRowToFlashcardItem(w *WordRow) FlashcardItem {
+	return FlashcardItem{
+		ID:                w.ID,
+		Type:              "word",
+		Text:              w.Word,
+		Definition:        w.Definition,
+		English:           w.English,
+		TargetTranslation: w.TargetTranslation,
+		Difficulty:        w.Difficulty,
+	}
+}
+
+// expressionRowToFlashcardItem converts an ExpressionRow to a FlashcardItem.
+// This is the canonical mapping used by the flashcard handler.
+func expressionRowToFlashcardItem(e *ExpressionRow) FlashcardItem {
+	return FlashcardItem{
+		ID:                e.ID,
+		Type:              "expression",
+		Text:              e.Expression,
+		Definition:        e.Definition,
+		English:           e.English,
+		TargetTranslation: e.TargetTranslation,
+		Difficulty:        e.Difficulty,
+	}
+}
+
+// Feature: flashcards, Property 2: FlashcardItem mapping preserves source data
+// **Validates: Requirements 2.2**
+func TestPropertyP17_FlashcardItemMapping(t *testing.T) {
+	validDifficulties := []string{"easy", "hard", "natural"}
+
+	safeStr := rapid.StringOfN(rapid.RuneFrom(nil, &unicode.RangeTable{
+		R16: []unicode.Range16{{Lo: 0x20, Hi: 0x7E, Stride: 1}},
+	}), 1, 50, -1)
+
+	rapid.Check(t, func(t *rapid.T) {
+		isWord := rapid.Bool().Draw(t, "isWord")
+
+		if isWord {
+			// Generate a random WordRow.
+			w := &WordRow{
+				ID:                rapid.Int64Range(1, 1_000_000).Draw(t, "id"),
+				Word:              safeStr.Draw(t, "word"),
+				Definition:        safeStr.Draw(t, "definition"),
+				English:           safeStr.Draw(t, "english"),
+				TargetTranslation: safeStr.Draw(t, "targetTranslation"),
+				Difficulty:        rapid.SampledFrom(validDifficulties).Draw(t, "difficulty"),
+				PartOfSpeech:      safeStr.Draw(t, "pos"),
+				Article:           safeStr.Draw(t, "article"),
+				SourceLanguage:    "nl",
+				TargetLanguage:    "hu",
+			}
+
+			item := wordRowToFlashcardItem(w)
+
+			if item.ID != w.ID {
+				t.Fatalf("ID mismatch: got %d, want %d", item.ID, w.ID)
+			}
+			if item.Type != "word" {
+				t.Fatalf("Type mismatch: got %q, want %q", item.Type, "word")
+			}
+			if item.Text != w.Word {
+				t.Fatalf("Text mismatch: got %q, want %q", item.Text, w.Word)
+			}
+			if item.Definition != w.Definition {
+				t.Fatalf("Definition mismatch: got %q, want %q", item.Definition, w.Definition)
+			}
+			if item.English != w.English {
+				t.Fatalf("English mismatch: got %q, want %q", item.English, w.English)
+			}
+			if item.TargetTranslation != w.TargetTranslation {
+				t.Fatalf("TargetTranslation mismatch: got %q, want %q", item.TargetTranslation, w.TargetTranslation)
+			}
+			if item.Difficulty != w.Difficulty {
+				t.Fatalf("Difficulty mismatch: got %q, want %q", item.Difficulty, w.Difficulty)
+			}
+		} else {
+			// Generate a random ExpressionRow.
+			e := &ExpressionRow{
+				ID:                rapid.Int64Range(1, 1_000_000).Draw(t, "id"),
+				Expression:        safeStr.Draw(t, "expression"),
+				Definition:        safeStr.Draw(t, "definition"),
+				English:           safeStr.Draw(t, "english"),
+				TargetTranslation: safeStr.Draw(t, "targetTranslation"),
+				Difficulty:        rapid.SampledFrom(validDifficulties).Draw(t, "difficulty"),
+				SourceLanguage:    "nl",
+				TargetLanguage:    "hu",
+			}
+
+			item := expressionRowToFlashcardItem(e)
+
+			if item.ID != e.ID {
+				t.Fatalf("ID mismatch: got %d, want %d", item.ID, e.ID)
+			}
+			if item.Type != "expression" {
+				t.Fatalf("Type mismatch: got %q, want %q", item.Type, "expression")
+			}
+			if item.Text != e.Expression {
+				t.Fatalf("Text mismatch: got %q, want %q", item.Text, e.Expression)
+			}
+			if item.Definition != e.Definition {
+				t.Fatalf("Definition mismatch: got %q, want %q", item.Definition, e.Definition)
+			}
+			if item.English != e.English {
+				t.Fatalf("English mismatch: got %q, want %q", item.English, e.English)
+			}
+			if item.TargetTranslation != e.TargetTranslation {
+				t.Fatalf("TargetTranslation mismatch: got %q, want %q", item.TargetTranslation, e.TargetTranslation)
+			}
+			if item.Difficulty != e.Difficulty {
+				t.Fatalf("Difficulty mismatch: got %q, want %q", item.Difficulty, e.Difficulty)
+			}
+		}
+	})
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -20,6 +20,7 @@ type WordRow struct {
 	Tags              string
 	SourceLanguage    string
 	TargetLanguage    string
+	Difficulty        string
 	CreatedAt         string
 	UpdatedAt         string
 }
@@ -40,6 +41,18 @@ type ExpressionRow struct {
 	Tags              string
 	SourceLanguage    string
 	TargetLanguage    string
+	Difficulty        string
 	CreatedAt         string
 	UpdatedAt         string
+}
+
+// FlashcardItem is a unified view of a word or expression entry used for flashcard display.
+type FlashcardItem struct {
+	ID                int64  `json:"id"`
+	Type              string `json:"type"`
+	Text              string `json:"text"`
+	Definition        string `json:"definition"`
+	English           string `json:"english"`
+	TargetTranslation string `json:"target_translation"`
+	Difficulty        string `json:"difficulty"`
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -29,6 +29,12 @@ func (s *SQLiteStore) Migrate() error {
 		}
 	}
 
+	if version < 2 {
+		if err := s.migrateV2(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -95,6 +101,36 @@ func (s *SQLiteStore) migrateV1() error {
 	if _, err := tx.Exec(
 		`INSERT INTO metadata (key, value) VALUES ('schema_version', '1')
 		 ON CONFLICT(key) DO UPDATE SET value = '1'`,
+	); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// migrateV2 adds the difficulty column to words and expressions tables.
+func (s *SQLiteStore) migrateV2() error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmts := []string{
+		`ALTER TABLE words ADD COLUMN difficulty TEXT DEFAULT 'natural'`,
+		`ALTER TABLE expressions ADD COLUMN difficulty TEXT DEFAULT 'natural'`,
+	}
+
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return err
+		}
+	}
+
+	// Upsert schema version.
+	if _, err := tx.Exec(
+		`INSERT INTO metadata (key, value) VALUES ('schema_version', '2')
+		 ON CONFLICT(key) DO UPDATE SET value = '2'`,
 	); err != nil {
 		return err
 	}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -65,7 +66,7 @@ func (s *SQLiteStore) FindWord(ctx context.Context, word, sourceLang string) (*W
 		`SELECT id, word, part_of_speech, article, definition, english_definition,
 			example, english, target_translation, notes, connotation, register,
 			collocations, contrastive_notes, secondary_meanings, tags,
-			source_language, target_language, created_at, updated_at
+			source_language, target_language, difficulty, created_at, updated_at
 		FROM words WHERE word = ? AND source_language = ? LIMIT 1`,
 		word, sourceLang,
 	)
@@ -78,7 +79,7 @@ func (s *SQLiteStore) GetWord(ctx context.Context, id int64) (*WordRow, error) {
 		`SELECT id, word, part_of_speech, article, definition, english_definition,
 			example, english, target_translation, notes, connotation, register,
 			collocations, contrastive_notes, secondary_meanings, tags,
-			source_language, target_language, created_at, updated_at
+			source_language, target_language, difficulty, created_at, updated_at
 		FROM words WHERE id = ?`,
 		id,
 	)
@@ -92,7 +93,7 @@ func (s *SQLiteStore) FindWords(ctx context.Context, word, sourceLang string) ([
 		`SELECT id, word, part_of_speech, article, definition, english_definition,
 			example, english, target_translation, notes, connotation, register,
 			collocations, contrastive_notes, secondary_meanings, tags,
-			source_language, target_language, created_at, updated_at
+			source_language, target_language, difficulty, created_at, updated_at
 		FROM words WHERE word = ? AND source_language = ?`,
 		word, sourceLang,
 	)
@@ -108,7 +109,7 @@ func (s *SQLiteStore) FindWords(ctx context.Context, word, sourceLang string) ([
 			&w.ID, &w.Word, &w.PartOfSpeech, &w.Article, &w.Definition, &w.EnglishDefinition,
 			&w.Example, &w.English, &w.TargetTranslation, &w.Notes, &w.Connotation, &w.Register,
 			&w.Collocations, &w.ContrastiveNotes, &w.SecondaryMeanings, &w.Tags,
-			&w.SourceLanguage, &w.TargetLanguage, &w.CreatedAt, &w.UpdatedAt,
+			&w.SourceLanguage, &w.TargetLanguage, &w.Difficulty, &w.CreatedAt, &w.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -178,7 +179,7 @@ func (s *SQLiteStore) FindExpression(ctx context.Context, expr, sourceLang strin
 	row := s.db.QueryRowContext(ctx,
 		`SELECT id, expression, definition, english_definition, example, english,
 			target_translation, notes, connotation, register, contrastive_notes, tags,
-			source_language, target_language, created_at, updated_at
+			source_language, target_language, difficulty, created_at, updated_at
 		FROM expressions WHERE expression = ? AND source_language = ? LIMIT 1`,
 		expr, sourceLang,
 	)
@@ -191,7 +192,7 @@ func (s *SQLiteStore) GetExpression(ctx context.Context, id int64) (*ExpressionR
 		`SELECT id, expression, definition, english_definition,
 			example, english, target_translation, notes, connotation, register,
 			contrastive_notes, tags,
-			source_language, target_language, created_at, updated_at
+			source_language, target_language, difficulty, created_at, updated_at
 		FROM expressions WHERE id = ?`,
 		id,
 	)
@@ -204,7 +205,7 @@ func (s *SQLiteStore) FindExpressions(ctx context.Context, expr, sourceLang stri
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, expression, definition, english_definition, example, english,
 			target_translation, notes, connotation, register, contrastive_notes, tags,
-			source_language, target_language, created_at, updated_at
+			source_language, target_language, difficulty, created_at, updated_at
 		FROM expressions WHERE expression = ? AND source_language = ?`,
 		expr, sourceLang,
 	)
@@ -219,7 +220,7 @@ func (s *SQLiteStore) FindExpressions(ctx context.Context, expr, sourceLang stri
 		if err := rows.Scan(
 			&e.ID, &e.Expression, &e.Definition, &e.EnglishDefinition, &e.Example, &e.English,
 			&e.TargetTranslation, &e.Notes, &e.Connotation, &e.Register, &e.ContrastiveNotes, &e.Tags,
-			&e.SourceLanguage, &e.TargetLanguage, &e.CreatedAt, &e.UpdatedAt,
+			&e.SourceLanguage, &e.TargetLanguage, &e.Difficulty, &e.CreatedAt, &e.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -339,7 +340,7 @@ func (s *SQLiteStore) ListWords(ctx context.Context, filter ListFilter) ([]WordR
 	dataQuery := `SELECT id, word, part_of_speech, article, definition, english_definition,
 		example, english, target_translation, notes, connotation, register,
 		collocations, contrastive_notes, secondary_meanings, tags,
-		source_language, target_language, created_at, updated_at
+		source_language, target_language, difficulty, created_at, updated_at
 		FROM words` + where + ` ORDER BY id DESC LIMIT ? OFFSET ?`
 	dataArgs := make([]any, len(args), len(args)+2)
 	copy(dataArgs, args)
@@ -358,7 +359,7 @@ func (s *SQLiteStore) ListWords(ctx context.Context, filter ListFilter) ([]WordR
 			&w.ID, &w.Word, &w.PartOfSpeech, &w.Article, &w.Definition, &w.EnglishDefinition,
 			&w.Example, &w.English, &w.TargetTranslation, &w.Notes, &w.Connotation, &w.Register,
 			&w.Collocations, &w.ContrastiveNotes, &w.SecondaryMeanings, &w.Tags,
-			&w.SourceLanguage, &w.TargetLanguage, &w.CreatedAt, &w.UpdatedAt,
+			&w.SourceLanguage, &w.TargetLanguage, &w.Difficulty, &w.CreatedAt, &w.UpdatedAt,
 		); err != nil {
 			return nil, 0, err
 		}
@@ -389,7 +390,7 @@ func (s *SQLiteStore) ListExpressions(ctx context.Context, filter ListFilter) ([
 	offset := (page - 1) * pageSize
 	dataQuery := `SELECT id, expression, definition, english_definition, example, english,
 		target_translation, notes, connotation, register, contrastive_notes, tags,
-		source_language, target_language, created_at, updated_at
+		source_language, target_language, difficulty, created_at, updated_at
 		FROM expressions` + where + ` ORDER BY id DESC LIMIT ? OFFSET ?`
 	dataArgs := make([]any, len(args), len(args)+2)
 	copy(dataArgs, args)
@@ -407,7 +408,7 @@ func (s *SQLiteStore) ListExpressions(ctx context.Context, filter ListFilter) ([
 		if err := rows.Scan(
 			&e.ID, &e.Expression, &e.Definition, &e.EnglishDefinition, &e.Example, &e.English,
 			&e.TargetTranslation, &e.Notes, &e.Connotation, &e.Register, &e.ContrastiveNotes, &e.Tags,
-			&e.SourceLanguage, &e.TargetLanguage, &e.CreatedAt, &e.UpdatedAt,
+			&e.SourceLanguage, &e.TargetLanguage, &e.Difficulty, &e.CreatedAt, &e.UpdatedAt,
 		); err != nil {
 			return nil, 0, err
 		}
@@ -623,7 +624,7 @@ func scanWordRow(row scanner) (*WordRow, error) {
 		&w.ID, &w.Word, &w.PartOfSpeech, &w.Article, &w.Definition, &w.EnglishDefinition,
 		&w.Example, &w.English, &w.TargetTranslation, &w.Notes, &w.Connotation, &w.Register,
 		&w.Collocations, &w.ContrastiveNotes, &w.SecondaryMeanings, &w.Tags,
-		&w.SourceLanguage, &w.TargetLanguage, &w.CreatedAt, &w.UpdatedAt,
+		&w.SourceLanguage, &w.TargetLanguage, &w.Difficulty, &w.CreatedAt, &w.UpdatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -640,7 +641,7 @@ func scanExpressionRow(row scanner) (*ExpressionRow, error) {
 	err := row.Scan(
 		&e.ID, &e.Expression, &e.Definition, &e.EnglishDefinition, &e.Example, &e.English,
 		&e.TargetTranslation, &e.Notes, &e.Connotation, &e.Register, &e.ContrastiveNotes, &e.Tags,
-		&e.SourceLanguage, &e.TargetLanguage, &e.CreatedAt, &e.UpdatedAt,
+		&e.SourceLanguage, &e.TargetLanguage, &e.Difficulty, &e.CreatedAt, &e.UpdatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -672,8 +673,26 @@ func buildWordFilter(f ListFilter) (string, []any) {
 		args = append(args, pattern, pattern, pattern, pattern)
 	}
 	if f.Tags != "" {
-		clauses = append(clauses, "(',' || tags || ',') LIKE ?")
-		args = append(args, "%,"+f.Tags+",%")
+		tagList := strings.Split(f.Tags, ",")
+		var tagClauses []string
+		for _, tag := range tagList {
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				tagClauses = append(tagClauses, "(',' || tags || ',') LIKE ?")
+				args = append(args, "%,"+tag+",%")
+			}
+		}
+		if len(tagClauses) > 0 {
+			clauses = append(clauses, "("+strings.Join(tagClauses, " OR ")+")")
+		}
+	}
+	if len(f.Difficulty) > 0 {
+		placeholders := make([]string, len(f.Difficulty))
+		for i, d := range f.Difficulty {
+			placeholders[i] = "?"
+			args = append(args, d)
+		}
+		clauses = append(clauses, "difficulty IN ("+strings.Join(placeholders, ",")+")")
 	}
 
 	if len(clauses) == 0 {
@@ -701,12 +720,88 @@ func buildExpressionFilter(f ListFilter) (string, []any) {
 		args = append(args, pattern, pattern, pattern, pattern)
 	}
 	if f.Tags != "" {
-		clauses = append(clauses, "(',' || tags || ',') LIKE ?")
-		args = append(args, "%,"+f.Tags+",%")
+		tagList := strings.Split(f.Tags, ",")
+		var tagClauses []string
+		for _, tag := range tagList {
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				tagClauses = append(tagClauses, "(',' || tags || ',') LIKE ?")
+				args = append(args, "%,"+tag+",%")
+			}
+		}
+		if len(tagClauses) > 0 {
+			clauses = append(clauses, "("+strings.Join(tagClauses, " OR ")+")")
+		}
+	}
+	if len(f.Difficulty) > 0 {
+		placeholders := make([]string, len(f.Difficulty))
+		for i, d := range f.Difficulty {
+			placeholders[i] = "?"
+			args = append(args, d)
+		}
+		clauses = append(clauses, "difficulty IN ("+strings.Join(placeholders, ",")+")")
 	}
 
 	if len(clauses) == 0 {
 		return "", nil
 	}
 	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// --- Flashcard support ---
+
+// ListDistinctTags returns all unique tags across both words and expressions tables,
+// sorted alphabetically. Returns an empty non-nil slice when no tags exist.
+func (s *SQLiteStore) ListDistinctTags(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT tags FROM words UNION ALL SELECT tags FROM expressions`,
+	)
+	if err != nil {
+		return []string{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	seen := make(map[string]bool)
+	for rows.Next() {
+		var tags string
+		if err := rows.Scan(&tags); err != nil {
+			return []string{}, err
+		}
+		for _, tag := range strings.Split(tags, ",") {
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				seen[tag] = true
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return []string{}, err
+	}
+
+	result := make([]string, 0, len(seen))
+	for tag := range seen {
+		result = append(result, tag)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+// UpdateWordDifficulty sets the difficulty rating for a word entry.
+func (s *SQLiteStore) UpdateWordDifficulty(ctx context.Context, id int64, difficulty string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE words SET difficulty = ?, updated_at = ? WHERE id = ?`,
+		difficulty, now, id,
+	)
+	return err
+}
+
+// UpdateExpressionDifficulty sets the difficulty rating for an expression entry.
+func (s *SQLiteStore) UpdateExpressionDifficulty(ctx context.Context, id int64, difficulty string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE expressions SET difficulty = ?, updated_at = ? WHERE id = ?`,
+		difficulty, now, id,
+	)
+	return err
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -71,14 +71,25 @@ type Store interface {
 
 	// RestoreFrom replaces the current database with the file at srcPath.
 	RestoreFrom(ctx context.Context, srcPath string) error
+
+	// ListDistinctTags returns all unique tags across both words and expressions tables,
+	// sorted alphabetically. Returns an empty non-nil slice when no tags exist.
+	ListDistinctTags(ctx context.Context) ([]string, error)
+
+	// UpdateWordDifficulty sets the difficulty rating for a word entry.
+	UpdateWordDifficulty(ctx context.Context, id int64, difficulty string) error
+
+	// UpdateExpressionDifficulty sets the difficulty rating for an expression entry.
+	UpdateExpressionDifficulty(ctx context.Context, id int64, difficulty string) error
 }
 
 // ListFilter holds pagination and filter parameters for list queries.
 type ListFilter struct {
 	SourceLang string
 	TargetLang string
-	Search     string // matches against word/expression, definition, english, tags
-	Tags       string // filter entries containing this tag
-	Page       int    // 1-based
-	PageSize   int    // default 50
+	Search     string   // matches against word/expression, definition, english, tags
+	Tags       string   // filter entries containing this tag
+	Difficulty []string // filter by difficulty values (e.g. ["hard", "natural"])
+	Page       int      // 1-based
+	PageSize   int      // default 50
 }

--- a/internal/web/handlers_flashcards.go
+++ b/internal/web/handlers_flashcards.go
@@ -1,0 +1,186 @@
+package web
+
+import (
+	"encoding/json"
+	"math/rand/v2"
+	"net/http"
+
+	"github.com/user/vocabgen/internal/db"
+)
+
+// rateRequest is the JSON body for PUT /api/flashcards/rate.
+type rateRequest struct {
+	Type       string `json:"type"` // "word" or "expression"
+	ID         int64  `json:"id"`
+	Difficulty string `json:"difficulty"` // "easy", "hard", "natural"
+}
+
+// difficultyPresets maps difficulty filter preset names to the actual
+// difficulty values used in the ListFilter query.
+var difficultyPresets = map[string][]string{
+	"hard_natural": {"hard", "natural"},
+	"hard":         {"hard"},
+	"all":          {},
+	"easy":         {"easy"},
+}
+
+// handleFlashcardsHTML handles GET /api/flashcards/html — returns the
+// flashcard_card partial with the filtered deck, tags, and filter state.
+func (s *Server) handleFlashcardsHTML(w http.ResponseWriter, r *http.Request) {
+	sourceLang := r.URL.Query().Get("source_lang")
+	targetLang := r.URL.Query().Get("target_lang")
+	tags := r.URL.Query().Get("tags")
+	difficultyParam := r.URL.Query().Get("difficulty")
+
+	// Default to hard_natural if not specified or unrecognized.
+	difficultyValues, ok := difficultyPresets[difficultyParam]
+	if !ok {
+		difficultyValues = difficultyPresets["hard_natural"]
+		difficultyParam = "hard_natural"
+	}
+
+	filter := db.ListFilter{
+		SourceLang: sourceLang,
+		TargetLang: targetLang,
+		Tags:       tags,
+		Difficulty: difficultyValues,
+		Page:       1,
+		PageSize:   10000,
+	}
+
+	words, _, err := s.store.ListWords(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("flashcards: list words failed", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	expressions, _, err := s.store.ListExpressions(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("flashcards: list expressions failed", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Convert to FlashcardItem slice.
+	deck := make([]db.FlashcardItem, 0, len(words)+len(expressions))
+	for _, w := range words {
+		deck = append(deck, db.FlashcardItem{
+			ID:                w.ID,
+			Type:              "word",
+			Text:              w.Word,
+			Definition:        w.Definition,
+			English:           w.English,
+			TargetTranslation: w.TargetTranslation,
+			Difficulty:        w.Difficulty,
+		})
+	}
+	for _, e := range expressions {
+		deck = append(deck, db.FlashcardItem{
+			ID:                e.ID,
+			Type:              "expression",
+			Text:              e.Expression,
+			Definition:        e.Definition,
+			English:           e.English,
+			TargetTranslation: e.TargetTranslation,
+			Difficulty:        e.Difficulty,
+		})
+	}
+
+	// Fetch distinct tags for the tag dropdown — graceful degradation on error.
+	allTags, err := s.store.ListDistinctTags(r.Context())
+	if err != nil {
+		s.logger.Error("flashcards: list distinct tags failed", "error", err)
+		allTags = []string{}
+	}
+
+	// Shuffle the deck for varied study order.
+	rand.Shuffle(len(deck), func(i, j int) {
+		deck[i], deck[j] = deck[j], deck[i]
+	})
+
+	deckJSON, _ := json.Marshal(deck)
+
+	data := map[string]any{
+		"Deck":       deck,
+		"DeckJSON":   string(deckJSON),
+		"DeckSize":   len(deck),
+		"Tags":       allTags,
+		"SourceLang": sourceLang,
+		"TargetLang": targetLang,
+		"ActiveTag":  tags,
+		"Difficulty": difficultyParam,
+	}
+
+	_ = renderPartial(w, "flashcard_card", data)
+}
+
+// handleFlashcardsRate handles PUT /api/flashcards/rate — persists a
+// difficulty rating for a word or expression entry.
+func (s *Server) handleFlashcardsRate(w http.ResponseWriter, r *http.Request) {
+	var req rateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Validate type.
+	if req.Type != "word" && req.Type != "expression" {
+		writeJSONError(w, http.StatusBadRequest, "invalid type: must be 'word' or 'expression'")
+		return
+	}
+
+	// Validate difficulty.
+	if req.Difficulty != "easy" && req.Difficulty != "hard" && req.Difficulty != "natural" {
+		writeJSONError(w, http.StatusBadRequest, "invalid difficulty: must be 'easy', 'hard', or 'natural'")
+		return
+	}
+
+	// Validate id.
+	if req.ID <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	ctx := r.Context()
+
+	// Check existence and update.
+	if req.Type == "word" {
+		existing, err := s.store.GetWord(ctx, req.ID)
+		if err != nil {
+			s.logger.Error("flashcards: get word failed", "id", req.ID, "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "database error")
+			return
+		}
+		if existing == nil {
+			writeJSONError(w, http.StatusNotFound, "entry not found")
+			return
+		}
+		if err := s.store.UpdateWordDifficulty(ctx, req.ID, req.Difficulty); err != nil {
+			s.logger.Error("flashcards: update word difficulty failed", "id", req.ID, "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "database error")
+			return
+		}
+	} else {
+		existing, err := s.store.GetExpression(ctx, req.ID)
+		if err != nil {
+			s.logger.Error("flashcards: get expression failed", "id", req.ID, "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "database error")
+			return
+		}
+		if existing == nil {
+			writeJSONError(w, http.StatusNotFound, "entry not found")
+			return
+		}
+		if err := s.store.UpdateExpressionDifficulty(ctx, req.ID, req.Difficulty); err != nil {
+			s.logger.Error("flashcards: update expression difficulty failed", "id", req.ID, "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "database error")
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":     "ok",
+		"difficulty": req.Difficulty,
+	})
+}

--- a/internal/web/handlers_flashcards_test.go
+++ b/internal/web/handlers_flashcards_test.go
@@ -1,0 +1,427 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/user/vocabgen/internal/config"
+	"github.com/user/vocabgen/internal/db"
+)
+
+// flashcardMockStore embeds stubStore and overrides methods needed for
+// flashcard handler tests with in-memory data and call tracking.
+type flashcardMockStore struct {
+	stubStore
+
+	words       []db.WordRow
+	expressions []db.ExpressionRow
+	tags        []string
+
+	// Track the last ListFilter passed to ListWords/ListExpressions.
+	lastWordFilter       db.ListFilter
+	lastExpressionFilter db.ListFilter
+
+	// Track difficulty updates.
+	updatedWordDifficulties       map[int64]string
+	updatedExpressionDifficulties map[int64]string
+}
+
+func newFlashcardMockStore() *flashcardMockStore {
+	return &flashcardMockStore{
+		updatedWordDifficulties:       make(map[int64]string),
+		updatedExpressionDifficulties: make(map[int64]string),
+	}
+}
+
+func (m *flashcardMockStore) ListWords(_ context.Context, filter db.ListFilter) ([]db.WordRow, int, error) {
+	m.lastWordFilter = filter
+	var result []db.WordRow
+	for _, w := range m.words {
+		if !matchesFilter(w.SourceLanguage, w.TargetLanguage, w.Tags, w.Difficulty, filter) {
+			continue
+		}
+		result = append(result, w)
+	}
+	return result, len(result), nil
+}
+
+func (m *flashcardMockStore) ListExpressions(_ context.Context, filter db.ListFilter) ([]db.ExpressionRow, int, error) {
+	m.lastExpressionFilter = filter
+	var result []db.ExpressionRow
+	for _, e := range m.expressions {
+		if !matchesFilter(e.SourceLanguage, e.TargetLanguage, e.Tags, e.Difficulty, filter) {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result, len(result), nil
+}
+
+func (m *flashcardMockStore) ListDistinctTags(_ context.Context) ([]string, error) {
+	return m.tags, nil
+}
+
+func (m *flashcardMockStore) GetWord(_ context.Context, id int64) (*db.WordRow, error) {
+	for _, w := range m.words {
+		if w.ID == id {
+			// Return current difficulty (may have been updated).
+			if d, ok := m.updatedWordDifficulties[id]; ok {
+				w.Difficulty = d
+			}
+			return &w, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *flashcardMockStore) GetExpression(_ context.Context, id int64) (*db.ExpressionRow, error) {
+	for _, e := range m.expressions {
+		if e.ID == id {
+			if d, ok := m.updatedExpressionDifficulties[id]; ok {
+				e.Difficulty = d
+			}
+			return &e, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *flashcardMockStore) UpdateWordDifficulty(_ context.Context, id int64, difficulty string) error {
+	m.updatedWordDifficulties[id] = difficulty
+	return nil
+}
+
+func (m *flashcardMockStore) UpdateExpressionDifficulty(_ context.Context, id int64, difficulty string) error {
+	m.updatedExpressionDifficulties[id] = difficulty
+	return nil
+}
+
+// matchesFilter checks whether a row matches the given ListFilter criteria.
+func matchesFilter(sourceLang, targetLang, tags, difficulty string, f db.ListFilter) bool {
+	if f.SourceLang != "" && sourceLang != f.SourceLang {
+		return false
+	}
+	if f.TargetLang != "" && targetLang != f.TargetLang {
+		return false
+	}
+	if f.Tags != "" && !strings.Contains(tags, f.Tags) {
+		return false
+	}
+	if len(f.Difficulty) > 0 {
+		found := false
+		for _, d := range f.Difficulty {
+			if d == difficulty {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func newFlashcardTestServer(store *flashcardMockStore) *Server {
+	cfg := config.DefaultConfig()
+	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22")
+}
+
+// TestFlashcardsPage_Returns200 verifies GET /flashcards returns 200 with HTML content type.
+//
+// Validates: Requirements 1.1
+func TestFlashcardsPage_Returns200(t *testing.T) {
+	store := newFlashcardMockStore()
+	srv := newFlashcardTestServer(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/flashcards", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "text/html; charset=utf-8" {
+		t.Fatalf("expected text/html; charset=utf-8, got %q", ct)
+	}
+}
+
+// TestFlashcardsHTML_ReturnsPartial verifies GET /api/flashcards/html returns
+// an HTML partial containing the data-deck attribute.
+//
+// Validates: Requirements 8.1
+func TestFlashcardsHTML_ReturnsPartial(t *testing.T) {
+	store := newFlashcardMockStore()
+	store.words = []db.WordRow{
+		{
+			ID:                1,
+			Word:              "huis",
+			Definition:        "een gebouw",
+			English:           "house",
+			TargetTranslation: "ház",
+			Difficulty:        "natural",
+			SourceLanguage:    "nl",
+			TargetLanguage:    "hu",
+		},
+	}
+	store.tags = []string{"chapter-1"}
+	srv := newFlashcardTestServer(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/flashcards/html", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "text/html; charset=utf-8" {
+		t.Fatalf("expected text/html; charset=utf-8, got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "data-deck") {
+		t.Fatal("expected response to contain data-deck attribute")
+	}
+}
+
+// TestFlashcardsHTML_EmptyDeck verifies the empty-state message when no entries match.
+//
+// Validates: Requirements 2.3
+func TestFlashcardsHTML_EmptyDeck(t *testing.T) {
+	store := newFlashcardMockStore()
+	// No words or expressions — empty deck.
+	srv := newFlashcardTestServer(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/flashcards/html", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "No flashcards match your filters") {
+		t.Fatal("expected empty-state message in response")
+	}
+}
+
+// TestFlashcardsRate_ValidRequest is a table-driven test for valid rate requests
+// covering word/expression × easy/hard/natural combinations.
+//
+// Validates: Requirements 10.2
+func TestFlashcardsRate_ValidRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		entryType  string
+		id         int64
+		difficulty string
+	}{
+		{"word easy", "word", 1, "easy"},
+		{"word hard", "word", 1, "hard"},
+		{"word natural", "word", 1, "natural"},
+		{"expression easy", "expression", 10, "easy"},
+		{"expression hard", "expression", 10, "hard"},
+		{"expression natural", "expression", 10, "natural"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFlashcardMockStore()
+			store.words = []db.WordRow{
+				{ID: 1, Word: "huis", Difficulty: "natural", SourceLanguage: "nl", TargetLanguage: "hu"},
+			}
+			store.expressions = []db.ExpressionRow{
+				{ID: 10, Expression: "op de hoogte", Difficulty: "natural", SourceLanguage: "nl", TargetLanguage: "hu"},
+			}
+			srv := newFlashcardTestServer(store)
+
+			body := `{"type":"` + tc.entryType + `","id":` + idToString(tc.id) + `,"difficulty":"` + tc.difficulty + `"}`
+			req := httptest.NewRequest(http.MethodPut, "/api/flashcards/rate", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+			}
+
+			var resp map[string]string
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode json: %v", err)
+			}
+			if resp["status"] != "ok" {
+				t.Fatalf("expected status ok, got %q", resp["status"])
+			}
+			if resp["difficulty"] != tc.difficulty {
+				t.Fatalf("expected difficulty %q, got %q", tc.difficulty, resp["difficulty"])
+			}
+
+			// Verify the mock recorded the update.
+			if tc.entryType == "word" {
+				if d, ok := store.updatedWordDifficulties[tc.id]; !ok || d != tc.difficulty {
+					t.Fatalf("expected word %d difficulty %q, got %q (ok=%v)", tc.id, tc.difficulty, d, ok)
+				}
+			} else {
+				if d, ok := store.updatedExpressionDifficulties[tc.id]; !ok || d != tc.difficulty {
+					t.Fatalf("expected expression %d difficulty %q, got %q (ok=%v)", tc.id, tc.difficulty, d, ok)
+				}
+			}
+		})
+	}
+}
+
+// idToString converts an int64 to its string representation for JSON building.
+func idToString(id int64) string {
+	return fmt.Sprintf("%d", id)
+}
+
+// TestFlashcardsRate_InvalidType is a table-driven test for invalid type values returning 400.
+//
+// Validates: Requirements 10.3
+func TestFlashcardsRate_InvalidType(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryType string
+	}{
+		{"empty type", ""},
+		{"unknown type", "phrase"},
+		{"numeric type", "123"},
+		{"capitalized", "Word"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFlashcardMockStore()
+			srv := newFlashcardTestServer(store)
+
+			body := `{"type":"` + tc.entryType + `","id":1,"difficulty":"easy"}`
+			req := httptest.NewRequest(http.MethodPut, "/api/flashcards/rate", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d; body: %s", w.Code, w.Body.String())
+			}
+
+			var resp map[string]string
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode json: %v", err)
+			}
+			if !strings.Contains(resp["detail"], "invalid type") {
+				t.Fatalf("expected error about invalid type, got %q", resp["detail"])
+			}
+		})
+	}
+}
+
+// TestFlashcardsRate_InvalidDifficulty is a table-driven test for invalid difficulty values returning 400.
+//
+// Validates: Requirements 10.3
+func TestFlashcardsRate_InvalidDifficulty(t *testing.T) {
+	tests := []struct {
+		name       string
+		difficulty string
+	}{
+		{"empty difficulty", ""},
+		{"unknown difficulty", "medium"},
+		{"numeric difficulty", "5"},
+		{"capitalized", "Easy"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFlashcardMockStore()
+			srv := newFlashcardTestServer(store)
+
+			body := `{"type":"word","id":1,"difficulty":"` + tc.difficulty + `"}`
+			req := httptest.NewRequest(http.MethodPut, "/api/flashcards/rate", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d; body: %s", w.Code, w.Body.String())
+			}
+
+			var resp map[string]string
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode json: %v", err)
+			}
+			if !strings.Contains(resp["detail"], "invalid difficulty") {
+				t.Fatalf("expected error about invalid difficulty, got %q", resp["detail"])
+			}
+		})
+	}
+}
+
+// TestFlashcardsRate_DefaultDifficultyFilter verifies that when no difficulty
+// query param is provided, the handler uses the hard_natural preset which
+// excludes entries with difficulty "easy".
+//
+// Validates: Requirements 11.2
+func TestFlashcardsRate_DefaultDifficultyFilter(t *testing.T) {
+	store := newFlashcardMockStore()
+	store.words = []db.WordRow{
+		{ID: 1, Word: "huis", Difficulty: "natural", SourceLanguage: "nl", TargetLanguage: "hu"},
+		{ID: 2, Word: "boek", Difficulty: "hard", SourceLanguage: "nl", TargetLanguage: "hu"},
+		{ID: 3, Word: "kat", Difficulty: "easy", SourceLanguage: "nl", TargetLanguage: "hu"},
+	}
+	store.expressions = []db.ExpressionRow{
+		{ID: 10, Expression: "op de hoogte", Difficulty: "easy", SourceLanguage: "nl", TargetLanguage: "hu"},
+	}
+	srv := newFlashcardTestServer(store)
+
+	// No difficulty param — should default to hard_natural.
+	req := httptest.NewRequest(http.MethodGet, "/api/flashcards/html", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+
+	// The response should contain "huis" (natural) and "boek" (hard) but NOT "kat" (easy)
+	// and NOT "op de hoogte" (easy). We check the data-deck JSON.
+	deckStart := strings.Index(body, `data-deck="`)
+	if deckStart == -1 {
+		t.Fatal("expected data-deck attribute in response")
+	}
+	deckStart += len(`data-deck="`)
+	deckEnd := strings.Index(body[deckStart:], `"`)
+	if deckEnd == -1 {
+		t.Fatal("expected closing quote for data-deck attribute")
+	}
+	deckJSON := body[deckStart : deckStart+deckEnd]
+	// HTML-decode the JSON (template escapes < > & " etc.)
+	deckJSON = strings.ReplaceAll(deckJSON, "&amp;", "&")
+	deckJSON = strings.ReplaceAll(deckJSON, "&lt;", "<")
+	deckJSON = strings.ReplaceAll(deckJSON, "&gt;", ">")
+	deckJSON = strings.ReplaceAll(deckJSON, "&#34;", `"`)
+	deckJSON = strings.ReplaceAll(deckJSON, "&quot;", `"`)
+
+	var deck []db.FlashcardItem
+	if err := json.Unmarshal([]byte(deckJSON), &deck); err != nil {
+		t.Fatalf("decode deck JSON: %v; raw: %s", err, deckJSON)
+	}
+
+	// Should have 2 items: huis (natural) and boek (hard).
+	if len(deck) != 2 {
+		t.Fatalf("expected 2 items in deck (hard+natural), got %d: %+v", len(deck), deck)
+	}
+
+	for _, item := range deck {
+		if item.Difficulty == "easy" {
+			t.Fatalf("deck should not contain easy items, but found: %+v", item)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -103,6 +103,11 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /docs/{slug}", s.handleDocsPage)
 	s.mux.HandleFunc("GET /update", s.handleUpdatePage)
 	s.mux.HandleFunc("GET /changelog", s.handleChangelog)
+	s.mux.HandleFunc("GET /flashcards", s.handlePage("flashcards"))
+
+	// Flashcards API
+	s.mux.HandleFunc("GET /api/flashcards/html", s.handleFlashcardsHTML)
+	s.mux.HandleFunc("PUT /api/flashcards/rate", s.handleFlashcardsRate)
 
 	// Update API
 	s.mux.HandleFunc("GET /api/update/check", s.handleUpdateCheck)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -81,6 +81,15 @@ func (s *stubStore) BackupTo(ctx context.Context, destPath string) error { retur
 func (s *stubStore) RestoreFrom(ctx context.Context, srcPath string) error {
 	return nil
 }
+func (s *stubStore) ListDistinctTags(ctx context.Context) ([]string, error) {
+	return []string{}, nil
+}
+func (s *stubStore) UpdateWordDifficulty(ctx context.Context, id int64, difficulty string) error {
+	return nil
+}
+func (s *stubStore) UpdateExpressionDifficulty(ctx context.Context, id int64, difficulty string) error {
+	return nil
+}
 
 func newTestServer() *Server {
 	cfg := config.DefaultConfig()

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -31,7 +31,7 @@ func init() {
 	templates = make(map[string]*template.Template)
 
 	// Parse page templates — each page combines base.html + profile_switcher partial + its own template.
-	pages := []string{"lookup", "batch", "config", "database", "about", "docs", "update", "changelog"}
+	pages := []string{"lookup", "batch", "config", "database", "flashcards", "about", "docs", "update", "changelog"}
 	for _, page := range pages {
 		t, err := template.New("").Funcs(funcMap).ParseFS(templateFS,
 			"templates/base.html",
@@ -61,7 +61,7 @@ func init() {
 	partials := []string{
 		"lookup_result", "lookup_conflict", "batch_summary",
 		"entry_edit", "entry_table", "update_result",
-		"setup_local_llm", "profile_switcher",
+		"setup_local_llm", "profile_switcher", "flashcard_card",
 	}
 	for _, partial := range partials {
 		t, err := template.ParseFS(templateFS,

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -22,6 +22,8 @@
         hover:text-blue-600{{end}}">Config</a>
       <a href="/database" class="{{if eq .ActivePage " database"}}text-blue-600 font-medium{{else}}text-gray-600
         hover:text-blue-600{{end}}">Database</a>
+      <a href="/flashcards" class="{{if eq .ActivePage " flashcards"}}text-blue-600 font-medium{{else}}text-gray-600
+        hover:text-blue-600{{end}}">Flashcards</a>
       <div class="flex-1"></div>
       {{template "profile_switcher" .}}
       <div class="relative" id="help-menu">

--- a/internal/web/templates/flashcards.html
+++ b/internal/web/templates/flashcards.html
@@ -1,0 +1,406 @@
+{{define "title"}}Flashcards{{end}}
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">Flashcards</h1>
+
+<!-- Filter Controls -->
+<div id="fc-filters" class="flex flex-wrap gap-4 items-end mb-6">
+    <div>
+        <label for="fc-source-lang" class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
+        <select id="fc-source-lang" name="source_lang"
+            class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            hx-get="/api/flashcards/html" hx-target="#flashcard-area" hx-swap="innerHTML" hx-include="#fc-filters">
+            <option value="">All</option>
+            {{range .Languages}}
+            <option value="{{.Code}}">{{.Name}}</option>
+            {{end}}
+        </select>
+    </div>
+    <div>
+        <label for="fc-target-lang" class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
+        <select id="fc-target-lang" name="target_lang"
+            class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            hx-get="/api/flashcards/html" hx-target="#flashcard-area" hx-swap="innerHTML" hx-include="#fc-filters">
+            <option value="">All</option>
+            {{range .Languages}}
+            <option value="{{.Code}}">{{.Name}}</option>
+            {{end}}
+        </select>
+    </div>
+    <div class="relative">
+        <label class="block text-sm font-medium text-gray-700 mb-1">Tags</label>
+        <input type="hidden" id="fc-tags" name="tags" value="">
+        <button type="button" id="fc-tags-btn"
+            class="border border-gray-300 rounded px-3 py-2 bg-white text-left min-w-[120px] focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700">
+            All
+        </button>
+        <div id="fc-tags-dropdown"
+            class="hidden absolute z-10 mt-1 bg-white border border-gray-300 rounded shadow-lg max-h-48 overflow-y-auto min-w-[160px]">
+            <label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">
+                <input type="checkbox" value="" class="fc-tag-cb mr-2" checked> All
+            </label>
+        </div>
+    </div>
+    <div>
+        <label for="fc-difficulty" class="block text-sm font-medium text-gray-700 mb-1">Difficulty</label>
+        <select id="fc-difficulty" name="difficulty"
+            class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            hx-get="/api/flashcards/html" hx-target="#flashcard-area" hx-swap="innerHTML" hx-include="#fc-filters">
+            <option value="hard_natural" selected>Hard + Natural</option>
+            <option value="hard">Hard only</option>
+            <option value="all">All</option>
+            <option value="easy">Easy only</option>
+        </select>
+    </div>
+    <div>
+        <label for="fc-display-mode" class="block text-sm font-medium text-gray-700 mb-1">Display Mode</label>
+        <select id="fc-display-mode"
+            class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="word_first" selected>Word first</option>
+            <option value="detail_first">Detail first</option>
+        </select>
+    </div>
+</div>
+
+<!-- Card Area (swapped by HTMX) -->
+<div id="flashcard-area" hx-get="/api/flashcards/html" hx-trigger="load, filterChange" hx-swap="innerHTML"
+    hx-include="#fc-filters">
+    <p class="text-gray-500">Loading flashcards…</p>
+</div>
+
+<!-- Navigation Controls -->
+<div class="flex items-center justify-center gap-6 mt-6">
+    <button id="fc-prev" type="button"
+        class="px-5 py-2 rounded bg-gray-200 text-gray-700 hover:bg-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
+        disabled>
+        ← Prev
+    </button>
+    <span id="fc-status" class="text-sm text-gray-600 font-medium min-w-[60px] text-center">0 / 0</span>
+    <button id="fc-next" type="button"
+        class="px-5 py-2 rounded bg-gray-200 text-gray-700 hover:bg-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
+        disabled>
+        Next →
+    </button>
+</div>
+
+<!-- Difficulty Rating Buttons -->
+<div id="fc-rating" class="flex items-center justify-center gap-3 mt-4">
+    <span class="text-sm text-gray-500 mr-1">Rate:</span>
+    <button type="button" data-difficulty="easy"
+        class="fc-rate-btn px-4 py-1.5 rounded text-sm border border-green-300 text-green-700 hover:bg-green-50">
+        Easy
+    </button>
+    <button type="button" data-difficulty="natural"
+        class="fc-rate-btn px-4 py-1.5 rounded text-sm border border-gray-300 text-gray-700 hover:bg-gray-50">
+        Natural
+    </button>
+    <button type="button" data-difficulty="hard"
+        class="fc-rate-btn px-4 py-1.5 rounded text-sm border border-red-300 text-red-700 hover:bg-red-50">
+        Hard
+    </button>
+</div>
+
+<!-- Flashcard Flip Styles -->
+<style>
+    .fc-scene {
+        perspective: 800px;
+    }
+
+    .fc-card {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        transition: transform 0.5s ease;
+        transform-style: preserve-3d;
+        cursor: pointer;
+    }
+
+    .fc-card.is-flipped {
+        transform: rotateY(180deg);
+    }
+
+    .fc-face {
+        position: absolute;
+        inset: 0;
+        backface-visibility: hidden;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        border-radius: 0.75rem;
+        overflow-y: auto;
+    }
+
+    .fc-face--back {
+        transform: rotateY(180deg);
+    }
+</style>
+
+<script>
+    (function () {
+        var deck = [];
+        var currentIndex = 0;
+
+        var cardArea = document.getElementById('flashcard-area');
+        var prevBtn = document.getElementById('fc-prev');
+        var nextBtn = document.getElementById('fc-next');
+        var statusEl = document.getElementById('fc-status');
+        var displayModeEl = document.getElementById('fc-display-mode');
+        var ratingBtns = document.querySelectorAll('.fc-rate-btn');
+
+        // After HTMX swaps the card area, read the deck JSON and initialize.
+        document.body.addEventListener('htmx:afterSwap', function (evt) {
+            if (evt.detail.target !== cardArea) return;
+            populateTagDropdown();
+            initDeck();
+        });
+
+        function populateTagDropdown() {
+            var tagsEl = document.getElementById('fc-tags-data');
+            var dropdown = document.getElementById('fc-tags-dropdown');
+            var hiddenInput = document.getElementById('fc-tags');
+            if (!tagsEl || !dropdown) return;
+
+            var raw = tagsEl.getAttribute('data-tags') || '';
+            var tags = raw ? raw.split(',') : [];
+            var currentValues = hiddenInput ? hiddenInput.value.split(',').filter(Boolean) : [];
+
+            // Rebuild dropdown: "All" checkbox + each tag.
+            var html = '<label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">'
+                + '<input type="checkbox" value="" class="fc-tag-cb mr-2"' + (currentValues.length === 0 ? ' checked' : '') + '> All</label>';
+            for (var i = 0; i < tags.length; i++) {
+                var checked = currentValues.indexOf(tags[i]) !== -1 ? ' checked' : '';
+                html += '<label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">'
+                    + '<input type="checkbox" value="' + escapeHtml(tags[i]) + '" class="fc-tag-cb mr-2"' + checked + '> '
+                    + escapeHtml(tags[i]) + '</label>';
+            }
+            dropdown.innerHTML = html;
+            updateTagButtonLabel();
+        }
+
+        function updateTagButtonLabel() {
+            var btn = document.getElementById('fc-tags-btn');
+            var hiddenInput = document.getElementById('fc-tags');
+            if (!btn || !hiddenInput) return;
+            var val = hiddenInput.value;
+            if (!val) {
+                btn.textContent = 'All';
+            } else {
+                var tags = val.split(',');
+                btn.textContent = tags.length === 1 ? tags[0] : tags.length + ' tags';
+            }
+        }
+
+        // Toggle tag dropdown visibility.
+        var tagBtn = document.getElementById('fc-tags-btn');
+        var tagDropdown = document.getElementById('fc-tags-dropdown');
+        if (tagBtn && tagDropdown) {
+            tagBtn.addEventListener('click', function (e) {
+                e.stopPropagation();
+                tagDropdown.classList.toggle('hidden');
+            });
+            document.addEventListener('click', function (e) {
+                if (!tagDropdown.contains(e.target) && e.target !== tagBtn) {
+                    tagDropdown.classList.add('hidden');
+                }
+            });
+            tagDropdown.addEventListener('change', function (e) {
+                var cb = e.target;
+                if (!cb.classList.contains('fc-tag-cb')) return;
+
+                var allCbs = tagDropdown.querySelectorAll('.fc-tag-cb');
+                var hiddenInput = document.getElementById('fc-tags');
+
+                if (cb.value === '') {
+                    // "All" was toggled — uncheck others.
+                    for (var i = 0; i < allCbs.length; i++) {
+                        allCbs[i].checked = (allCbs[i].value === '');
+                    }
+                    hiddenInput.value = '';
+                } else {
+                    // Uncheck "All" when a specific tag is selected.
+                    allCbs[0].checked = false;
+                    // Collect selected tags.
+                    var selected = [];
+                    for (var i = 0; i < allCbs.length; i++) {
+                        if (allCbs[i].checked && allCbs[i].value !== '') {
+                            selected.push(allCbs[i].value);
+                        }
+                    }
+                    if (selected.length === 0) {
+                        // Nothing selected — revert to All.
+                        allCbs[0].checked = true;
+                        hiddenInput.value = '';
+                    } else {
+                        hiddenInput.value = selected.join(',');
+                    }
+                }
+                updateTagButtonLabel();
+                // Trigger HTMX request to reload deck.
+                htmx.trigger(cardArea, 'filterChange');
+            });
+        }
+
+        function initDeck() {
+            var dataEl = document.getElementById('fc-deck-data');
+            if (dataEl) {
+                try {
+                    deck = JSON.parse(dataEl.getAttribute('data-deck') || '[]');
+                } catch (e) {
+                    deck = [];
+                }
+            } else {
+                deck = [];
+            }
+            currentIndex = 0;
+            renderCard();
+            updateStatus();
+            updateNav();
+            updateRatingHighlight();
+        }
+
+        function renderCard() {
+            var scene = document.getElementById('fc-scene');
+            if (!scene) return;
+            var card = scene.querySelector('.fc-card');
+            if (!card) return;
+
+            // Reset flip state.
+            card.classList.remove('is-flipped');
+
+            if (deck.length === 0) return;
+
+            var item = deck[currentIndex];
+            var mode = displayModeEl ? displayModeEl.value : 'word_first';
+
+            var frontEl = card.querySelector('.fc-face--front');
+            var backEl = card.querySelector('.fc-face--back');
+            if (!frontEl || !backEl) return;
+
+            var wordContent = '<div class="text-3xl font-bold text-gray-800 text-center">' + escapeHtml(item.text) + '</div>';
+
+            var detailContent = '<div class="space-y-3 text-center">'
+                + '<div class="text-lg text-gray-700"><span class="text-sm text-gray-400 block mb-1">Definition</span>' + escapeHtml(item.definition) + '</div>'
+                + '<div class="text-lg text-gray-700"><span class="text-sm text-gray-400 block mb-1">English</span>' + escapeHtml(item.english) + '</div>'
+                + '<div class="text-lg text-gray-700"><span class="text-sm text-gray-400 block mb-1">Translation</span>' + escapeHtml(item.target_translation) + '</div>'
+                + '</div>';
+
+            if (mode === 'word_first') {
+                frontEl.innerHTML = wordContent;
+                backEl.innerHTML = detailContent;
+            } else {
+                frontEl.innerHTML = detailContent;
+                backEl.innerHTML = wordContent;
+            }
+
+            updateRatingHighlight();
+        }
+
+        function updateStatus() {
+            if (!statusEl) return;
+            if (deck.length === 0) {
+                statusEl.textContent = '0 / 0';
+            } else {
+                statusEl.textContent = (currentIndex + 1) + ' / ' + deck.length;
+            }
+        }
+
+        function updateNav() {
+            if (prevBtn) prevBtn.disabled = (deck.length === 0 || currentIndex <= 0);
+            if (nextBtn) nextBtn.disabled = (deck.length === 0 || currentIndex >= deck.length - 1);
+        }
+
+        function updateRatingHighlight() {
+            if (deck.length === 0) return;
+            var item = deck[currentIndex];
+            for (var i = 0; i < ratingBtns.length; i++) {
+                var btn = ratingBtns[i];
+                var diff = btn.getAttribute('data-difficulty');
+                // Reset all buttons.
+                btn.classList.remove('bg-green-100', 'bg-gray-100', 'bg-red-100', 'ring-2', 'ring-green-400', 'ring-gray-400', 'ring-red-400');
+                if (diff === item.difficulty) {
+                    if (diff === 'easy') {
+                        btn.classList.add('bg-green-100', 'ring-2', 'ring-green-400');
+                    } else if (diff === 'hard') {
+                        btn.classList.add('bg-red-100', 'ring-2', 'ring-red-400');
+                    } else {
+                        btn.classList.add('bg-gray-100', 'ring-2', 'ring-gray-400');
+                    }
+                }
+            }
+        }
+
+        // Card flip on click.
+        cardArea.addEventListener('click', function (evt) {
+            var scene = document.getElementById('fc-scene');
+            if (!scene) return;
+            // Only flip if clicking inside the scene.
+            if (!scene.contains(evt.target)) return;
+            var card = scene.querySelector('.fc-card');
+            if (card) card.classList.toggle('is-flipped');
+        });
+
+        // Prev button.
+        if (prevBtn) {
+            prevBtn.addEventListener('click', function () {
+                if (currentIndex > 0) {
+                    currentIndex--;
+                    renderCard();
+                    updateStatus();
+                    updateNav();
+                }
+            });
+        }
+
+        // Next button.
+        if (nextBtn) {
+            nextBtn.addEventListener('click', function () {
+                if (currentIndex < deck.length - 1) {
+                    currentIndex++;
+                    renderCard();
+                    updateStatus();
+                    updateNav();
+                }
+            });
+        }
+
+        // Display mode toggle.
+        if (displayModeEl) {
+            displayModeEl.addEventListener('change', function () {
+                renderCard();
+            });
+        }
+
+        // Difficulty rating buttons.
+        for (var i = 0; i < ratingBtns.length; i++) {
+            ratingBtns[i].addEventListener('click', function () {
+                if (deck.length === 0) return;
+                var item = deck[currentIndex];
+                var difficulty = this.getAttribute('data-difficulty');
+
+                fetch('/api/flashcards/rate', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ type: item.type, id: item.id, difficulty: difficulty })
+                }).then(function (resp) {
+                    if (!resp.ok) throw new Error('Rate failed: ' + resp.status);
+                    return resp.json();
+                }).then(function (data) {
+                    // Update local deck data.
+                    deck[currentIndex].difficulty = data.difficulty;
+                    updateRatingHighlight();
+                }).catch(function (err) {
+                    console.error('Failed to rate card:', err);
+                });
+            });
+        }
+
+        function escapeHtml(str) {
+            if (!str) return '';
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(str));
+            return div.innerHTML;
+        }
+    })();
+</script>
+{{end}}

--- a/internal/web/templates/partials/flashcard_card.html
+++ b/internal/web/templates/partials/flashcard_card.html
@@ -1,0 +1,25 @@
+{{define "flashcard_card"}}
+<!-- Hidden deck data for JS -->
+<div id="fc-deck-data" data-deck="{{.DeckJSON}}" class="hidden"></div>
+<!-- Hidden tags data for populating the tag dropdown -->
+<div id="fc-tags-data" data-tags="{{range $i, $t := .Tags}}{{if $i}},{{end}}{{$t}}{{end}}" class="hidden"></div>
+
+{{if eq .DeckSize 0}}
+<!-- Empty state -->
+<div
+    class="flex items-center justify-center min-h-[300px] border-2 border-dashed border-gray-300 rounded-xl bg-gray-50">
+    <div class="text-center px-6 py-8">
+        <p class="text-gray-500 text-lg">No flashcards match your filters.</p>
+        <p class="text-gray-400 text-sm mt-2">Try adjusting your filters or add vocabulary via Lookup or Batch.</p>
+    </div>
+</div>
+{{else}}
+<!-- Card scene -->
+<div id="fc-scene" class="fc-scene mx-auto" style="min-height:300px; max-width:600px;">
+    <div class="fc-card bg-white border border-gray-200 rounded-xl shadow-md" style="min-height:300px;">
+        <div class="fc-face fc-face--front bg-white rounded-xl"></div>
+        <div class="fc-face fc-face--back bg-gray-50 rounded-xl"></div>
+    </div>
+</div>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary

Add a Flashcards study mode to the VocabGen web UI. Users can flip through vocabulary cards, filter by language/tag/difficulty, rate cards as easy/hard/natural, and toggle between "Word first" and "Detail first" display modes. The deck combines both words and expressions from the database. A V2 schema migration adds a `difficulty` column to both tables.

## Related Issue

Fixes #39

## Changes

- Add V2 schema migration (`difficulty` column on words and expressions tables)
- Add `FlashcardItem` model, `ListDistinctTags`, `UpdateWordDifficulty`, `UpdateExpressionDifficulty` store methods
- Add difficulty filter to `ListFilter` and filter builders
- Add flashcards handler (`GET /flashcards`, `GET /api/flashcards/html`, `PUT /api/flashcards/rate`)
- Add flashcards page template with inline JS for flip, navigation, mode toggle, and rating
- Add flashcard_card partial template for HTMX swaps
- Add "Flashcards" link to navigation bar
- Add property-based tests (P13–P17) and table-driven handler tests
- Update user guide, architecture docs, CHANGELOG, and README

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
