### PR TITLE
feat: dev workflow, Docker defaults, unified tag picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 
 ## [1.3.1]
 
+### Added
+
+- `make dev` and `make dev-serve` targets for a faster build-and-run development workflow (#71)
+
 ### Changed
 
 - Highlighted provider quality guidance across README, user guide, and marketing page — clearer messaging that paid models produce better results for nuanced vocabulary tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 
 - `make dev` and `make dev-serve` targets for a faster build-and-run development workflow (#71)
 - Unified tag picker across Database, Lookup, and Batch pages — select existing tags from a dropdown instead of typing from memory; Lookup and Batch also support free-text entry for new tags (#74)
+- Separate dev database for `make dev-serve` — uses `~/.vocabgen/vocabgen-dev.db` so dev testing never pollutes the production database; active DB path shown in the nav bar next to the profile indicator (#72)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 
 ## [1.3.1]
 
-### Added
-
-- `make dev` and `make dev-serve` targets for a faster build-and-run development workflow (#71)
-
 ### Changed
 
 - Highlighted provider quality guidance across README, user guide, and marketing page — clearer messaging that paid models produce better results for nuanced vocabulary tasks

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dev:
 
 # Dev build + launch web server on port 8081 (keeps stable on 8080)
 dev-serve: dev
-	bin/vocabgen serve --port 8081
+	bin/vocabgen serve --port 8081 --db-path ~/.vocabgen/vocabgen-dev.db
 
 test:
 	go test -race ./...

--- a/cmd/vocabgen/main.go
+++ b/cmd/vocabgen/main.go
@@ -511,6 +511,14 @@ var serveCmd = &cobra.Command{
 		}
 		defer func() { _ = store.Close() }()
 
+		// Resolve the DB path for display in the web UI.
+		resolvedDBPath := appConfig.DBPath
+		if strings.HasPrefix(resolvedDBPath, "~/") {
+			if home, hErr := os.UserHomeDir(); hErr == nil {
+				resolvedDBPath = filepath.Join(home, resolvedDBPath[2:])
+			}
+		}
+
 		addr := fmt.Sprintf(":%d", port)
 		slog.Info("starting web server", "addr", addr)
 
@@ -518,7 +526,7 @@ var serveCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 		defer stop()
 
-		srv := web.NewServer(store, &appConfig, slog.Default(), version, buildDate, runtime.Version())
+		srv := web.NewServer(store, &appConfig, slog.Default(), version, buildDate, runtime.Version(), resolvedDBPath)
 		return srv.ListenAndServe(ctx, addr)
 	},
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -181,6 +181,28 @@ Version is injected at build time via ldflags:
 go build -ldflags "-X main.version=v1.0.0 -X main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o vocabgen ./cmd/vocabgen
 ```
 
+## Development Workflow
+
+### Build Targets
+
+| Target | Output | Purpose |
+|--------|--------|---------|
+| `make build` | `./vocabgen` | Production build (CI, releases) |
+| `make dev` | `bin/vocabgen` | Dev build (feature branches) |
+| `make dev-serve` | — | Dev build + launch web server on port 8081 |
+
+### Dev Database
+
+`make dev-serve` passes `--db-path ~/.vocabgen/vocabgen-dev.db` so development testing never touches the production database (`~/.vocabgen/vocabgen.db`). The active database path is displayed in the web UI nav bar next to the profile indicator, making it immediately clear which database you're looking at.
+
+To use a custom database path with the production binary:
+
+```bash
+vocabgen serve --port 8080 --db-path ~/.vocabgen/my-project.db
+```
+
+The `--db-path` flag overrides the `db_path` setting in `config.yaml`. If the file doesn't exist, it's created automatically with all migrations applied.
+
 ## IDE Setup (VS Code / Kiro)
 
 Install the [Go extension](https://marketplace.visualstudio.com/items?itemName=golang.Go) (`golang.Go`). It provides:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -607,6 +607,17 @@ All user data is stored in `~/.vocabgen/`, independent of where the vocabgen bin
 |------|---------|
 | `~/.vocabgen/config.yaml` | Application configuration (provider, languages, model) |
 | `~/.vocabgen/vocabgen.db` | SQLite vocabulary database (cached lookups, entries) |
+| `~/.vocabgen/vocabgen-dev.db` | Dev database (used by `make dev-serve`, never touched by production) |
+
+The web UI displays the active database path in the navigation bar (next to the profile indicator), so you can always tell at a glance which database you're connected to.
+
+To use a custom database path:
+
+```bash
+vocabgen serve --db-path ~/.vocabgen/my-project.db
+```
+
+If the file doesn't exist, it's created automatically. The `--db-path` flag overrides the `db_path` setting in `config.yaml`.
 
 Replacing the binary (e.g., downloading a new release) does not affect your configuration or vocabulary data. You can safely update vocabgen by overwriting the binary in place — your settings and database remain untouched.
 

--- a/internal/web/handlers_db_test.go
+++ b/internal/web/handlers_db_test.go
@@ -23,7 +23,7 @@ func (m *tagMockStore) ListDistinctTags(_ context.Context) ([]string, error) {
 
 func newTagTestServer(store *tagMockStore) *Server {
 	cfg := config.DefaultConfig()
-	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22")
+	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
 }
 
 func TestHandleListTags(t *testing.T) {

--- a/internal/web/handlers_flashcards_test.go
+++ b/internal/web/handlers_flashcards_test.go
@@ -130,7 +130,7 @@ func matchesFilter(sourceLang, targetLang, tags, difficulty string, f db.ListFil
 
 func newFlashcardTestServer(store *flashcardMockStore) *Server {
 	cfg := config.DefaultConfig()
-	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22")
+	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
 }
 
 // TestFlashcardsPage_Returns200 verifies GET /flashcards returns 200 with HTML content type.

--- a/internal/web/integration_test.go
+++ b/internal/web/integration_test.go
@@ -504,7 +504,7 @@ func TestPropertyP21_AboutPageContentIdentical(t *testing.T) {
 		goVersion := rapid.StringMatching(`go1\.[0-9]{1,2}(\.[0-9]{1,2})?`).Draw(t, "goVersion")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, buildDate, goVersion)
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, buildDate, goVersion, "/tmp/test.db")
 
 		req := httptest.NewRequest(http.MethodGet, "/about", nil)
 		w := httptest.NewRecorder()
@@ -560,7 +560,7 @@ func TestPropertyP22_AboutURLServesAboutPage(t *testing.T) {
 		version := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(t, "version")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db")
 
 		req := httptest.NewRequest(http.MethodGet, "/about", nil)
 		w := httptest.NewRecorder()
@@ -742,7 +742,7 @@ func TestPropertyP12_HelpDropdownContainsFiveLinksInOrder(t *testing.T) {
 		path := pagePaths[idx]
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
 
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		w := httptest.NewRecorder()
@@ -808,7 +808,7 @@ func TestPropertyP31_ReportAnIssueOpensCorrectURL(t *testing.T) {
 		version := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(t, "version")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db")
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
@@ -838,7 +838,7 @@ func TestPropertyP32_ReportAnIssueOpensInNewTabSecurely(t *testing.T) {
 		version := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(t, "version")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db")
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -21,6 +21,7 @@ type Server struct {
 	store         db.Store
 	cfg           *config.Config
 	activeProfile string
+	dbPath        string
 	mux           *http.ServeMux
 	logger        *slog.Logger
 	version       string
@@ -42,10 +43,11 @@ type pageData struct {
 	ActiveProfile     string
 	Profiles          []string
 	LocalModelWarning bool
+	DBPath            string
 }
 
 // NewServer creates a Server with all routes registered.
-func NewServer(store db.Store, cfg *config.Config, logger *slog.Logger, version, buildDate, goVersion string) *Server {
+func NewServer(store db.Store, cfg *config.Config, logger *slog.Logger, version, buildDate, goVersion, dbPath string) *Server {
 	// Resolve the initial active profile name.
 	_, defaultProfile, _ := config.ListProfiles()
 
@@ -53,6 +55,7 @@ func NewServer(store db.Store, cfg *config.Config, logger *slog.Logger, version,
 		store:         store,
 		cfg:           cfg,
 		activeProfile: defaultProfile,
+		dbPath:        dbPath,
 		mux:           http.NewServeMux(),
 		logger:        logger,
 		version:       version,
@@ -184,6 +187,7 @@ func (s *Server) newPageData(activePage string) pageData {
 		GoVersion:     s.goVersion,
 		ActiveProfile: s.activeProfile,
 		Profiles:      profiles,
+		DBPath:        s.dbPath,
 	}
 	if info := s.updater.cached(); info != nil && info.HasUpdate && !s.updater.isDismissed() {
 		pd.UpdateAvailable = true

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,7 +94,7 @@ func (s *stubStore) UpdateExpressionDifficulty(ctx context.Context, id int64, di
 
 func newTestServer() *Server {
 	cfg := config.DefaultConfig()
-	return NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22")
+	return NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
 }
 
 func TestNewServer(t *testing.T) {
@@ -261,6 +262,50 @@ func TestAPIRoutesRegistered(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDBPathRenderedInNavBar verifies that the active database path is
+// displayed in the navigation bar on all pages.
+func TestDBPathRenderedInNavBar(t *testing.T) {
+	cfg := config.DefaultConfig()
+	srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/home/user/.vocabgen/vocabgen-dev.db")
+
+	pages := []string{"/", "/batch", "/config", "/database", "/about"}
+	for _, path := range pages {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET %s: expected 200, got %d", path, w.Code)
+			}
+			body := w.Body.String()
+			if !strings.Contains(body, "/home/user/.vocabgen/vocabgen-dev.db") {
+				t.Fatalf("GET %s: response does not contain the DB path", path)
+			}
+		})
+	}
+}
+
+// TestDBPathEmptyNotRendered verifies that when dbPath is empty, no DB path
+// indicator appears in the navigation bar.
+func TestDBPathEmptyNotRendered(t *testing.T) {
+	cfg := config.DefaultConfig()
+	srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	// The 📂 emoji is only rendered when DBPath is non-empty
+	if strings.Contains(body, "📂") {
+		t.Fatal("DB path indicator should not be rendered when dbPath is empty")
 	}
 }
 

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -25,6 +25,9 @@
       <a href="/flashcards" class="{{if eq .ActivePage " flashcards"}}text-blue-600 font-medium{{else}}text-gray-600
         hover:text-blue-600{{end}}">Flashcards</a>
       <div class="flex-1"></div>
+      {{if .DBPath}}
+      <span class="text-xs text-gray-400 truncate max-w-xs" title="{{.DBPath}}">📂 {{.DBPath}}</span>
+      {{end}}
       {{template "profile_switcher" .}}
       <div class="relative" id="help-menu">
         <button onclick="document.getElementById('help-dropdown').classList.toggle('hidden')"


### PR DESCRIPTION
## Summary

Dev workflow improvements and Docker container fixes: adds `make dev`/`make dev-serve` targets with a separate dev database, fixes Docker image to default to `/data/vocabgen.db` for simple volume mounts, and shows the active DB path in the nav bar.

## Related Issue

Fixes #71, Fixes #72, Fixes #73

## Changes

- `make dev` and `make dev-serve` targets for faster build-and-run development workflow
- Separate dev database (`~/.vocabgen/vocabgen-dev.db`) so dev testing never pollutes production data
- Active DB path shown in the nav bar next to the profile indicator
- Docker image defaults to `/data/vocabgen.db` — simple `-v ./data:/data` mount works out of the box

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
