### PR TITLE
feat: dev workflow, Docker defaults, unified tag picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 /vocabgen
+bin/
 
 # Test binary
 *.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 
 ## [1.3.1]
 
+### Added
+
+- `make dev` and `make dev-serve` targets for a faster build-and-run development workflow (#71)
+
 ### Changed
 
 - Highlighted provider quality guidance across README, user guide, and marketing page — clearer messaging that paid models produce better results for nuanced vocabulary tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [1.4.1]
+
+### Added
+
+- `make dev` and `make dev-serve` targets for a faster build-and-run development workflow (#71)
+
+### Fixed
+
+- Docker image now defaults to `/data/vocabgen.db` instead of `~/.vocabgen/vocabgen.db` — simple `-v ./data:/data` mount works out of the box without `chown` or UID mapping (#73)
+
 ## [1.4.0]
 
 ### Added
@@ -11,10 +21,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 - Sentence lookup mode — analyze full sentences for grammar errors, corrections, translations, and key vocabulary (#26)
 
 ## [1.3.1]
-
-### Added
-
-- `make dev` and `make dev-serve` targets for a faster build-and-run development workflow (#71)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 ### Added
 
 - `make dev` and `make dev-serve` targets for a faster build-and-run development workflow (#71)
+- Unified tag picker across Database, Lookup, and Batch pages — select existing tags from a dropdown instead of typing from memory; Lookup and Batch also support free-text entry for new tags (#74)
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM gcr.io/distroless/static:nonroot
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/vocabgen /vocabgen
 
-# Data directory for config.yaml and vocabgen.db
-VOLUME /home/nonroot/.vocabgen
+# Data directory for config.yaml and vocabgen.db — container-friendly mount point.
+# Users mount a host directory here: docker run -v ./data:/data ...
+VOLUME /data
 ENV HOME=/home/nonroot
 
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
-.PHONY: build test lint vet fmt-check clean coverage quality e2e
+.PHONY: build dev dev-serve test lint vet fmt-check clean coverage quality e2e
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -X main.version=$(VERSION) -X main.buildDate=$(BUILD_DATE)
 
+# Production build — outputs to ./vocabgen (used by CI and release pipeline)
 build:
 	cp CHANGELOG.md docs/changelog.md
 	go build -ldflags "$(LDFLAGS)" -o vocabgen ./cmd/vocabgen
+
+# Dev build — outputs to bin/vocabgen (use on feature branches)
+dev:
+	cp CHANGELOG.md docs/changelog.md
+	go build -ldflags "$(LDFLAGS)" -o bin/vocabgen ./cmd/vocabgen
+
+# Dev build + launch web server on port 8081 (keeps stable on 8080)
+dev-serve: dev
+	bin/vocabgen serve --port 8081
 
 test:
 	go test -race ./...
@@ -26,11 +36,13 @@ vet:
 	go vet ./...
 
 fmt-check:
-	@test -z "$$(gofmt -l .)" || { echo "Files not formatted:"; gofmt -l .; exit 1; }
+	@test -z "$(gofmt -l .)" || { echo "Files not formatted:"; gofmt -l .; exit 1; }
 
 clean:
 	rm -f vocabgen coverage.out coverage.html
+	rm -rf bin/
 
+# Full quality gate — build, vet, format, lint, tests + coverage
 quality:
 	@echo "=== Build ==="
 	cp CHANGELOG.md docs/changelog.md
@@ -52,5 +64,6 @@ quality:
 	@echo "=== Coverage Summary ==="
 	@go tool cover -func=coverage.out | tail -1
 
+# End-to-end tests (requires E2E_PROFILE env var)
 e2e:
 	@E2E_PROFILE=$(E2E_PROFILE) ./scripts/e2e-test.sh

--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ Documentation is also available in the web UI via Help → Documentation when ru
 ```bash
 docker run -d \
   -p 8080:8080 \
-  -v ~/.vocabgen:/home/nonroot/.vocabgen \
+  -v ./data:/data \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   ghcr.io/npozs77/vocabgen:latest
 ```
 
-The volume mount persists config and database across restarts. Pass API keys via `-e`. All CLI commands work: `docker run ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl`.
+The container auto-detects Docker and defaults to `/data/vocabgen.db` — just mount a host directory to `/data`. Pass API keys via `-e`. All CLI commands work: `docker run ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl`.
 
 ## Build from Source
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -242,10 +242,12 @@ Multi-arch Docker images (amd64/arm64) are published to GitHub Container Registr
 ```bash
 docker run -d \
   -p 8080:8080 \
-  -v ~/.vocabgen:/home/nonroot/.vocabgen \
+  -v ./data:/data \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   ghcr.io/npozs77/vocabgen:latest
 ```
+
+Inside the container, vocabgen automatically detects the Docker environment and defaults to `/data/vocabgen.db` for the database (instead of `~/.vocabgen/vocabgen.db`). A simple `-v ./data:/data` mount is all you need — no `chown` or UID mapping required.
 
 ### Image Tags
 
@@ -256,14 +258,20 @@ docker run -d \
 
 ### Volume Mount
 
-Mount `/home/nonroot/.vocabgen` to persist `config.yaml` and `vocabgen.db` across container restarts.
+Mount `/data` to persist `config.yaml` and `vocabgen.db` across container restarts:
+
+```bash
+-v ./data:/data
+```
+
+The container runs as a non-root user (UID 65532). The `/data` directory is writable by this user out of the box.
 
 ### CLI Commands via Docker
 
 ```bash
 docker run ghcr.io/npozs77/vocabgen:latest version
-docker run ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl --provider openai -e OPENAI_API_KEY=...
-docker run -v ~/.vocabgen:/home/nonroot/.vocabgen ghcr.io/npozs77/vocabgen:latest batch --input-file /data/words.csv --mode words -l nl
+docker run -e OPENAI_API_KEY=sk-... ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl --provider openai
+docker run -v ./data:/data ghcr.io/npozs77/vocabgen:latest batch --input-file /data/words.csv --mode words -l nl
 ```
 
 ### Build Locally
@@ -273,5 +281,5 @@ The Dockerfile expects a pre-built `vocabgen` binary in the build context (gorel
 ```bash
 CGO_ENABLED=0 GOOS=linux go build -o vocabgen ./cmd/vocabgen
 docker build -t vocabgen:local .
-docker run -p 8080:8080 vocabgen:local
+docker run -p 8080:8080 -v ./data:/data vocabgen:local
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -390,6 +390,16 @@ vocabgen batch --input-file ch2.csv --mode words -l nl --tags "chapter-2"
 
 Tags are stored as comma-separated strings. Filter by tags in the web UI database page.
 
+### Tag Picker (Web UI)
+
+All pages that use tags share a unified tag picker component:
+
+- **Database page**: A dropdown filter populated from existing tags in the database. Select one or more tags to filter the entry list — works the same way as the language and type filters. Select "All" to clear the filter.
+- **Lookup and Batch pages**: A text input with autocomplete suggestions from existing tags. Start typing to see matching tags, or click the field to see all available tags. You can also type a new tag that doesn't exist yet. Separate multiple tags with commas.
+- **Flashcards page**: A dropdown filter identical to the Database page — select tags to narrow the study deck.
+
+Tags are fetched from the `GET /api/tags` endpoint, which returns all distinct tags across words and expressions.
+
 ## Database Management
 
 ### Backup

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -51,16 +51,16 @@ Run VocabGen as a container without downloading platform-specific binaries:
 ```bash
 docker run -d \
   -p 8080:8080 \
-  -v ~/.vocabgen:/home/nonroot/.vocabgen \
+  -v ./data:/data \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   ghcr.io/npozs77/vocabgen:latest
 ```
 
-The volume mount persists config and database across restarts. Pass API keys via `-e`. All CLI commands work via Docker:
+Inside the container, vocabgen automatically defaults to `/data/vocabgen.db` — just mount a host directory to `/data` and you're set. No `chown` or UID mapping needed. Pass API keys via `-e`. All CLI commands work via Docker:
 
 ```bash
 docker run ghcr.io/npozs77/vocabgen:latest version
-docker run ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl --provider openai
+docker run -e OPENAI_API_KEY=sk-... ghcr.io/npozs77/vocabgen:latest lookup "werk" -l nl --provider openai
 ```
 
 See [Deployment — Docker](deployment.md#docker) for image tags and detailed usage.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,23 @@ type Config struct {
 	DBPath                string `yaml:"db_path"`
 }
 
+// isDocker reports whether the process is running inside a Docker container.
+// It checks for the /.dockerenv marker file that Docker creates automatically.
+var isDocker = func() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
+}
+
+// DefaultDBPath returns the default database path. Inside a Docker container
+// it returns "/data/vocabgen.db" (a standard mount point); otherwise it
+// returns "~/.vocabgen/vocabgen.db" (the user's home directory).
+func DefaultDBPath() string {
+	if isDocker() {
+		return "/data/vocabgen.db"
+	}
+	return "~/.vocabgen/vocabgen.db"
+}
+
 // DefaultConfig returns the default configuration.
 func DefaultConfig() Config {
 	return Config{
@@ -60,7 +77,7 @@ func DefaultConfig() Config {
 		AWSRegion:             "us-east-1",
 		DefaultSourceLanguage: "nl",
 		DefaultTargetLanguage: "hu",
-		DBPath:                "~/.vocabgen/vocabgen.db",
+		DBPath:                DefaultDBPath(),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -121,3 +121,62 @@ func TestSaveConfigCreatesDirectory(t *testing.T) {
 		t.Fatal("expected a file, got a directory")
 	}
 }
+
+// TestDefaultDBPath verifies that DefaultDBPath returns the correct path
+// depending on whether the process is running inside Docker or not.
+//
+// Validates: Issue #73 — Docker image uses container-friendly /data path.
+func TestDefaultDBPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		inDocker bool
+		want     string
+	}{
+		{
+			name:     "non-Docker environment returns home-dir path",
+			inDocker: false,
+			want:     "~/.vocabgen/vocabgen.db",
+		},
+		{
+			name:     "Docker environment returns /data path",
+			inDocker: true,
+			want:     "/data/vocabgen.db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origIsDocker := isDocker
+			isDocker = func() bool { return tt.inDocker }
+			t.Cleanup(func() { isDocker = origIsDocker })
+
+			got := DefaultDBPath()
+			if got != tt.want {
+				t.Fatalf("DefaultDBPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDefaultConfigUsesDefaultDBPath verifies that DefaultConfig() delegates
+// to DefaultDBPath() for the DBPath field, so Docker detection flows through.
+//
+// Validates: Issue #73 — DefaultConfig uses dynamic path detection.
+func TestDefaultConfigUsesDefaultDBPath(t *testing.T) {
+	// Simulate Docker environment
+	origIsDocker := isDocker
+	isDocker = func() bool { return true }
+	t.Cleanup(func() { isDocker = origIsDocker })
+
+	cfg := DefaultConfig()
+	if cfg.DBPath != "/data/vocabgen.db" {
+		t.Fatalf("DefaultConfig().DBPath = %q in Docker, want %q", cfg.DBPath, "/data/vocabgen.db")
+	}
+
+	// Simulate non-Docker environment
+	isDocker = func() bool { return false }
+	cfg = DefaultConfig()
+	if cfg.DBPath != "~/.vocabgen/vocabgen.db" {
+		t.Fatalf("DefaultConfig().DBPath = %q outside Docker, want %q", cfg.DBPath, "~/.vocabgen/vocabgen.db")
+	}
+}

--- a/internal/web/handlers_config.go
+++ b/internal/web/handlers_config.go
@@ -202,6 +202,7 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 
 	// Validate provider credentials are available via environment.
 	if warning := validateProviderEnv(updated.Provider, updated.BaseURL, updated.GCPProject); warning != "" {
+		s.logger.Warn("provider env validation failed", "provider", updated.Provider, "warning", warning)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = w.Write([]byte(`<p class="text-red-600 text-sm mt-1">` + warning + `</p>`))
 		return
@@ -284,12 +285,14 @@ func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
 	// Try a minimal invocation to test the connection
 	_, err = provider.Invoke(r.Context(), "Say hello in one word.", s.cfg.ModelID)
 	if err != nil {
+		s.logger.Warn("connection test failed", "provider", provider.Name(), "error", err)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = w.Write([]byte(`<div class="bg-red-50 border border-red-200 text-red-700 rounded p-3 text-sm">` +
 			"Connection failed: " + err.Error() + `</div>`))
 		return
 	}
 
+	s.logger.Info("connection test successful", "provider", provider.Name())
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = w.Write([]byte(`<div class="bg-green-50 border border-green-200 text-green-700 rounded p-3 text-sm">` +
 		"Connection successful! Provider: " + provider.Name() + `</div>`))

--- a/internal/web/handlers_db.go
+++ b/internal/web/handlers_db.go
@@ -43,6 +43,17 @@ func parseListParams(r *http.Request) (db.ListFilter, error) {
 	return filter, nil
 }
 
+// handleListTags handles GET /api/tags — returns all distinct tags as a JSON array.
+func (s *Server) handleListTags(w http.ResponseWriter, r *http.Request) {
+	tags, err := s.store.ListDistinctTags(r.Context())
+	if err != nil {
+		s.logger.Error("list tags failed", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to list tags")
+		return
+	}
+	writeJSON(w, http.StatusOK, tags)
+}
+
 // handleListWords handles GET /api/words — paginated word list.
 func (s *Server) handleListWords(w http.ResponseWriter, r *http.Request) {
 	// If type=expressions, delegate to the expressions handler.

--- a/internal/web/handlers_db_test.go
+++ b/internal/web/handlers_db_test.go
@@ -1,0 +1,93 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/user/vocabgen/internal/config"
+)
+
+// tagMockStore embeds stubStore and overrides ListDistinctTags for testing.
+type tagMockStore struct {
+	stubStore
+	tags []string
+}
+
+func (m *tagMockStore) ListDistinctTags(_ context.Context) ([]string, error) {
+	return m.tags, nil
+}
+
+func newTagTestServer(store *tagMockStore) *Server {
+	cfg := config.DefaultConfig()
+	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22")
+}
+
+func TestHandleListTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []string
+		wantLen  int
+		wantTags []string
+	}{
+		{
+			name:     "empty database returns empty array",
+			tags:     []string{},
+			wantLen:  0,
+			wantTags: []string{},
+		},
+		{
+			name:     "returns all distinct tags",
+			tags:     []string{"B2", "chapter-1", "HS2.2"},
+			wantLen:  3,
+			wantTags: []string{"B2", "chapter-1", "HS2.2"},
+		},
+		{
+			name:     "single tag",
+			tags:     []string{"exam-prep"},
+			wantLen:  1,
+			wantTags: []string{"exam-prep"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &tagMockStore{tags: tc.tags}
+			srv := newTagTestServer(store)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/tags", nil)
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+
+			ct := w.Header().Get("Content-Type")
+			if ct != "application/json; charset=utf-8" {
+				t.Fatalf("expected application/json; charset=utf-8, got %q", ct)
+			}
+
+			var got []string
+			if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+				t.Fatalf("decode json: %v", err)
+			}
+
+			if len(got) != tc.wantLen {
+				t.Fatalf("expected %d tags, got %d", tc.wantLen, len(got))
+			}
+
+			for i, want := range tc.wantTags {
+				if i >= len(got) {
+					break
+				}
+				if got[i] != want {
+					t.Errorf("tag[%d]: expected %q, got %q", i, want, got[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/web/handlers_flashcards.go
+++ b/internal/web/handlers_flashcards.go
@@ -87,13 +87,6 @@ func (s *Server) handleFlashcardsHTML(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Fetch distinct tags for the tag dropdown — graceful degradation on error.
-	allTags, err := s.store.ListDistinctTags(r.Context())
-	if err != nil {
-		s.logger.Error("flashcards: list distinct tags failed", "error", err)
-		allTags = []string{}
-	}
-
 	// Shuffle the deck for varied study order.
 	rand.Shuffle(len(deck), func(i, j int) {
 		deck[i], deck[j] = deck[j], deck[i]
@@ -105,7 +98,6 @@ func (s *Server) handleFlashcardsHTML(w http.ResponseWriter, r *http.Request) {
 		"Deck":       deck,
 		"DeckJSON":   string(deckJSON),
 		"DeckSize":   len(deck),
-		"Tags":       allTags,
 		"SourceLang": sourceLang,
 		"TargetLang": targetLang,
 		"ActiveTag":  tags,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -139,6 +139,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/profile/switcher", s.handleProfileSwitcherPartial)
 
 	// Database API
+	s.mux.HandleFunc("GET /api/tags", s.handleListTags)
 	s.mux.HandleFunc("GET /api/words", s.handleListWords)
 	s.mux.HandleFunc("GET /api/expressions", s.handleListExpressions)
 	s.mux.HandleFunc("GET /api/words/{id}/edit", s.handleEditWord)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -233,6 +233,8 @@ func TestAPIRoutesRegistered(t *testing.T) {
 		{"bulk-delete-expressions", http.MethodDelete, "/api/expressions/bulk", http.StatusBadRequest},
 		// Export with empty store → 200 (empty xlsx)
 		{"export", http.MethodGet, "/api/export", http.StatusOK},
+		// Tags endpoint
+		{"tags", http.MethodGet, "/api/tags", http.StatusOK},
 		// Config update with empty body
 		{"put-config", http.MethodPut, "/api/config", 0},
 		// Test connection with no provider configured

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -30,14 +30,24 @@ var funcMap = template.FuncMap{
 func init() {
 	templates = make(map[string]*template.Template)
 
+	// Pages that include the tag_picker partial in addition to base + profile_switcher.
+	tagPickerPages := map[string]bool{
+		"lookup": true, "batch": true, "database": true, "flashcards": true,
+	}
+
 	// Parse page templates — each page combines base.html + profile_switcher partial + its own template.
+	// Pages that use the tag picker also include the tag_picker partial.
 	pages := []string{"lookup", "batch", "config", "database", "flashcards", "about", "docs", "update", "changelog"}
 	for _, page := range pages {
-		t, err := template.New("").Funcs(funcMap).ParseFS(templateFS,
+		files := []string{
 			"templates/base.html",
 			"templates/partials/profile_switcher.html",
 			fmt.Sprintf("templates/%s.html", page),
-		)
+		}
+		if tagPickerPages[page] {
+			files = append(files, "templates/partials/tag_picker.html")
+		}
+		t, err := template.New("").Funcs(funcMap).ParseFS(templateFS, files...)
 		if err != nil {
 			panic(fmt.Sprintf("parse template %s: %v", page, err))
 		}

--- a/internal/web/templates/batch.html
+++ b/internal/web/templates/batch.html
@@ -71,12 +71,7 @@
     </div>
   </div>
 
-  <div>
-    <label for="tags" class="block text-sm font-medium text-gray-700 mb-1">Tags (optional)</label>
-    <input type="text" id="tags" name="tags"
-      class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-      placeholder="e.g. chapter-1, B2">
-  </div>
+  {{template "tag_picker_input" .}}
 
   <button type="submit" id="batch-submit"
     class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">

--- a/internal/web/templates/database.html
+++ b/internal/web/templates/database.html
@@ -3,7 +3,7 @@
 <h1 class="text-2xl font-bold mb-6">Database</h1>
 
 <div class="space-y-4">
-  <div class="flex flex-wrap gap-4 items-end">
+  <div id="db-filters" class="flex flex-wrap gap-4 items-end">
     <div>
       <label for="db-source-lang" class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
       <select id="db-source-lang" name="source_lang" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
@@ -34,13 +34,7 @@
         <option value="expressions">Expressions</option>
       </select>
     </fieldset>
-    <div>
-      <label for="db-tags" class="block text-sm font-medium text-gray-700 mb-1">Tags</label>
-      <input type="text" id="db-tags" name="tags" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
-        hx-trigger="keyup changed delay:300ms" hx-include="#db-filters"
-        class="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 w-32"
-        placeholder="e.g. HS2.2">
-    </div>
+    {{template "tag_picker_filter" .}}
     <div class="flex-1 min-w-[200px]">
       <label for="db-search" class="block text-sm font-medium text-gray-700 mb-1">Search</label>
       <input type="text" id="db-search" name="search" hx-get="/api/words" hx-target="#entry-table" hx-swap="innerHTML"
@@ -49,10 +43,6 @@
         placeholder="Search entries...">
     </div>
   </div>
-
-  <form id="db-filters" class="hidden">
-    <!-- Hidden form to collect all filter values for hx-include -->
-  </form>
 
   <div class="flex gap-3">
     <a id="export-btn" href="#" target="_blank"

--- a/internal/web/templates/flashcards.html
+++ b/internal/web/templates/flashcards.html
@@ -151,32 +151,34 @@
         // After HTMX swaps the card area, read the deck JSON and initialize.
         document.body.addEventListener('htmx:afterSwap', function (evt) {
             if (evt.detail.target !== cardArea) return;
-            populateTagDropdown();
             initDeck();
         });
 
+        // Fetch tags from API and populate dropdown (replaces inline fc-tags-data approach).
         function populateTagDropdown() {
-            var tagsEl = document.getElementById('fc-tags-data');
             var dropdown = document.getElementById('fc-tags-dropdown');
             var hiddenInput = document.getElementById('fc-tags');
-            if (!tagsEl || !dropdown) return;
+            if (!dropdown || !hiddenInput) return;
 
-            var raw = tagsEl.getAttribute('data-tags') || '';
-            var tags = raw ? raw.split(',') : [];
-            var currentValues = hiddenInput ? hiddenInput.value.split(',').filter(Boolean) : [];
+            fetch('/api/tags').then(function (r) { return r.json(); }).then(function (tags) {
+                if (!tags || !tags.length) return;
+                var currentValues = hiddenInput.value.split(',').filter(Boolean);
 
-            // Rebuild dropdown: "All" checkbox + each tag.
-            var html = '<label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">'
-                + '<input type="checkbox" value="" class="fc-tag-cb mr-2"' + (currentValues.length === 0 ? ' checked' : '') + '> All</label>';
-            for (var i = 0; i < tags.length; i++) {
-                var checked = currentValues.indexOf(tags[i]) !== -1 ? ' checked' : '';
-                html += '<label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">'
-                    + '<input type="checkbox" value="' + escapeHtml(tags[i]) + '" class="fc-tag-cb mr-2"' + checked + '> '
-                    + escapeHtml(tags[i]) + '</label>';
-            }
-            dropdown.innerHTML = html;
-            updateTagButtonLabel();
+                var html = '<label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">'
+                    + '<input type="checkbox" value="" class="fc-tag-cb mr-2"' + (currentValues.length === 0 ? ' checked' : '') + '> All</label>';
+                for (var i = 0; i < tags.length; i++) {
+                    var checked = currentValues.indexOf(tags[i]) !== -1 ? ' checked' : '';
+                    html += '<label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">'
+                        + '<input type="checkbox" value="' + escapeHtml(tags[i]) + '" class="fc-tag-cb mr-2"' + checked + '> '
+                        + escapeHtml(tags[i]) + '</label>';
+                }
+                dropdown.innerHTML = html;
+                updateTagButtonLabel();
+            });
         }
+
+        // Populate tags on initial load.
+        populateTagDropdown();
 
         function updateTagButtonLabel() {
             var btn = document.getElementById('fc-tags-btn');

--- a/internal/web/templates/lookup.html
+++ b/internal/web/templates/lookup.html
@@ -2,31 +2,31 @@
 {{define "content"}}
 <h1 class="text-2xl font-bold mb-6">Vocabulary Lookup</h1>
 
-<form hx-post="/api/lookup/html" hx-target="#result" hx-swap="innerHTML"
-      hx-indicator="#lookup-spinner" class="space-y-4 max-w-lg">
+<form hx-post="/api/lookup/html" hx-target="#result" hx-swap="innerHTML" hx-indicator="#lookup-spinner"
+  class="space-y-4 max-w-lg">
   <div>
     <label for="text" class="block text-sm font-medium text-gray-700 mb-1">Text</label>
     <input type="text" id="text" name="text" required
-           class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-           placeholder="Enter a word, expression, or sentence">
+      class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      placeholder="Enter a word, expression, or sentence">
   </div>
 
   <div class="grid grid-cols-2 gap-4">
     <div>
       <label for="source_language" class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
       <select id="source_language" name="source_language"
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         {{range .Languages}}
-        <option value="{{.Code}}"{{if eq $.Config.DefaultSourceLanguage .Code}} selected{{end}}>{{.Name}}</option>
+        <option value="{{.Code}}" {{if eq $.Config.DefaultSourceLanguage .Code}} selected{{end}}>{{.Name}}</option>
         {{end}}
       </select>
     </div>
     <div>
       <label for="target_language" class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
       <select id="target_language" name="target_language"
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
         {{range .Languages}}
-        <option value="{{.Code}}"{{if eq $.Config.DefaultTargetLanguage .Code}} selected{{end}}>{{.Name}}</option>
+        <option value="{{.Code}}" {{if eq $.Config.DefaultTargetLanguage .Code}} selected{{end}}>{{.Name}}</option>
         {{end}}
       </select>
     </div>
@@ -50,24 +50,20 @@
   <div>
     <label for="context" class="block text-sm font-medium text-gray-700 mb-1">Context (optional)</label>
     <textarea id="context" name="context" rows="2"
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Sentence or context where the word appears"></textarea>
+      class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      placeholder="Sentence or context where the word appears"></textarea>
   </div>
 
-  <div>
-    <label for="tags" class="block text-sm font-medium text-gray-700 mb-1">Tags (optional)</label>
-    <input type="text" id="tags" name="tags"
-           class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-           placeholder="e.g. chapter-3, B2">
-  </div>
+  {{template "tag_picker_input" .}}
 
   <div class="flex items-center gap-3">
     <button type="submit"
-            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
       Look Up
     </button>
     <div id="lookup-spinner" class="htmx-indicator">
-      <svg class="animate-spin h-5 w-5 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <svg class="animate-spin h-5 w-5 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none"
+        viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>

--- a/internal/web/templates/partials/config_form.html
+++ b/internal/web/templates/partials/config_form.html
@@ -109,7 +109,7 @@
       class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
       placeholder="{{if eq .Config.Provider " bedrock"}}e.g. us.anthropic.claude-sonnet-4-20250514-v1:0{{else if eq
       .Config.Provider "openai" }}e.g. gpt-4o, or translategemma for Ollama{{else if eq .Config.Provider "anthropic"
-      }}e.g. claude-sonnet-4-20250514{{else if eq .Config.Provider "vertexai" }}e.g. gemini-2.0-flash{{else}}Enter model
+      }}e.g. claude-sonnet-4-6{{else if eq .Config.Provider "vertexai" }}e.g. gemini-2.0-flash{{else}}Enter model
       ID{{end}}">
   </div>
 

--- a/internal/web/templates/partials/flashcard_card.html
+++ b/internal/web/templates/partials/flashcard_card.html
@@ -1,8 +1,6 @@
 {{define "flashcard_card"}}
 <!-- Hidden deck data for JS -->
 <div id="fc-deck-data" data-deck="{{.DeckJSON}}" class="hidden"></div>
-<!-- Hidden tags data for populating the tag dropdown -->
-<div id="fc-tags-data" data-tags="{{range $i, $t := .Tags}}{{if $i}},{{end}}{{$t}}{{end}}" class="hidden"></div>
 
 {{if eq .DeckSize 0}}
 <!-- Empty state -->

--- a/internal/web/templates/partials/tag_picker.html
+++ b/internal/web/templates/partials/tag_picker.html
@@ -1,0 +1,212 @@
+{{define "tag_picker_filter"}}
+<!-- Tag picker: filter mode (Database page) -->
+<div class="relative" id="tag-picker-filter">
+    <label class="block text-sm font-medium text-gray-700 mb-1">Tags</label>
+    <input type="hidden" id="db-tags" name="tags" value="" hx-get="/api/words" hx-target="#entry-table"
+        hx-swap="innerHTML" hx-include="#db-filters" hx-trigger="change">
+    <button type="button" id="tag-filter-btn"
+        class="border border-gray-300 rounded px-3 py-2 bg-white text-left min-w-[120px] focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700">
+        All
+    </button>
+    <div id="tag-filter-dropdown"
+        class="hidden absolute z-10 mt-1 bg-white border border-gray-300 rounded shadow-lg max-h-48 overflow-y-auto min-w-[160px]">
+        <label class="flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm">
+            <input type="checkbox" value="" class="tag-filter-cb mr-2" checked> All
+        </label>
+    </div>
+</div>
+<script>
+    (function () {
+        var btn = document.getElementById('tag-filter-btn');
+        var dropdown = document.getElementById('tag-filter-dropdown');
+        var hiddenInput = document.getElementById('db-tags');
+        if (!btn || !dropdown || !hiddenInput) return;
+
+        // Fetch tags and populate dropdown.
+        fetch('/api/tags').then(function (r) { return r.json(); }).then(function (tags) {
+            if (!tags || !tags.length) return;
+            for (var i = 0; i < tags.length; i++) {
+                var label = document.createElement('label');
+                label.className = 'flex items-center px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-sm';
+                label.innerHTML = '<input type="checkbox" value="' + escapeAttr(tags[i]) + '" class="tag-filter-cb mr-2"> ' + escapeText(tags[i]);
+                dropdown.appendChild(label);
+            }
+        });
+
+        btn.addEventListener('click', function (e) {
+            e.stopPropagation();
+            dropdown.classList.toggle('hidden');
+        });
+        document.addEventListener('click', function (e) {
+            if (!dropdown.contains(e.target) && e.target !== btn) {
+                dropdown.classList.add('hidden');
+            }
+        });
+        dropdown.addEventListener('change', function (e) {
+            var cb = e.target;
+            if (!cb.classList.contains('tag-filter-cb')) return;
+            var allCbs = dropdown.querySelectorAll('.tag-filter-cb');
+            if (cb.value === '') {
+                for (var i = 0; i < allCbs.length; i++) allCbs[i].checked = (allCbs[i].value === '');
+                hiddenInput.value = '';
+            } else {
+                allCbs[0].checked = false;
+                var selected = [];
+                for (var i = 0; i < allCbs.length; i++) {
+                    if (allCbs[i].checked && allCbs[i].value !== '') selected.push(allCbs[i].value);
+                }
+                if (selected.length === 0) {
+                    allCbs[0].checked = true;
+                    hiddenInput.value = '';
+                } else {
+                    hiddenInput.value = selected.join(',');
+                }
+            }
+            updateFilterBtnLabel();
+            htmx.trigger(hiddenInput, 'change');
+        });
+
+        function updateFilterBtnLabel() {
+            var val = hiddenInput.value;
+            if (!val) { btn.textContent = 'All'; return; }
+            var tags = val.split(',');
+            btn.textContent = tags.length === 1 ? tags[0] : tags.length + ' tags';
+        }
+
+        function escapeAttr(s) {
+            return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        }
+        function escapeText(s) {
+            var d = document.createElement('div'); d.appendChild(document.createTextNode(s)); return d.innerHTML;
+        }
+    })();
+</script>
+{{end}}
+
+{{define "tag_picker_input"}}
+<!-- Tag picker: input mode (Lookup/Batch pages) -->
+<div class="relative" id="tag-picker-input">
+    <label for="tags" class="block text-sm font-medium text-gray-700 mb-1">Tags (optional)</label>
+    <input type="text" id="tags" name="tags"
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        placeholder="e.g. chapter-3, B2" autocomplete="off">
+    <div id="tag-suggestions"
+        class="hidden absolute z-10 mt-1 bg-white border border-gray-300 rounded shadow-lg max-h-48 overflow-y-auto w-full">
+    </div>
+</div>
+<script>
+    (function () {
+        var input = document.getElementById('tags');
+        var suggestionsDiv = document.getElementById('tag-suggestions');
+        if (!input || !suggestionsDiv) return;
+
+        var allTags = [];
+
+        // Fetch existing tags for suggestions.
+        fetch('/api/tags').then(function (r) { return r.json(); }).then(function (tags) {
+            allTags = tags || [];
+        });
+
+        input.addEventListener('input', function () {
+            var parts = input.value.split(',');
+            var current = parts[parts.length - 1].trim().toLowerCase();
+            if (!current || allTags.length === 0) {
+                suggestionsDiv.classList.add('hidden');
+                return;
+            }
+            // Already-entered tags (to exclude from suggestions).
+            var entered = {};
+            for (var i = 0; i < parts.length - 1; i++) {
+                entered[parts[i].trim().toLowerCase()] = true;
+            }
+            var matches = [];
+            for (var i = 0; i < allTags.length; i++) {
+                if (allTags[i].toLowerCase().indexOf(current) !== -1 && !entered[allTags[i].toLowerCase()]) {
+                    matches.push(allTags[i]);
+                }
+            }
+            if (matches.length === 0) {
+                suggestionsDiv.classList.add('hidden');
+                return;
+            }
+            var html = '';
+            for (var i = 0; i < matches.length; i++) {
+                html += '<div class="tag-suggestion px-3 py-1.5 hover:bg-blue-50 cursor-pointer text-sm">' + escapeText(matches[i]) + '</div>';
+            }
+            suggestionsDiv.innerHTML = html;
+            suggestionsDiv.classList.remove('hidden');
+        });
+
+        input.addEventListener('focus', function () {
+            // Show all tags if input is empty or at a comma boundary.
+            var parts = input.value.split(',');
+            var current = parts[parts.length - 1].trim();
+            if (current === '' && allTags.length > 0) {
+                var entered = {};
+                for (var i = 0; i < parts.length - 1; i++) {
+                    entered[parts[i].trim().toLowerCase()] = true;
+                }
+                var available = [];
+                for (var i = 0; i < allTags.length; i++) {
+                    if (!entered[allTags[i].toLowerCase()]) available.push(allTags[i]);
+                }
+                if (available.length > 0) {
+                    var html = '';
+                    for (var i = 0; i < available.length; i++) {
+                        html += '<div class="tag-suggestion px-3 py-1.5 hover:bg-blue-50 cursor-pointer text-sm">' + escapeText(available[i]) + '</div>';
+                    }
+                    suggestionsDiv.innerHTML = html;
+                    suggestionsDiv.classList.remove('hidden');
+                }
+            }
+        });
+
+        suggestionsDiv.addEventListener('click', function (e) {
+            var el = e.target;
+            if (!el.classList.contains('tag-suggestion')) return;
+            e.stopPropagation(); // Prevent document click from hiding the dropdown.
+            var tag = el.textContent;
+            // Append the selected tag to existing tags.
+            var existing = input.value.split(',').map(function (t) { return t.trim(); }).filter(Boolean);
+            existing.push(tag);
+            input.value = existing.join(', ');
+            input.focus();
+            // Show remaining available tags for multi-select.
+            showAvailableTags();
+        });
+
+        function showAvailableTags() {
+            var parts = input.value.split(',');
+            var entered = {};
+            for (var i = 0; i < parts.length; i++) {
+                var t = parts[i].trim().toLowerCase();
+                if (t) entered[t] = true;
+            }
+            var available = [];
+            for (var i = 0; i < allTags.length; i++) {
+                if (!entered[allTags[i].toLowerCase()]) available.push(allTags[i]);
+            }
+            if (available.length === 0) {
+                suggestionsDiv.classList.add('hidden');
+                return;
+            }
+            var html = '';
+            for (var i = 0; i < available.length; i++) {
+                html += '<div class="tag-suggestion px-3 py-1.5 hover:bg-blue-50 cursor-pointer text-sm">' + escapeText(available[i]) + '</div>';
+            }
+            suggestionsDiv.innerHTML = html;
+            suggestionsDiv.classList.remove('hidden');
+        }
+
+        document.addEventListener('click', function (e) {
+            if (!suggestionsDiv.contains(e.target) && e.target !== input) {
+                suggestionsDiv.classList.add('hidden');
+            }
+        });
+
+        function escapeText(s) {
+            var d = document.createElement('div'); d.appendChild(document.createTextNode(s)); return d.innerHTML;
+        }
+    })();
+</script>
+{{end}}


### PR DESCRIPTION
## Summary

Batch of quick fixes and improvements: dev workflow targets, Docker container-friendly defaults, and a unified tag picker component.

## Related Issue

Fixes #71, Fixes #73, Fixes #74

## Changes

- `make dev` and `make dev-serve` targets for faster build-and-run development workflow
- Docker image now defaults to `/data/vocabgen.db` instead of `~/.vocabgen/vocabgen.db` for simpler volume mounts
- Unified tag picker across Database, Lookup, and Batch pages — select existing tags from a dropdown instead of typing from memory; Lookup and Batch also support free-text entry for new tags

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
