### PR TITLE
ci: add OCI labels to Docker images and Docker link to marketing page

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,6 +42,15 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
+    labels:
+      "org.opencontainers.image.title": "VocabGen"
+      "org.opencontainers.image.description": "Vocabulary web app and flashcard tool for language learners"
+      "org.opencontainers.image.source": "https://github.com/npozs77/VocabGen"
+      "org.opencontainers.image.url": "https://npozs77.github.io/VocabGen/"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.licenses": "MIT"
 
 release:
   header: "{{ .TagBody }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [1.3.1]
+
+### Changed
+
+- Highlighted provider quality guidance across README, user guide, and marketing page — clearer messaging that paid models produce better results for nuanced vocabulary tasks
+- OCI labels on Docker images — GitHub Packages page now shows title, description, version, and license metadata
+- Docker packages link added to the marketing page footer
+- GitHub Pages deployment now only triggers when `docs/` changes (dedicated workflow with path filter)
+- Dependabot auto-rebases open PRs when they fall behind main
+
 ## [1.3.0]
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -333,6 +333,7 @@ vocabgen lookup "casa" -l Italian --provider openai \
         <footer>
             <p>MIT License · <a href="https://github.com/npozs77/VocabGen">GitHub</a> · <a
                     href="https://github.com/npozs77/VocabGen/releases">Releases</a> · <a
+                    href="https://github.com/npozs77/VocabGen/pkgs/container/vocabgen">Docker</a> · <a
                     href="https://github.com/npozs77/VocabGen/issues">Issues</a></p>
         </footer>
     </div>


### PR DESCRIPTION
- Adds OCI labels (title, description, source, version, license, etc.) to goreleaser dockers_v2 config so the GitHub Packages page shows useful metadata instead of bare digests
- Adds Docker packages link to the marketing page footer

Note: v1.3.0 multi-arch manifest is working correctly — the untagged SHAs are the per-platform images behind the manifest (normal OCI behavior). The OCI labels will take effect on the next release.