### PR TITLE
ci: add rebase-strategy auto to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: auto
     commit-message:
       prefix: "deps"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: auto
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
Adds `rebase-strategy: auto` to both gomod and github-actions ecosystems so Dependabot automatically rebases open PRs when they fall behind main.