### PR TITLE
Group Dependabot PRs and fix Docker entrypoint chown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,24 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
-    rebase-strategy: auto
+      interval: monthly
     commit-message:
-      prefix: "deps"
+      prefix: "deps:"
+    groups:
+      all-go-deps:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go-v2/internal/*"
+        update-types: ["version-update:semver-patch"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-    rebase-strategy: auto
+      interval: monthly
     commit-message:
-      prefix: "ci"
+      prefix: "ci:"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine:3.23
 
-RUN apk add --no-cache curl \
+RUN apk add --no-cache curl su-exec \
     && addgroup -S vocabgen && adduser -S vocabgen -G vocabgen
 
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/vocabgen /vocabgen
+COPY scripts/docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Data directory for config.yaml and vocabgen.db — container-friendly mount point.
 # Users mount a host directory here: docker run -v ./data:/data ...
@@ -16,7 +18,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8080/api/health || exit 1
 
-USER vocabgen
-
-ENTRYPOINT ["/vocabgen"]
-CMD ["serve", "--port", "8080"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/vocabgen", "serve", "--port", "8080"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Ensure /data is writable by the vocabgen user.
+# Runs as root, then drops to vocabgen via exec su-exec.
+chown -R vocabgen:vocabgen /data 2>/dev/null || true
+exec su-exec vocabgen "$@"


### PR DESCRIPTION
## Summary

Group Dependabot PRs by ecosystem (monthly schedule) and fix Docker entrypoint to auto-chown `/data` for the vocabgen user.

## Related Issue

Fixes #83

## Changes

- Configure Dependabot grouping for Go modules and GitHub Actions with monthly schedule
- Fix Docker entrypoint to auto-chown `/data` directory so the non-root vocabgen user has write access

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] New tests added for new functionality
