### PR TITLE
docs: highlight provider quality guidance in README, user guide, and marketing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ This app calls LLM APIs to generate vocabulary data. It does not include a built
 
 A free ChatGPT, Claude, or Gemini account does not provide API access. You need a separate API key from the provider's developer platform, which requires a payment method on file.
 
-The cheapest way to get started is Ollama — install it, pull a model (`ollama pull translategemma`), and point vocabgen at it with `--provider openai --base-url http://localhost:11434/v1`.
-
-For best translation quality, use a large model (Claude Sonnet/Opus, GPT-4o). Local models like Llama 3 work but produce noticeably lower quality for nuanced vocabulary tasks — especially for less common languages, connotation/register distinctions, and contrastive notes. Use `--dry-run` to preview results before committing to a provider.
+> **💡 Free to try, better with a paid model.** The cheapest way to get started is Ollama — install it, pull a model (`ollama pull translategemma`), and point vocabgen at it with `--provider openai --base-url http://localhost:11434/v1`.
+>
+> For best translation quality, use a large model (Claude Sonnet/Opus, GPT-4o). Local models like Llama 3 work but produce noticeably lower quality for nuanced vocabulary tasks — especially for less common languages, connotation/register distinctions, and contrastive notes. Use `--dry-run` to preview results before committing to a provider.
 
 ## Quick Start
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -206,6 +206,23 @@
         a {
             color: #0066cc;
         }
+
+        .quality-note {
+            background: #fff8e1;
+            border-left: 4px solid #f9a825;
+            padding: 0.75rem 1rem;
+            margin: 0.75rem 0;
+            border-radius: 0 6px 6px 0;
+            font-size: 0.92rem;
+            line-height: 1.5;
+        }
+
+        .quality-note code {
+            background: #f0f0f0;
+            padding: 0.1rem 0.3rem;
+            border-radius: 3px;
+            font-size: 0.85rem;
+        }
     </style>
 </head>
 
@@ -270,6 +287,16 @@
             <div class="provider">Ollama (free)</div>
             <div class="provider">Azure OpenAI</div>
             <div class="provider">LM Studio</div>
+        </div>
+
+        <div class="quality-note">
+            <p><strong>Free to try, better with a paid model.</strong> The cheapest way to get started is
+                <a href="https://ollama.com">Ollama</a> — install it, pull a model, and you're running locally for free.
+                For the best translation quality — especially for less common languages, connotation/register
+                distinctions, and contrastive notes — use a large model like Claude Sonnet/Opus or GPT-4o.
+                Local models work but produce noticeably lower quality on nuanced vocabulary tasks.
+                Use <code>--dry-run</code> to preview results before committing to a provider.
+            </p>
         </div>
 
         <h2>Quick Start</h2>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,7 +15,7 @@ ollama pull translategemma
 vocabgen lookup "uitkomen" -l nl --provider openai --base-url http://localhost:11434/v1 --model-id translategemma
 ```
 
-Note on model quality: vocabgen's prompts are designed for large, capable models (Claude Sonnet/Opus, GPT-4o). Local models like Llama 3 will work but produce lower quality results — particularly for less common language pairs, connotation/register nuances, and contrastive notes. If translation quality matters to you, a paid API is worth it.
+> **💡 Free to try, better with a paid model.** vocabgen's prompts are designed for large, capable models (Claude Sonnet/Opus, GPT-4o). Local models like Llama 3 will work but produce lower quality results — particularly for less common language pairs, connotation/register nuances, and contrastive notes. If translation quality matters to you, a paid API is worth it.
 
 ## Installation
 


### PR DESCRIPTION
Adds highlighted callouts (blockquote in README/user-guide, amber box on marketing page) so users clearly see that paid models produce better results for nuanced vocabulary tasks.

This PR also tests the new pages.yml workflow — since it touches docs/, the GitHub Pages deploy should trigger.