### PR TITLE
feat: database picker, multiple meanings, detail panel fix, look & feel page

### DIFF
--- a/.kiro/specs/go-vocabulary-generator/.config.kiro
+++ b/.kiro/specs/go-vocabulary-generator/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "bb4eca8e-bc08-4a54-b117-9fe698167bb7", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/go-vocabulary-generator/design.md
+++ b/.kiro/specs/go-vocabulary-generator/design.md
@@ -1,0 +1,1950 @@
+# Design Document: Go Vocabulary Generator
+
+## Overview
+
+The Go Vocabulary Generator (`vocabgen`) is a single-binary CLI and embedded web application that automates creation of structured B2→C1 vocabulary lists for language learners. It processes words, expressions, and sentences through LLM providers (Bedrock, OpenAI, Anthropic), validates and maps the JSON responses, caches word/expression results in SQLite (sentence lookups are ephemeral), and presents them via CLI output or a browser-based HTMX interface.
+
+### Key Design Principles
+
+1. **Single Binary**: All templates, static assets, and the SQLite driver compile into one executable via `go:embed` and a pure-Go SQLite driver. Zero runtime dependencies.
+2. **Language-Agnostic**: Three unified prompt templates parameterized by `{source_language}` — words, expressions, and sentences. No per-language code branches. The LLM provides native POS labels, register labels, and grammatical categories.
+3. **Provider Abstraction**: A Go `Provider` interface decouples the service layer from any specific LLM API. New providers require one file and one registry entry.
+4. **Cache-First with Context Bypass**: SQLite acts as a cache layer — every lookup checks the DB before invoking the LLM, eliminating duplicate API costs. When a context sentence is provided for an existing entry, the cache is bypassed to get a context-specific result.
+5. **Multi-Version Entries**: The database allows multiple entries per word/expression (e.g., "werk" as noun vs. verb). Conflict resolution (replace, add, skip) lets the user control how the vocabulary database evolves.
+6. **Error Resilience**: Batch processing continues after per-item failures. Errors are collected and reported in a summary.
+7. **Connotation-Aware**: A Core Rule Block and Decision Rubric in every prompt ensures translations preserve register and tone.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| CLI framework | Cobra | Subcommands (`lookup`, `batch`, `serve`), auto-generated help, flag parsing |
+| Web framework | stdlib `net/http` + `html/template` + HTMX | No JS build step, embedded in binary, sufficient for local tool |
+| Database | SQLite via `modernc.org/sqlite` | Pure-Go, cross-compiles, embedded, zero-config |
+| LLM abstraction | Go interface + provider registry | 4 real implementations (Bedrock, OpenAI, Anthropic, Vertex AI), testable with manual mocks |
+| Config format | YAML at `~/.vocabgen/config.yaml` | Human-readable, simple, `gopkg.in/yaml.v3` |
+| PBT library | `pgregory.net/rapid` | Go-native, integrates with `testing`, no external runner |
+| Excel export | `github.com/xuri/excelize/v2` | Well-maintained, pure-Go xlsx writer |
+| Logging | `log/slog` | Stdlib, structured, leveled, zero dependencies |
+
+## Architecture
+
+### System Architecture
+
+```mermaid
+graph TB
+    subgraph "Single Binary"
+        CLI["cmd/vocabgen<br/>Cobra CLI"]
+        WEB["internal/web<br/>net/http + HTMX"]
+        SVC["internal/service<br/>Lookup · ProcessBatch"]
+        LANG["internal/language<br/>Templates · Validation · Registry"]
+        PARSE["internal/parsing<br/>CSV · Normalization"]
+        LLM["internal/llm<br/>Provider Interface"]
+        DB["internal/db<br/>SQLite · Cache"]
+        CFG["internal/config<br/>YAML Config"]
+        OUT["internal/output<br/>Field Mapping · Excel"]
+    end
+
+    CLI --> SVC
+    WEB --> SVC
+    SVC --> LANG
+    SVC --> LLM
+    SVC --> DB
+    SVC --> PARSE
+    SVC --> OUT
+    LLM --> BEDROCK["AWS Bedrock"]
+    LLM --> OPENAI["OpenAI API<br/>(+ Azure, Ollama, LM Studio)"]
+    LLM --> ANTHROPIC["Anthropic API"]
+    LLM --> VERTEXAI["Google Vertex AI"]
+    CLI --> CFG
+    WEB --> CFG
+    DB --> SQLITE["~/.vocabgen/vocabgen.db"]
+    CFG --> YAML["~/.vocabgen/config.yaml"]
+```
+
+### Package Layout
+
+```
+vocabgen/
+├── cmd/vocabgen/          # Cobra CLI entry point
+│   └── main.go
+├── internal/
+│   ├── config/            # YAML config manager (LoadConfig, SaveConfig)
+│   ├── db/                # SQLite schema, migrations, CRUD, cache layer
+│   ├── language/          # Prompt templates, schemas, validation, language registry
+│   ├── llm/               # Provider interface, Bedrock/OpenAI/Anthropic implementations
+│   ├── output/            # Field mapping, translation flattening, Excel export
+│   ├── parsing/           # CSV reading, word/expression normalization
+│   ├── service/           # Lookup, ProcessBatch — shared business logic
+│   └── web/               # HTTP handlers, routes, embedded templates
+│       └── templates/     # Go html/template files (go:embed)
+├── go.mod
+├── go.sum
+└── Makefile
+```
+
+### Data Flow: Single Lookup (with Context-Aware Cache Bypass and Conflict Resolution)
+
+```mermaid
+sequenceDiagram
+    participant C as CLI / Web Handler
+    participant S as service.Lookup()
+    participant DB as db.Store
+    participant L as language.BuildPrompt()
+    participant V as language.Validate()
+    participant P as llm.Provider
+    participant O as output.MapFields()
+
+    C->>S: Lookup(ctx, store, params)
+    S->>S: Normalize token
+    S->>S: Apply timeout to ctx via context.WithTimeout
+    alt Sentence lookup (ephemeral)
+        S->>L: BuildPrompt(lang, "sentence", token, context, targetLang)
+        L-->>S: prompt string
+        S->>P: Invoke(ctx, prompt, modelID)
+        P-->>S: raw JSON string
+        S->>V: ValidateSentenceResponse(rawJSON)
+        V-->>S: SentenceEntry (grammar check + vocabulary)
+        Note over S: No DB read, no DB write
+        S-->>C: result (ephemeral)
+    else Word/Expression lookup
+        S->>DB: FindWords/FindExpressions(lang, text)
+        alt No existing entries (cache miss)
+            S->>L: BuildPrompt(lang, mode, token, context, targetLang)
+            L-->>S: prompt string
+            S->>P: Invoke(ctx, prompt, modelID)
+            P-->>S: raw JSON string
+            S->>V: ValidateResponse(mode, rawJSON)
+            V-->>S: validated struct
+            S->>O: MapFields(validated, mode)
+            O-->>S: output struct
+            S->>DB: InsertEntry(output, lang, targetLang)
+            S-->>C: result
+        else Existing entries found, no context sentence
+            DB-->>S: []existing entries
+            S-->>C: first cached entry
+        else Existing entries found, context sentence provided (cache bypass)
+            DB-->>S: []existing entries
+            S->>L: BuildPrompt(lang, mode, token, context, targetLang)
+            L-->>S: prompt string
+            S->>P: Invoke(ctx, prompt, modelID)
+            P-->>S: raw JSON string
+            S->>V: ValidateResponse(mode, rawJSON)
+            V-->>S: validated struct
+            S->>O: MapFields(validated, mode)
+            O-->>S: new entry
+            S-->>C: LookupResult{New: newEntry, Existing: []existing, NeedsResolution: true}
+            Note over C,S: Caller applies conflict resolution strategy
+            alt Strategy: replace
+                C->>S: ResolveConflict(replace, targetID)
+                S->>DB: UpdateWord/UpdateExpression(targetID, newEntry)
+            else Strategy: add
+                C->>S: ResolveConflict(add)
+                S->>DB: InsertEntry(newEntry)
+            else Strategy: skip
+                C->>S: ResolveConflict(skip)
+                Note over S: No DB write
+            end
+        end
+    end
+```
+
+### Data Flow: Batch Processing (with Context-Aware Cache Bypass and Conflict Resolution)
+
+```mermaid
+sequenceDiagram
+    participant C as CLI / Web Handler
+    participant S as service.ProcessBatch()
+    participant DB as db.Store
+    participant P as llm.Provider
+
+    C->>S: ProcessBatch(ctx, store, params)
+    Note over S: params.OnConflict = "replace" | "add" | "skip"
+    loop For each (token, context) in tokens
+        S->>S: Normalize token
+        S->>DB: FindWords/FindExpressions(lang, normalizedToken)
+        alt No existing entries (cache miss)
+            alt limit reached
+                S->>S: break
+            else within limit
+                S->>S: BuildPrompt → Invoke → Validate → MapFields
+                S->>DB: InsertEntry(result)
+                S->>S: count as processed
+            end
+        else Existing entries found, no context sentence
+            S->>S: count as cached, skip
+        else Existing entries found, context sentence provided
+            alt limit reached
+                S->>S: break
+            else within limit
+                S->>S: BuildPrompt → Invoke → Validate → MapFields
+                alt OnConflict = replace
+                    S->>DB: UpdateWord/UpdateExpression(firstExistingID, newResult)
+                    S->>S: count as replaced
+                else OnConflict = add
+                    S->>DB: InsertEntry(newResult)
+                    S->>S: count as added
+                else OnConflict = skip
+                    S->>S: count as skipped
+                end
+            end
+        end
+    end
+    S-->>C: BatchResult{Results, Errors, Processed, Cached, Failed, Skipped, Replaced, Added}
+```
+
+## Components and Interfaces
+
+### Go-Specific Patterns Used
+
+This section explains Go idioms that appear throughout the design, for readers new to Go.
+
+- **Interfaces**: Go interfaces are satisfied implicitly — a type implements an interface just by having the right methods, with no `implements` keyword. This is called "structural typing." The `Provider` interface below is satisfied by any struct with `Invoke` and `Name` methods matching the signatures.
+- **"Accept interfaces, return structs"**: Constructor functions like `NewBedrockProvider(...)` return a concrete struct (e.g., `*BedrockProvider`), not the interface. Callers that need flexibility accept the `Provider` interface. This gives you both type safety and testability.
+- **Constructor functions**: Go has no constructors. By convention, `NewXxx(...)` functions create and return initialized structs. They replace `__init__` or class constructors from other languages.
+- **`context.Context` as first parameter**: Any function that does I/O (network calls, DB queries) takes `context.Context` as its first argument. This carries cancellation signals and deadlines through the call chain — critical for graceful shutdown and timeouts.
+- **Error returns**: Go functions return errors as the last return value instead of throwing exceptions. Callers check `if err != nil` and handle or propagate. This makes error paths explicit.
+- **`go:embed`**: A compiler directive that embeds files into the binary at compile time. Used for HTML templates and static assets so the binary is self-contained.
+- **Embedding (struct composition)**: Go uses struct embedding instead of inheritance. A struct can embed another struct to "inherit" its methods. Not used heavily here, but worth knowing.
+
+### 1. `internal/llm` — Provider Interface and Implementations
+
+```go
+// provider.go
+
+// Provider defines the contract for LLM API backends.
+// Any struct with these two methods automatically satisfies this interface.
+type Provider interface {
+    // Invoke sends a prompt to the LLM and returns the raw text response.
+    // ctx carries cancellation/timeout; callers can cancel long-running requests.
+    Invoke(ctx context.Context, prompt string, modelID string) (string, error)
+
+    // Name returns the provider identifier (e.g., "bedrock", "openai").
+    Name() string
+}
+
+// ProviderError wraps provider-specific errors with the provider name.
+// All provider errors can be checked with errors.As(&ProviderError{}).
+type ProviderError struct {
+    Provider string
+    Message  string
+    Err      error // underlying error, if any
+}
+
+func (e *ProviderError) Error() string {
+    return fmt.Sprintf("%s: %s", e.Provider, e.Message)
+}
+
+func (e *ProviderError) Unwrap() error { return e.Err }
+
+// NewProviderFunc is the signature for provider constructor functions.
+// The registry maps provider names to these constructors.
+type NewProviderFunc func(opts ProviderOptions) (Provider, error)
+
+// ProviderOptions holds configuration passed to provider constructors.
+type ProviderOptions struct {
+    APIKey     string // for OpenAI/Anthropic
+    BaseURL    string // for OpenAI-compatible servers (Azure, Ollama, LM Studio)
+    Region     string // for Bedrock (AWS) or Vertex AI (GCP)
+    Profile    string // for Bedrock AWS profile
+    GCPProject string // for Vertex AI
+}
+
+// Registry maps provider name strings to constructor functions.
+var Registry = map[string]NewProviderFunc{
+    "bedrock":   NewBedrockProvider,
+    "openai":    NewOpenAIProvider,
+    "anthropic": NewAnthropicProvider,
+    "vertexai":  NewVertexAIProvider,
+}
+```
+
+```go
+// bedrock.go
+
+// BedrockProvider implements Provider for AWS Bedrock.
+type BedrockProvider struct {
+    client    *bedrockruntime.Client // AWS SDK v2 Bedrock Runtime client
+    region    string
+    maxRetry  int
+}
+
+// NewBedrockProvider creates a BedrockProvider using the AWS credential chain.
+// Returns a concrete *BedrockProvider (not the Provider interface) — this is
+// the "accept interfaces, return structs" pattern.
+func NewBedrockProvider(opts ProviderOptions) (Provider, error)
+
+func (p *BedrockProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error)
+func (p *BedrockProvider) Name() string { return "bedrock" }
+```
+
+```go
+// openai.go
+
+type OpenAIProvider struct {
+    apiKey   string
+    baseURL  string
+    maxRetry int
+    client   *http.Client
+}
+
+func NewOpenAIProvider(opts ProviderOptions) (Provider, error)
+func (p *OpenAIProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error)
+func (p *OpenAIProvider) Name() string { return "openai" }
+```
+
+```go
+// anthropic.go
+
+type AnthropicProvider struct {
+    apiKey   string
+    maxRetry int
+    client   *http.Client
+}
+
+func NewAnthropicProvider(opts ProviderOptions) (Provider, error)
+func (p *AnthropicProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error)
+func (p *AnthropicProvider) Name() string { return "anthropic" }
+```
+
+```go
+// vertexai.go
+
+type VertexAIProvider struct {
+    project  string
+    region   string
+    maxRetry int
+    client   *http.Client // uses Google ADC for auth
+}
+
+// NewVertexAIProvider creates a VertexAIProvider using Google Application Default Credentials.
+func NewVertexAIProvider(opts ProviderOptions) (Provider, error)
+func (p *VertexAIProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error)
+func (p *VertexAIProvider) Name() string { return "vertexai" }
+```
+
+### 2. `internal/language` — Templates, Validation, Registry
+
+```go
+// templates.go
+
+// WordsTemplate is the unified prompt template for word lookups.
+// Uses Go string formatting with named placeholders replaced via strings.NewReplacer.
+const WordsTemplate = `You are helping to build a vocabulary list for {source_language} learners...`
+
+// ExpressionsTemplate is the unified prompt template for expression lookups.
+const ExpressionsTemplate = `You are helping to build a vocabulary list for {source_language} learners...`
+
+// SentenceTemplate is the dedicated prompt template for sentence lookups.
+// Focuses on grammar checking, correction, and key vocabulary extraction.
+// Placeholders: {source_language}, {sentence}, {context}, {target_language_name}.
+const SentenceTemplate = `You are a {source_language} language tutor...`
+
+// BuildPrompt constructs a complete prompt from template + parameters.
+// Returns an error only for invalid mode values.
+func BuildPrompt(sourceLang, mode, token, context, targetLang string) (string, error)
+
+// ResolveLanguageName maps a language code to its full name, or returns the input as-is.
+func ResolveLanguageName(code string) string
+```
+
+```go
+// registry.go
+
+// SupportedLanguages maps language codes to full names.
+// Used for both source and target language resolution.
+var SupportedLanguages = map[string]string{
+    "nl": "Dutch",
+    "hu": "Hungarian",
+    "it": "Italian",
+    "ru": "Russian",
+    "en": "English",
+    "de": "German",
+    "fr": "French",
+    "es": "Spanish",
+    "pt": "Portuguese",
+    "pl": "Polish",
+    "tr": "Turkish",
+}
+
+// GetHeaderMarker is removed — CSV input files have no headers.
+// The --mode flag determines whether tokens are words or expressions.
+```
+
+```go
+// validation.go
+
+// ValidationError is returned when LLM JSON doesn't match the expected schema.
+type ValidationError struct {
+    Message string
+    Fields  []string // names of problematic fields
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+
+// ValidateResponse parses raw JSON and validates against the English schema
+// for the given mode ("words", "expressions", or "sentence").
+// Normalizes translation fields and defaults optional fields to "".
+func ValidateResponse(mode, rawJSON string) (*ValidatedEntry, error)
+
+// ValidateSentenceResponse parses raw JSON and validates against the sentence schema.
+// Returns a SentenceEntry with grammar check results and extracted vocabulary.
+func ValidateSentenceResponse(rawJSON string) (*SentenceEntry, error)
+
+// SentenceEntry holds the validated data from a sentence lookup LLM response.
+type SentenceEntry struct {
+    Sentence     string
+    Translation  string
+    GrammarCheck GrammarCheck
+    Vocabulary   []VocabItem
+}
+
+// GrammarCheck holds grammar analysis results for a sentence.
+type GrammarCheck struct {
+    HasErrors         bool
+    CorrectedSentence string
+    Errors            []GrammarError
+}
+
+// GrammarError describes a single grammatical error found in the sentence.
+type GrammarError struct {
+    Original    string
+    Corrected   string
+    Explanation string
+}
+
+// VocabItem represents a key vocabulary item extracted from a sentence.
+type VocabItem struct {
+    Word       string
+    Type       string // POS in source language terminology
+    Definition string // in source language
+    English    string // English translation
+}
+func ValidateResponse(mode, rawJSON string) (*ValidatedEntry, error)
+
+// ValidatedEntry holds the validated and normalized data from an LLM response.
+// Translation fields are always normalized to {primary, alternatives} form.
+type ValidatedEntry struct {
+    // Words fields (Expression field used for expressions mode)
+    Word              string
+    Expression        string
+    Type              string
+    Article           string
+    Definition        string
+    EnglishDefinition string
+    Example           string
+    English           Translation
+    TargetTranslation Translation
+    Notes             string
+    Connotation       string
+    Register          string
+    Collocations      string       // words only
+    ContrastiveNotes  string
+    SecondaryMeanings string       // words only
+}
+
+// Translation holds a normalized translation with primary and alternatives.
+type Translation struct {
+    Primary      string
+    Alternatives string
+}
+```
+
+### 3. `internal/parsing` — CSV Reading and Normalization
+
+```go
+// csv.go
+
+// ReadInputFile reads a CSV file and returns (token, context) pairs.
+// Skips empty/whitespace-only lines. All non-empty lines are treated as data.
+func ReadInputFile(path string) ([]TokenWithContext, error)
+
+// TokenWithContext pairs a raw token with its optional context sentence.
+type TokenWithContext struct {
+    Token   string
+    Context string
+}
+```
+
+```go
+// normalize.go
+
+// NormalizeWord strips quotes, vocabulary-list markers (* > (sep.)),
+// conjugation annotations (parenthetical groups with commas), collapses
+// whitespace, and preserves simple parenthetical info (e.g., (ergens), (zich)).
+// Returns empty string for whitespace-only input.
+func NormalizeWord(raw string) string
+
+// NormalizeExpression strips quotes, vocabulary-list markers, conjugation
+// annotations, and collapses whitespace.
+// Returns empty string for whitespace-only input.
+func NormalizeExpression(raw string) string
+```
+
+### 4. `internal/service` — Business Logic
+
+```go
+// conflict.go
+
+// ConflictStrategy represents the user's choice when a new LLM result
+// conflicts with an existing database entry.
+type ConflictStrategy string
+
+const (
+    // ConflictReplace updates the existing entry in-place.
+    ConflictReplace ConflictStrategy = "replace"
+    // ConflictAdd inserts the new result as a separate entry alongside existing ones.
+    ConflictAdd ConflictStrategy = "add"
+    // ConflictSkip discards the new result and keeps the existing entry unchanged.
+    ConflictSkip ConflictStrategy = "skip"
+)
+
+// ParseConflictStrategy converts a string to a ConflictStrategy.
+// Returns an error for invalid values.
+func ParseConflictStrategy(s string) (ConflictStrategy, error)
+```
+
+```go
+// service.go
+
+// LookupParams holds all parameters for a single vocabulary lookup.
+type LookupParams struct {
+    SourceLang  string
+    LookupType  string // "word", "expression", or "sentence"
+    Text        string
+    Provider    llm.Provider // accepts the interface, not a concrete type
+    ModelID     string
+    Context     string
+    TargetLang  string
+    Tags        string // comma-separated tags, or empty
+    DryRun      bool
+    Timeout     time.Duration // per-request LLM timeout (default 60s)
+    OnConflict  ConflictStrategy // pre-selected strategy; empty means interactive
+    ReplaceID   int64            // when OnConflict=replace and multiple entries exist, target this ID
+}
+
+// LookupResult holds the outcome of a single lookup, including conflict info.
+type LookupResult struct {
+    Entry           *output.Entry          // the new or cached entry (word/expression lookups)
+    SentenceResult  *language.SentenceEntry // sentence analysis (sentence lookups only)
+    Existing        []output.Entry         // existing entries (populated when conflict detected)
+    ExistingIDs     []int64         // DB IDs of existing entries (for replace targeting)
+    NeedsResolution bool            // true when context bypass found existing entries
+    FromCache       bool            // true when result was served from cache
+}
+
+// Lookup performs a single vocabulary lookup: normalize → cache check →
+// build prompt → invoke LLM → validate → map fields → handle conflict or store.
+//
+// For sentence lookups: always invokes LLM (no cache check, no DB write).
+// Returns a LookupResult with Entry containing the sentence analysis as JSON.
+// The service layer calls ValidateSentenceResponse instead of ValidateResponse.
+//
+// For word/expression lookups:
+// When no context sentence is provided and entries exist: returns cached result.
+// When a context sentence is provided and entries exist: invokes LLM (cache bypass),
+// returns LookupResult with NeedsResolution=true so the caller can apply conflict resolution.
+// When OnConflict is pre-set, applies the strategy automatically without requiring caller intervention.
+func Lookup(ctx context.Context, store db.Store, params LookupParams) (*LookupResult, error)
+
+// ResolveConflict applies a conflict resolution strategy after a cache-bypass lookup.
+// For "replace": updates the entry at targetID with the new data.
+// For "add": inserts the new entry as a separate row.
+// For "skip": no-op.
+func ResolveConflict(ctx context.Context, store db.Store, strategy ConflictStrategy, mode string, entry *output.Entry, targetID int64, sourceLang, targetLang, tags string) error
+
+// BatchParams holds all parameters for batch processing.
+type BatchParams struct {
+    SourceLang string
+    Mode       string // "words" or "expressions"
+    Tokens     []parsing.TokenWithContext
+    Provider   llm.Provider
+    ModelID    string
+    TargetLang string
+    Tags       string // comma-separated tags, or empty
+    Limit      int    // 0 means no limit
+    DryRun     bool
+    Timeout    time.Duration    // per-request LLM timeout (default 60s)
+    OnConflict ConflictStrategy // batch-level conflict strategy (default: "skip")
+    OnProgress func(current, total int, token, status string) // optional SSE progress callback
+}
+
+// BatchResult holds the outcome of batch processing.
+type BatchResult struct {
+    Results   []output.Entry
+    Errors    []BatchError
+    Processed int
+    Cached    int
+    Failed    int
+    Skipped   int // empty tokens after normalization
+    Replaced  int // entries updated via "replace" strategy
+    Added     int // entries inserted via "add" strategy
+}
+
+// BatchError pairs a token with its error message.
+type BatchError struct {
+    Token   string
+    Message string
+}
+
+// ProcessBatch processes a list of tokens: for each, normalize → cache check →
+// (if context + existing: apply OnConflict strategy) → LLM invoke → validate → map → store.
+// Continues on per-item errors. Checks ctx.Err() between items to support cancellation.
+// If OnProgress is set, calls it after each item with current index, total, token, and status.
+//
+// Conflict resolution in batch mode:
+// - Token with no context + existing entry → skip (cache hit, regardless of OnConflict)
+// - Token with context + existing entry → invoke LLM, apply OnConflict strategy
+// - Token with no existing entry → invoke LLM, insert normally
+func ProcessBatch(ctx context.Context, store db.Store, params BatchParams) (*BatchResult, error)
+
+// GetSupportedLanguages returns the language registry as a slice of {Code, Name} pairs.
+func GetSupportedLanguages() []LanguageInfo
+```
+
+### 5. `internal/output` — Field Mapping and Export
+
+```go
+// mapper.go
+
+// Entry is the final output struct with flattened translations.
+// Used for CLI JSON output, web UI display, and DB storage.
+type Entry struct {
+    Word              string `json:"word,omitempty"`
+    Expression        string `json:"expression,omitempty"`
+    Type              string `json:"type,omitempty"`
+    Article           string `json:"article,omitempty"`
+    Definition        string `json:"definition"`
+    EnglishDefinition string `json:"english_definition,omitempty"`
+    Example           string `json:"example"`
+    English           string `json:"english"`
+    TargetTranslation string `json:"target_translation"`
+    Notes             string `json:"notes"`
+    Connotation       string `json:"connotation"`
+    Register          string `json:"register"`
+    Collocations      string `json:"collocations,omitempty"`
+    ContrastiveNotes  string `json:"contrastive_notes"`
+    SecondaryMeanings string `json:"secondary_meanings,omitempty"`
+    Tags              string `json:"tags,omitempty"`
+}
+
+// MapFields converts a ValidatedEntry to an output Entry,
+// flattening translation objects to "primary (alternatives)" strings.
+// Mode determines which fields are populated (words vs expressions).
+// Non-translation fields (including english_definition) are passed through as-is.
+func MapFields(v *language.ValidatedEntry, mode string) *Entry
+
+// FlattenTranslation converts a Translation to a display string.
+// {primary: "p", alternatives: "a"} → "p (a)" when a is non-empty, else "p".
+func FlattenTranslation(t language.Translation) string
+```
+
+```go
+// excel.go
+
+// ExportToExcel writes entries to an .xlsx file.
+// Uses excelize for pure-Go Excel generation.
+func ExportToExcel(entries []Entry, mode string) ([]byte, error)
+```
+
+### 6. `internal/db` — SQLite Storage and Cache
+
+```go
+// store.go
+
+// Store defines the database operations interface.
+// Using an interface here enables test doubles without a mocking framework.
+type Store interface {
+    // FindWord looks up a cached word entry by text and source language.
+    // Returns the first matching entry or nil. Retained for backward compatibility.
+    FindWord(ctx context.Context, word, sourceLang string) (*WordRow, error)
+
+    // FindExpression looks up a cached expression entry.
+    // Returns the first matching entry or nil. Retained for backward compatibility.
+    FindExpression(ctx context.Context, expr, sourceLang string) (*ExpressionRow, error)
+
+    // FindWords returns ALL matching word entries for a given word and source language.
+    // Returns an empty slice (not nil) when no entries exist.
+    // Used by the service layer for conflict-aware lookups (multi-version support).
+    FindWords(ctx context.Context, word, sourceLang string) ([]WordRow, error)
+
+    // FindExpressions returns ALL matching expression entries for a given expression and source language.
+    // Returns an empty slice (not nil) when no entries exist.
+    // Used by the service layer for conflict-aware lookups (multi-version support).
+    FindExpressions(ctx context.Context, expr, sourceLang string) ([]ExpressionRow, error)
+
+    // InsertWord stores a new word entry.
+    InsertWord(ctx context.Context, row *WordRow) error
+
+    // InsertExpression stores a new expression entry.
+    InsertExpression(ctx context.Context, row *ExpressionRow) error
+
+    // ListWords returns paginated word entries with optional filters.
+    ListWords(ctx context.Context, filter ListFilter) ([]WordRow, int, error)
+
+    // ListExpressions returns paginated expression entries with optional filters.
+    ListExpressions(ctx context.Context, filter ListFilter) ([]ExpressionRow, int, error)
+
+    // UpdateWord updates an existing word entry by ID.
+    // Used by the "replace" conflict resolution strategy to update a specific version.
+    UpdateWord(ctx context.Context, id int64, row *WordRow) error
+
+    // UpdateExpression updates an existing expression entry by ID.
+    // Used by the "replace" conflict resolution strategy to update a specific version.
+    UpdateExpression(ctx context.Context, id int64, row *ExpressionRow) error
+
+    // DeleteWord removes a word entry by ID.
+    DeleteWord(ctx context.Context, id int64) error
+
+    // DeleteExpression removes an expression entry by ID.
+    DeleteExpression(ctx context.Context, id int64) error
+
+    // BulkDeleteWords removes multiple word entries by IDs.
+    BulkDeleteWords(ctx context.Context, ids []int64) error
+
+    // BulkDeleteExpressions removes multiple expression entries by IDs.
+    BulkDeleteExpressions(ctx context.Context, ids []int64) error
+
+    // ImportWords bulk-inserts word rows, skipping duplicates.
+    ImportWords(ctx context.Context, rows []WordRow) (imported, skipped, failed int, err error)
+
+    // ImportExpressions bulk-inserts expression rows, skipping duplicates.
+    ImportExpressions(ctx context.Context, rows []ExpressionRow) (imported, skipped, failed int, err error)
+
+    // Close closes the database connection.
+    Close() error
+
+    // BackupTo copies the database file to the given path.
+    BackupTo(ctx context.Context, destPath string) error
+
+    // RestoreFrom replaces the current database with the file at srcPath.
+    // Creates a backup of the current DB before overwriting.
+    RestoreFrom(ctx context.Context, srcPath string) error
+}
+
+// ListFilter holds pagination and filter parameters for list queries.
+type ListFilter struct {
+    SourceLang string
+    TargetLang string
+    Search     string // matches against word/expression, definition, english
+    Page       int    // 1-based
+    PageSize   int    // default 50
+}
+```
+
+```go
+// sqlite.go
+
+// SQLiteStore implements Store using modernc.org/sqlite.
+type SQLiteStore struct {
+    db *sql.DB
+}
+
+// NewSQLiteStore opens (or creates) the SQLite database at the given path,
+// runs migrations, and returns a ready-to-use store.
+func NewSQLiteStore(dbPath string) (*SQLiteStore, error)
+```
+
+```go
+// schema.go
+
+// Migrate runs schema migrations up to the current version.
+// Each migration runs in a transaction — if it fails, the DB is unchanged.
+func (s *SQLiteStore) Migrate() error
+
+// Initial schema (version 1):
+// - words table with index on (source_language, word)
+// - expressions table with index on (source_language, expression)
+// - metadata table with schema_version
+```
+
+```go
+// models.go
+
+// WordRow represents a row in the words table.
+type WordRow struct {
+    ID                int64
+    Word              string
+    PartOfSpeech      string
+    Article           string
+    Definition        string
+    EnglishDefinition string
+    Example           string
+    English           string
+    TargetTranslation string
+    Notes             string
+    Connotation       string
+    Register          string
+    Collocations      string
+    ContrastiveNotes  string
+    SecondaryMeanings string
+    Tags              string // comma-separated tags
+    SourceLanguage    string
+    TargetLanguage    string
+    CreatedAt         string // RFC3339 timestamp
+    UpdatedAt         string
+}
+
+// ExpressionRow represents a row in the expressions table.
+type ExpressionRow struct {
+    ID                int64
+    Expression        string
+    Definition        string
+    EnglishDefinition string
+    Example           string
+    English           string
+    TargetTranslation string
+    Notes             string
+    Connotation       string
+    Register          string
+    ContrastiveNotes  string
+    Tags              string // comma-separated tags
+    SourceLanguage    string
+    TargetLanguage    string
+    CreatedAt         string
+    UpdatedAt         string
+}
+```
+
+### 7. `internal/config` — YAML Configuration
+
+```go
+// config.go
+
+// Config holds application settings persisted to ~/.vocabgen/config.yaml.
+// API keys are deliberately excluded — they come from env vars or CLI flags.
+type Config struct {
+    Provider              string `yaml:"provider"`
+    AWSProfile            string `yaml:"aws_profile,omitempty"`
+    AWSRegion             string `yaml:"aws_region"`
+    ModelID               string `yaml:"model_id,omitempty"`
+    BaseURL               string `yaml:"base_url,omitempty"`
+    GCPProject            string `yaml:"gcp_project,omitempty"`
+    GCPRegion             string `yaml:"gcp_region,omitempty"`
+    DefaultSourceLanguage string `yaml:"default_source_language"`
+    DefaultTargetLanguage string `yaml:"default_target_language"`
+    DBPath                string `yaml:"db_path"`
+}
+
+// DefaultConfig returns the default configuration.
+func DefaultConfig() Config {
+    return Config{
+        Provider:              "bedrock",
+        AWSRegion:             "us-east-1",
+        DefaultSourceLanguage: "nl",
+        DefaultTargetLanguage: "hu",
+        DBPath:                "~/.vocabgen/vocabgen.db",
+    }
+}
+
+// LoadConfig reads config from ~/.vocabgen/config.yaml.
+// Returns DefaultConfig() if the file doesn't exist.
+func LoadConfig() (Config, error)
+
+// SaveConfig writes config to ~/.vocabgen/config.yaml.
+// Creates the directory if it doesn't exist.
+// Never writes API keys to the file.
+func SaveConfig(cfg Config) error
+```
+
+### 8. `internal/web` — HTTP Handlers, Embedded Templates, and Web UI
+
+```go
+// server.go
+
+// Server holds the HTTP server and its dependencies.
+type Server struct {
+    store   db.Store
+    cfg     *config.Config
+    mux     *http.ServeMux
+    logger  *slog.Logger
+}
+
+// NewServer creates a Server with all routes registered.
+func NewServer(store db.Store, cfg *config.Config, logger *slog.Logger) *Server
+
+// ListenAndServe starts the HTTP server. Blocks until ctx is cancelled,
+// then performs graceful shutdown.
+func (s *Server) ListenAndServe(ctx context.Context, addr string) error
+```
+
+```go
+// templates.go
+
+//go:embed templates/*.html templates/partials/*.html
+var templateFS embed.FS
+
+// Templates are parsed once at startup from the embedded filesystem.
+```
+
+```go
+// routes.go — registered in NewServer
+
+// Page routes (serve HTML)
+// GET  /           → lookup page
+// GET  /batch      → batch page
+// GET  /config     → config page
+// GET  /database   → database page
+
+// API routes (JSON)
+// POST   /api/lookup          → single lookup
+// POST   /api/lookup/resolve  → resolve conflict after cache-bypass lookup
+// POST   /api/batch           → batch processing (multipart)
+// GET    /api/config          → read config
+// PUT    /api/config          → update config
+// GET    /api/languages       → list supported languages
+// GET    /api/health          → health check
+// POST   /api/test-connection → test provider connection
+// GET    /api/words           → list/search words (paginated)
+// GET    /api/expressions     → list/search expressions (paginated)
+// PUT    /api/words/{id}      → update word entry
+// PUT    /api/expressions/{id}→ update expression entry
+// DELETE /api/words/{id}      → delete word entry
+// DELETE /api/expressions/{id}→ delete expression entry
+// DELETE /api/words/bulk      → bulk delete word entries (JSON array of IDs)
+// DELETE /api/expressions/bulk→ bulk delete expression entries (JSON array of IDs)
+// POST   /api/import          → CSV import (multipart)
+// GET    /api/export          → Excel export
+
+// HTMX partial routes (return HTML fragments)
+// POST   /api/lookup/html     → lookup result partial (or conflict partial when cache bypass)
+// POST   /api/lookup/resolve/html → resolve conflict, return final lookup result partial
+// POST   /api/batch/html      → batch upload + start SSE stream
+// GET    /api/batch/stream     → SSE endpoint for batch progress
+// GET    /api/config/html     → config form partial
+```
+
+#### Web UI Architecture
+
+The web UI uses server-side rendering with Go `html/template` and HTMX for dynamic interactions. All templates and static assets are embedded in the binary via `go:embed`. No JavaScript build step, no external file dependencies.
+
+**Technology stack**: Go `html/template` + HTMX + Tailwind CSS (CDN)
+
+**How HTMX works** (for Go newcomers): HTMX adds attributes to HTML elements that trigger HTTP requests and swap the response HTML into the page. For example, `hx-post="/api/lookup/html"` sends a POST when a form is submitted, and `hx-target="#result"` replaces the content of the `#result` div with the server's HTML response. No JavaScript needed — the server returns HTML fragments, not JSON.
+
+#### Template File Structure
+
+```
+internal/web/templates/
+├── base.html              # Shared layout: <html>, <head>, nav bar, Tailwind CDN, HTMX CDN
+├── lookup.html            # Lookup page: form + result area
+├── batch.html             # Batch page: upload form + summary area
+├── config.html            # Config page: settings form + test connection
+├── database.html          # Database page: table + filters + search + pagination
+└── partials/
+    ├── lookup_result.html # HTMX partial: rendered vocabulary entry
+    ├── lookup_conflict.html # HTMX partial: side-by-side existing vs new entry with resolve buttons
+    ├── batch_summary.html # HTMX partial: processed/cached/failed/replaced/added counts + error list
+    ├── config_form.html   # HTMX partial: config form with current values
+    ├── entry_edit.html    # HTMX partial: edit form for a single vocabulary entry
+    └── entry_table.html   # HTMX partial: paginated table rows for database page
+```
+
+#### Template Inheritance Pattern
+
+Go `html/template` uses `{{define}}` and `{{template}}` for composition (not inheritance like Jinja2). The base layout defines named blocks that page templates fill in:
+
+```go
+// base.html defines the shell
+{{define "base"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <title>VocabGen — {{template "title" .}}</title>
+</head>
+<body class="bg-gray-50">
+    <nav><!-- Lookup | Batch | Config | Database --></nav>
+    <main class="max-w-4xl mx-auto p-6">
+        {{template "content" .}}
+    </main>
+</body>
+</html>
+{{end}}
+
+// lookup.html fills in the blocks
+{{define "title"}}Lookup{{end}}
+{{define "content"}}
+    <form hx-post="/api/lookup/html" hx-target="#result">
+        <!-- text input, language selectors, type selector, submit -->
+    </form>
+    <div id="result"><!-- HTMX swaps lookup_result.html here --></div>
+{{end}}
+```
+
+#### Page Designs
+
+**Lookup Page** (`/`)
+- Form: text input, source language dropdown, target language dropdown, lookup type radio (word/expression/sentence), optional context textarea, optional tags input
+- Submit triggers `hx-post="/api/lookup/html"` → server returns `lookup_result.html` partial
+- Loading: `hx-indicator="#lookup-spinner"` shows a spinner while the LLM request is in flight
+- Result area shows: word/expression, POS, article, definition, english definition (when non-empty), example, English translation, target translation, notes, connotation, register, collocations, contrastive notes
+- Error display: inline red alert if API returns error
+- Conflict resolution (when context sentence triggers cache bypass and existing entries found):
+  - The server returns a `lookup_conflict.html` partial instead of `lookup_result.html`
+  - Side-by-side display: existing entry/entries on the left, new LLM result on the right
+  - When multiple existing entries match, all are shown as a scrollable list on the left
+  - Action buttons below the comparison: "Replace" (with entry selector dropdown when multiple exist), "Add as New Version", "Skip"
+  - Each button triggers `hx-post="/api/lookup/resolve"` with the chosen strategy and target entry ID
+  - After resolution, the server returns the final `lookup_result.html` partial showing the saved entry
+
+**Batch Page** (`/batch`)
+- Form: CSV file upload, source language dropdown, target language dropdown, mode radio (words/expressions), optional tags input, conflict resolution dropdown (skip/replace/add, default: skip)
+- Submit triggers `hx-post="/api/batch/html"` with `hx-encoding="multipart/form-data"`
+- Server enforces 10 MB upload limit (HTTP 413 on exceed)
+- Progress: The batch endpoint uses Server-Sent Events (SSE) to stream real-time progress. The server sends events as each item completes:
+  ```
+  event: progress
+  data: {"processed": 5, "cached": 2, "failed": 0, "total": 100, "current": "uitkomen"}
+
+  event: complete
+  data: {"processed": 85, "cached": 12, "failed": 3, "total": 100, "errors": [...]}
+  ```
+- The Web_UI uses HTMX SSE extension (`hx-ext="sse"`, `sse-connect="/api/batch/stream"`) to update a progress bar and current-token display in real-time
+- On `complete` event, the progress area is replaced with the final `batch_summary.html` partial showing processed/cached/failed/replaced/added counts and failed items list
+- Cancellation: A Cancel button is shown during processing. Clicking it aborts the fetch via `AbortController`. The server detects `ctx.Err()` between items and stops processing. A `cancelled` SSE event is emitted with partial results. The Web_UI displays partial results with a cancellation notice.
+  ```
+  event: cancelled
+  data: {"processed": 30, "cached": 5, "failed": 1, "total": 100, "errors": [...]}
+  ```
+
+**Config Page** (`/config`)
+- Form fields: provider dropdown (bedrock/openai/anthropic/vertexai), conditional fields shown/hidden via HTMX:
+  - bedrock selected → show aws_profile, aws_region
+  - openai selected → show env var hint for OPENAI_API_KEY, base_url
+  - anthropic selected → show env var hint for ANTHROPIC_API_KEY
+  - vertexai selected → show gcp_project, gcp_region
+- Common fields: model_id, default_source_language, default_target_language
+- Read-only: database path
+- Save button → `hx-put="/api/config"` → inline success/error message
+- Test Connection button → `hx-post="/api/test-connection"` → inline result (uses API keys from env vars)
+- On save, validates that required env vars/credentials are available for the selected provider; shows error if missing
+
+**Database Page** (`/database`)
+- Filter bar: source language dropdown, target language dropdown, type radio (words/expressions), search text input (300ms debounce via `hx-trigger="keyup changed delay:300ms"`)
+- Table: paginated (50 rows/page), columns vary by type (word vs expression fields)
+- Multi-version indicator: entries sharing the same word/expression text are visually distinguished (e.g., POS badge or version count indicator) so the user can tell apart "werk (znw)" from "werk (ww)"
+- Total count display above table
+- Row click → `entry_edit.html` partial with pre-populated edit form
+- Edit form: save → `hx-put="/api/words/{id}"` or `hx-put="/api/expressions/{id}"`
+- Delete button with `hx-confirm="Are you sure?"` → `hx-delete="/api/words/{id}"`
+- Bulk delete: each row has a checkbox; a "select all" checkbox toggles all visible entries. When entries are selected, a bulk action bar appears with a Delete Selected button. Clicking it sends `DELETE /api/words/bulk` (or `/api/expressions/bulk`) with a JSON array of IDs. The table refreshes after deletion.
+- Import: CSV upload form (file, source_lang, target_lang, type) → `hx-post="/api/import"` → summary
+- Export: button → `GET /api/export?source_lang=...&type=...` → downloads .xlsx file
+- Export button disabled when no entries match current filters
+
+#### HTMX Interaction Patterns
+
+| User Action | HTMX Attribute | Server Endpoint | Response |
+|---|---|---|---|
+| Submit lookup form | `hx-post="/api/lookup/html"` | POST /api/lookup/html | `lookup_result.html` or `lookup_conflict.html` partial |
+| Resolve lookup conflict | `hx-post="/api/lookup/resolve"` | POST /api/lookup/resolve | `lookup_result.html` partial |
+| Upload batch CSV | `hx-post="/api/batch/html"` | POST /api/batch/html | Starts processing, returns SSE connection info |
+| Batch progress | `sse-connect="/api/batch/stream"` | GET /api/batch/stream | SSE events: progress, complete |
+| Save config | `hx-put="/api/config"` | PUT /api/config | `config_form.html` partial with success msg |
+| Test connection | `hx-post="/api/test-connection"` | POST /api/test-connection | Inline result text |
+| Search database | `hx-get="/api/words"` `hx-trigger="keyup changed delay:300ms"` | GET /api/words?search=... | `entry_table.html` partial |
+| Change page | `hx-get="/api/words?page=2"` | GET /api/words?page=2 | `entry_table.html` partial |
+| Click entry row | `hx-get="/api/words/{id}/edit"` | GET /api/words/{id}/edit | `entry_edit.html` partial |
+| Save entry edit | `hx-put="/api/words/{id}"` | PUT /api/words/{id} | Updated row HTML |
+| Delete entry | `hx-delete="/api/words/{id}"` `hx-confirm` | DELETE /api/words/{id} | Empty (row removed) |
+| Bulk delete | `hx-delete="/api/words/bulk"` `hx-confirm` | DELETE /api/words/bulk | Updated `entry_table.html` partial |
+| Import CSV | `hx-post="/api/import"` | POST /api/import | Import summary HTML |
+| Change provider | `hx-get="/api/config/html?provider=openai"` | GET /api/config/html | `config_form.html` with conditional fields |
+
+#### Navigation
+
+Shared nav bar in `base.html` with four links: Lookup (`/`), Batch (`/batch`), Config (`/config`), Database (`/database`). Active page highlighted via template data.
+
+### 9. `cmd/vocabgen` — CLI Entry Point
+
+```go
+// main.go
+
+func main() {
+    // rootCmd with persistent flags: --verbose, --provider, --region, --timeout, --tags, --version
+    // Subcommands: lookupCmd, batchCmd, serveCmd, backupCmd, restoreCmd, versionCmd
+    // Config loaded at PreRun; CLI flags override config values.
+    // Version injected via ldflags at build time.
+}
+
+// lookupCmd: vocabgen lookup "uitkomen" -l nl --type word --context "De waarheid komt altijd uit." --tags "chapter-3"
+// lookupCmd with conflict: vocabgen lookup "werk" -l nl --type word --context "Ik ga naar mijn werk." --on-conflict add
+// batchCmd:  vocabgen batch --input-file ch1.csv --mode words -l nl --tags "chapter-1"
+// batchCmd with conflict: vocabgen batch --input-file ch1.csv --mode words -l nl --on-conflict replace
+// serveCmd:  vocabgen serve --port 8080
+// backupCmd: vocabgen backup → copies vocabgen.db to vocabgen.db.2026-03-30T14-00-00.bak
+// restoreCmd: vocabgen restore ~/.vocabgen/vocabgen.db.2026-03-30T14-00-00.bak
+// versionCmd: vocabgen version → "vocabgen v1.0.0 (go1.22.0, built 2026-03-30)"
+```
+
+## Data Models
+
+### Unified Words JSON Schema
+
+The LLM returns JSON with these English field names. Required fields must be present; optional fields default to `""`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `word` | string | yes | Canonical form (infinitive/singular) |
+| `type` | string | yes | Native POS label (e.g., "znw", "főnév") |
+| `article` | string | yes | Article/gender marker, or "—" |
+| `definition` | string | yes | Definition in source language |
+| `english_definition` | string | no | Concise English-language explanation of meaning |
+| `example` | string | yes | Example sentence in source language |
+| `english` | string or object | yes | `{primary, alternatives}` or plain string |
+| `target_translation` | string or object | yes | `{primary, alternatives}` or plain string |
+| `notes` | string | no | Connotation notes, register, tone |
+| `connotation` | string | no | Emotional/evaluative association |
+| `register` | string | no | Native register label |
+| `collocations` | string | no | 2–4 common collocations, semicolon-separated |
+| `contrastive_notes` | string | no | Near-synonyms with difference explanation |
+| `secondary_meanings` | string | no | Additional meanings, semicolon-separated |
+
+### Unified Expressions JSON Schema
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `expression` | string | yes | The expression text |
+| `definition` | string | yes | Definition in source language |
+| `english_definition` | string | no | Concise English-language explanation of meaning |
+| `example` | string | yes | Example sentence in source language |
+| `english` | string or object | yes | `{primary, alternatives}` or plain string |
+| `target_translation` | string or object | yes | `{primary, alternatives}` or plain string |
+| `notes` | string | no | Connotation notes, register, tone |
+| `connotation` | string | no | Emotional/evaluative association |
+| `register` | string | no | Native register label |
+| `contrastive_notes` | string | no | Near-synonyms with difference explanation |
+
+### Translation Object
+
+Nested form: `{"primary": "main translation", "alternatives": "alt1; alt2"}`
+Plain string form: validator normalizes to `{"primary": "the string", "alternatives": ""}`
+
+### SQLite Schema (Version 1)
+
+Note: The words and expressions tables intentionally have no unique constraint on (source_language, word) or (source_language, expression). Multiple rows with the same word/expression and source_language are allowed to support multi-version entries (e.g., "werk" as noun vs. verb). The indexes on these columns are for query performance, not uniqueness.
+
+```sql
+CREATE TABLE IF NOT EXISTS metadata (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+-- Initial: INSERT INTO metadata (key, value) VALUES ('schema_version', '1');
+
+CREATE TABLE IF NOT EXISTS words (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    word                TEXT NOT NULL,
+    part_of_speech      TEXT,
+    article             TEXT,
+    definition          TEXT,
+    english_definition  TEXT,
+    example             TEXT,
+    english             TEXT,
+    target_translation  TEXT,
+    notes               TEXT,
+    connotation         TEXT,
+    register            TEXT,
+    collocations        TEXT,
+    contrastive_notes   TEXT,
+    secondary_meanings  TEXT,
+    tags                TEXT,
+    source_language     TEXT NOT NULL,
+    target_language     TEXT NOT NULL,
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_words_lang_word ON words(source_language, word);
+
+CREATE TABLE IF NOT EXISTS expressions (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    expression          TEXT NOT NULL,
+    definition          TEXT,
+    english_definition  TEXT,
+    example             TEXT,
+    english             TEXT,
+    target_translation  TEXT,
+    notes               TEXT,
+    connotation         TEXT,
+    register            TEXT,
+    contrastive_notes   TEXT,
+    tags                TEXT,
+    source_language     TEXT NOT NULL,
+    target_language     TEXT NOT NULL,
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_expr_lang_expr ON expressions(source_language, expression);
+```
+
+### Config YAML Schema
+
+```yaml
+provider: bedrock              # "bedrock", "openai", "anthropic", or "vertexai"
+aws_profile: ""                # AWS profile name (bedrock only)
+aws_region: us-east-1          # AWS region (bedrock only)
+model_id: ""                   # LLM model identifier
+base_url: ""                   # Custom API endpoint (openai only)
+gcp_project: ""                # GCP project ID (vertexai only)
+gcp_region: us-central1        # GCP region (vertexai only)
+default_source_language: nl    # Default source language code
+default_target_language: hu    # Default target language code
+db_path: ~/.vocabgen/vocabgen.db
+```
+
+Note: `api_key` is deliberately absent — sourced from env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) or `--api-key` CLI flag at runtime.
+
+### Supported Languages Registry
+
+```go
+var SupportedLanguages = map[string]string{
+    "nl": "Dutch",    "hu": "Hungarian", "it": "Italian",
+    "ru": "Russian",  "en": "English",   "de": "German",
+    "fr": "French",   "es": "Spanish",   "pt": "Portuguese",
+    "pl": "Polish",   "tr": "Turkish",
+}
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Template formatting produces valid prompts for any source language
+
+*For any* source language name string (including known codes like "nl" and arbitrary names like "German" or "日本語"), formatting either the words or expressions template with valid parameters (token, context, target_language_name) should produce a string that: contains the resolved source language name, contains the token value, contains the target language name, contains no unresolved `{...}` placeholders, contains the Core Rule Block text, and contains the Decision Rubric text.
+
+**Validates: Requirements 1.10, 2.9, 4.5**
+
+### Property 2: Translation field normalization
+
+*For any* translation value that is either a plain string or a JSON object with `primary` (string) and optional `alternatives` (string) keys, the Validator should normalize it to an object with exactly two keys: `primary` (string) and `alternatives` (string, defaulting to `""` if absent). When the input is a plain string `s`, the output should be `{"primary": s, "alternatives": ""}`.
+
+**Validates: Requirements 3.3, 3.4**
+
+### Property 3: Optional fields default to empty string
+
+*For any* valid JSON response where a random subset of optional fields (`notes`, `connotation`, `register`, `collocations`, `contrastive_notes`, `secondary_meanings`, `english_definition`) is absent, the Validator should succeed and the returned struct should contain those fields with value `""`.
+
+**Validates: Requirements 3.5, 52.1, 52.4**
+
+### Property 4: Missing required fields and malformed values return validation error
+
+*For any* non-empty subset of required fields removed from an otherwise valid JSON response, the Validator should return an error and the error message should mention every missing field name. Additionally, non-string values for optional fields and malformed translation fields (neither string nor valid object with string `primary`) should also return a validation error.
+
+**Validates: Requirements 3.6, 3.7, 3.8, 3.9**
+
+### Property 5: BuildPrompt injects all parameters into output
+
+*For any* source language (known code or arbitrary name), mode ("words" or "expressions"), token string, context string, and target language code, `BuildPrompt` should return a string containing the resolved source language name, the token, the context (when non-empty), and the resolved target language name.
+
+**Validates: Requirements 6.1–6.6, 42.1–42.4**
+
+### Property 6: CSV parsing
+
+*For any* list of CSV lines (some empty, some containing data), the input parser should return exactly the non-empty lines as (token, context) pairs. Two-column lines return both token and context; single-column lines return token with empty context.
+
+**Validates: Requirements 14.2, 14.5, 14.6**
+
+### Property 7: Field mapper pass-through preserves non-translation fields
+
+*For any* validated entry with English field names (as returned by the Validator), the Field_Mapper should return an output entry where every non-translation field value equals the corresponding input field value.
+
+**Validates: Requirement 5.1**
+
+### Property 8: Translation flattening
+
+*For any* Translation struct `{Primary: p, Alternatives: a}` where `p` and `a` are strings, `FlattenTranslation` should return `"p (a)"` when `a` is non-empty, and `p` when `a` is empty. For a plain string input `s`, it should return `s`.
+
+**Validates: Requirements 5.2, 5.5**
+
+### Property 9: Validation accepts any valid English-schema JSON
+
+*For any* JSON object containing all required English field names with string values (and translation fields as string or valid object), the Validator should succeed for the matching mode and return a struct with all schema fields present. A synthetically generated valid JSON response should pass through `ValidateResponse` then `MapFields` without returning any error.
+
+**Validates: Requirements 3.1, 3.2, 43.10**
+
+### Property 10: Token normalization consistency (idempotence)
+
+*For any* input token (word or expression), normalizing the token should strip quotes, collapse whitespace, and strip leading/trailing whitespace, producing a consistent canonical form. Normalizing an already-normalized token should produce the same result (i.e., `Normalize(Normalize(x)) == Normalize(x)`).
+
+**Validates: Requirements 15.1–15.4, 16.1–16.3**
+
+### Property 11: Database cache idempotency
+
+*For any* input token, looking it up twice through the service layer (with a mocked provider and real SQLite store) should result in exactly one LLM invocation and one cache hit. The returned data should be identical for both calls.
+
+**Validates: Requirements 18.1–18.4, 19.1–19.4**
+
+### Property 12: UTF-8 round-trip consistency
+
+*For any* text containing special characters (ë, ï, ü, ő, ű, à, è, ì, ò, ù, я, ё, etc.), writing to the SQLite database then reading back should preserve the exact character sequence.
+
+**Validates: Requirements 39.1, 39.2**
+
+### Property 13: Dry-run no side effects
+
+*For any* input token list, running `ProcessBatch` in dry-run mode should not invoke the LLM provider, not write to the database, and not modify any persistent state. The provider's `Invoke` method should be called zero times.
+
+**Validates: Requirements 37.1–37.4**
+
+### Property 14: Config file round-trip
+
+*For any* valid Config struct (with non-sensitive fields only), saving via `SaveConfig` then loading via `LoadConfig` should produce a struct equal to the original.
+
+**Validates: Requirements 34.1, 34.2**
+
+### Property 15: Limit enforcement
+
+*For any* limit value N and input with M tokens (M > N, no cached items), `ProcessBatch` should invoke the LLM provider for at most N tokens.
+
+**Validates: Requirement 23.6**
+
+### Property 16: Error resilience
+
+*For any* list of tokens where a mocked provider fails on a known subset and succeeds on the rest, `ProcessBatch` should return results for all successful tokens and errors for all failed tokens. The count of results plus errors should equal the count of non-empty, non-cached input tokens (up to the limit).
+
+**Validates: Requirement 36.3**
+
+### Property 17: Provider interface consistency
+
+*For any* provider implementation (including test doubles), `Invoke` should return either a non-empty string with nil error, or an empty string with a non-nil error — never both nil, never a non-empty string with a non-nil error. The `Name()` method should return a non-empty string. Any error returned should be wrappable as a `*ProviderError` containing the provider name.
+
+**Validates: Requirements 7.2, 7.3, 13.1, 13.4**
+
+### Property 18: Multi-version entry integrity
+
+*For any* word/expression with N existing entries in the Database (N ≥ 1), applying the "add" conflict resolution strategy with a new LLM result should result in exactly N+1 entries, with the new entry inserted and all existing entries unchanged. Applying the "replace" strategy targeting entry ID K should result in exactly N entries, with entry K updated to the new data and all other entries unchanged. Applying the "skip" strategy should result in exactly N entries with no modifications. The `FindWords`/`FindExpressions` functions should return all N entries for a given word and source_language, and an empty slice when no entries exist.
+
+**Validates: Requirements 53.1, 53.4, 54.1, 57.1, 57.2, 57.3, 19.5, 19.6, 19.7**
+
+### Property 19: Context-aware cache bypass
+
+*For any* word/expression with at least one existing entry in the Database, a lookup with an empty context sentence should return the cached entry without invoking the LLM provider (provider invocation count = 0). A lookup with a non-empty context sentence should invoke the LLM provider exactly once regardless of the cache state (provider invocation count = 1). When no existing entry exists, a lookup with or without context should invoke the LLM provider exactly once and insert the result. In all cases, the final database state should be consistent with the selected conflict resolution strategy.
+
+**Validates: Requirements 55.1, 55.2, 55.3, 18.6**
+
+## Error Handling
+
+### Error Types
+
+```go
+// internal/llm/errors.go
+type ProviderError struct {
+    Provider string // "bedrock", "openai", "anthropic"
+    Message  string
+    Err      error
+}
+
+// internal/language/errors.go
+type ValidationError struct {
+    Message string
+    Fields  []string
+}
+```
+
+All provider errors wrap `ProviderError`, enabling callers to use `errors.As(&ProviderError{})` for unified error handling regardless of which provider failed.
+
+### Error Categories and Behavior
+
+```mermaid
+graph TD
+    ERR["Error Occurs"] --> AUTH{"Auth Error?"}
+    AUTH -->|Yes| EXIT["Exit non-zero<br/>Suggest corrective action"]
+    AUTH -->|No| INPUT{"Input Error?"}
+    INPUT -->|Yes| EXIT
+    INPUT -->|No| PROC{"Processing Error?<br/>(LLM / Validation)"}
+    PROC -->|Yes| LOG["Log error<br/>Continue batch<br/>Add to errors list"]
+    PROC -->|No| DB{"DB Error?"}
+    DB -->|Yes| EXIT
+    LOG --> SUMMARY["Include in summary report"]
+```
+
+| Category | Examples | Behavior |
+|---|---|---|
+| Authentication | Missing API key, expired AWS creds, invalid profile | Fail fast, exit non-zero, suggest fix |
+| Input | File not found, empty file, invalid mode | Fail fast, exit non-zero |
+| LLM invocation | Throttling, timeout, empty response | Log, retry once, continue batch on failure |
+| Validation | Invalid JSON, missing required fields, wrong types | Log, continue batch, add to errors |
+| Database | SQLite open failure, migration error | Fail fast, exit non-zero |
+| Config | YAML parse error, directory creation failure | Fail fast with defaults or exit |
+
+### Retry Logic
+
+- Bedrock: retry once on throttling/timeout errors (1 second delay)
+- OpenAI: retry once on HTTP 429 rate-limit (1 second delay)
+- Anthropic: retry once on HTTP 429 rate-limit (1 second delay)
+- All other errors: no retry
+
+### API Error Response Format
+
+All HTTP error responses use a consistent JSON envelope:
+
+```json
+{"detail": "Human-readable, actionable error message"}
+```
+
+HTTP status codes:
+- `400` — bad request (invalid input, missing fields, unsupported mode)
+- `413` — request entity too large (batch upload > 10 MB)
+- `500` — internal server error (DB failure, unexpected error)
+- `502` — bad gateway (LLM provider failure, validation failure)
+
+### Logging Strategy
+
+Uses `log/slog` with structured fields. No `fmt.Println` in production code.
+
+| Level | What gets logged |
+|---|---|
+| DEBUG | Prompts sent to LLM, raw LLM responses (only with `--verbose`) |
+| INFO | Processed items, cache hits/misses, progress, summaries |
+| ERROR | Auth failures, LLM errors, validation errors, DB errors |
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+The test suite uses two complementary strategies:
+
+1. **Property-based tests** (`rapid`): Verify universal properties across randomly generated inputs. Each property test runs a minimum of 100 iterations. These catch edge cases that example-based tests miss.
+2. **Table-driven unit tests**: Verify specific known inputs, edge cases, and error conditions. These document expected behavior for concrete scenarios.
+
+Both are necessary — property tests provide breadth, unit tests provide documentation and specific regression coverage.
+
+### Property-Based Testing Configuration
+
+- Library: `pgregory.net/rapid`
+- Minimum iterations: 100 per property (rapid's default is higher, which is fine)
+- Each test function is tagged with a comment referencing the design property
+- Tag format: `// Feature: go-vocabulary-generator, Property N: <title>`
+- Each correctness property is implemented by a single `rapid.Check` call
+
+### Property Test Plan
+
+| Property | Package | Test Function | Generator Strategy |
+|---|---|---|---|
+| P1: Template formatting | `language` | `TestPropertyTemplateFormatting` | `rapid.String()` for language names, tokens, context |
+| P2: Translation normalization | `language` | `TestPropertyTranslationNormalization` | `rapid.OneOf(rapid.String(), translationObjectGen)` |
+| P3: Optional field defaults | `language` | `TestPropertyOptionalFieldDefaults` | Valid JSON with random subset of optional fields (including `english_definition`) removed |
+| P4: Required field validation | `language` | `TestPropertyRequiredFieldValidation` | Valid JSON with random non-empty subset of required fields removed |
+| P5: BuildPrompt injection | `language` | `TestPropertyBuildPromptInjection` | `rapid.String()` for all params, `rapid.SampledFrom([]string{"words","expressions"})` for mode |
+| P6: CSV parsing | `parsing` | `TestPropertyCSVParsing` | Generate CSV lines: mix of empty and data lines, single/two-column |
+| P7: Field mapper pass-through | `output` | `TestPropertyFieldMapperPassThrough` | Generate `ValidatedEntry` structs with random field values |
+| P8: Translation flattening | `output` | `TestPropertyTranslationFlattening` | `rapid.String()` for primary and alternatives |
+| P9: Validation round-trip | `language` | `TestPropertyValidationRoundTrip` | Generate complete valid JSON objects with all required English fields |
+| P10: Token normalization idempotence | `parsing` | `TestPropertyTokenNormalization` | `rapid.String()` with quotes, spaces, parentheses mixed in |
+| P11: Cache idempotency | `service` | `TestPropertyCacheIdempotency` | Random tokens with a mock provider counting invocations + real SQLite |
+| P12: UTF-8 round-trip | `db` | `TestPropertyUTF8RoundTrip` | `rapid.String()` including Unicode ranges for special chars |
+| P13: Dry-run no side effects | `service` | `TestPropertyDryRunNoSideEffects` | Random token lists with a mock provider that panics if called |
+| P14: Config round-trip | `config` | `TestPropertyConfigRoundTrip` | Generate random Config structs with valid field values |
+| P15: Limit enforcement | `service` | `TestPropertyLimitEnforcement` | Random limit N, token list of size M > N, counting mock provider |
+| P16: Error resilience | `service` | `TestPropertyErrorResilience` | Random token list, mock provider that fails on a random subset |
+| P17: Provider consistency | `llm` | `TestPropertyProviderConsistency` | Test against mock provider implementation |
+| P18: Multi-version entry integrity | `service` | `TestPropertyMultiVersionIntegrity` | Generate random entry counts N, insert N entries, apply each strategy (add/replace/skip), verify DB state via `FindWords`/`FindExpressions` |
+| P19: Context-aware cache bypass | `service` | `TestPropertyContextCacheBypass` | Generate random tokens, insert existing entries, call `Lookup` with/without context, count mock provider invocations, verify DB state |
+
+### Table-Driven Unit Tests
+
+| Area | Package | What's Tested |
+|---|---|---|
+| Language resolution | `language` | Known codes (nl→Dutch, hu→Hungarian, etc.), unknown codes pass through |
+| Template content | `language` | Templates contain expected field names, rubric text, placeholders |
+| Schema content | `language` | Schemas contain exactly the expected required/optional fields |
+| BuildPrompt mode | `language` | Words mode selects words template, expressions selects expressions, invalid mode returns error |
+| Normalization edge cases | `parsing` | Nested parentheses, mixed quotes, whitespace-only input, empty string |
+| CSV edge cases | `parsing` | File not found, empty file, BOM handling, single-column, two-column |
+| Config defaults | `config` | LoadConfig returns defaults when file missing |
+| Config no secrets | `config` | SaveConfig does not write api_key to YAML |
+| DB schema | `db` | Tables and indexes exist after migration |
+| DB multi-version | `db` | FindWords returns all entries for same word; FindWords returns empty slice for non-existent word; FindWord returns first entry (backward compat) |
+| Conflict resolution | `service` | ParseConflictStrategy accepts "replace"/"add"/"skip", rejects invalid values |
+| Lookup with conflict | `service` | Lookup with context + existing entry returns NeedsResolution=true; Lookup without context returns cached entry |
+| Batch with conflict | `service` | Batch with --on-conflict=replace updates entries; --on-conflict=add inserts new rows; --on-conflict=skip discards |
+| Provider registry | `llm` | Registry contains bedrock, openai, anthropic, vertexai entries |
+| Error formatting | `llm` | ProviderError includes provider name in message |
+| CLI flags | `cmd` | Required flags enforced, defaults applied, --on-conflict flag accepted, help output |
+
+### Integration Tests
+
+Uses `httptest` for web endpoints and mock providers (Go interfaces, no mocking framework).
+
+| Test | What's Verified |
+|---|---|
+| Full lookup flow | CLI → service.Lookup → mock provider → validate → map → DB insert |
+| Lookup with context bypass | Lookup with context + existing entry → LLM invoked → conflict result returned → resolve with each strategy |
+| Batch with cache | Process tokens, re-process same tokens, verify cache hits |
+| Batch with context + conflict | Process tokens with context sentences and existing entries, verify --on-conflict strategies applied correctly |
+| Web API lookup | POST /api/lookup → JSON response with vocabulary entry |
+| Web API lookup conflict | POST /api/lookup with context + existing entry → conflict response → POST /api/lookup/resolve → resolved entry |
+| Web API batch | POST /api/batch → multipart upload → JSON summary with replaced/added counts |
+| Web API config | GET/PUT /api/config round-trip |
+| Web API health | GET /api/health → 200 {"status": "ok"} |
+| Graceful shutdown | Start server, send SIGINT, verify in-flight requests complete |
+
+### Test File Organization
+
+Tests are co-located with source files (`*_test.go` alongside implementation):
+
+```
+internal/
+├── language/
+│   ├── templates.go
+│   ├── templates_test.go      # P1, P5 + template content unit tests
+│   ├── validation.go
+│   ├── validation_test.go     # P2, P3, P4, P9 + schema unit tests
+│   └── registry_test.go       # Language resolution unit tests
+├── parsing/
+│   ├── csv.go
+│   ├── csv_test.go            # P6 + CSV edge case unit tests
+│   ├── normalize.go
+│   └── normalize_test.go      # P10 + normalization edge case unit tests
+├── output/
+│   ├── mapper.go
+│   └── mapper_test.go         # P7, P8 + flattening unit tests
+├── service/
+│   ├── service.go
+│   └── service_test.go        # P11, P13, P15, P16 + integration tests
+├── db/
+│   ├── sqlite.go
+│   └── sqlite_test.go         # P12 + schema/migration unit tests
+├── config/
+│   ├── config.go
+│   └── config_test.go         # P14 + defaults/secrets unit tests
+├── llm/
+│   ├── provider.go
+│   ├── mock_test.go           # Mock provider for testing (unexported)
+│   └── provider_test.go       # P17 + registry unit tests
+└── web/
+    ├── handlers.go
+    └── handlers_test.go       # Integration tests with httptest
+```
+
+### Mock Provider for Testing
+
+Instead of a mocking framework, a simple mock struct implements the `Provider` interface:
+
+```go
+// internal/llm/mock_test.go (test-only, unexported)
+
+type mockProvider struct {
+    name        string
+    response    string
+    err         error
+    invocations int // counts Invoke calls for P11, P13, P15, P19
+}
+
+func (m *mockProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error) {
+    m.invocations++
+    return m.response, m.err
+}
+
+func (m *mockProvider) Name() string { return m.name }
+```
+
+For P16 (error resilience), a variant mock that fails on specific tokens:
+
+```go
+type failingMockProvider struct {
+    failTokens map[string]bool
+    response   string
+    invocations int
+}
+```
+
+For P18 and P19 (multi-version and cache bypass), the `mockProvider` is used with a real temp SQLite store. The test pre-inserts N entries for a word, then calls `Lookup`/`ProcessBatch` and verifies the invocation count and final DB state via `FindWords`/`FindExpressions`.
+
+### Fuzz Testing
+
+Go's built-in fuzz testing (`func FuzzXxx(f *testing.F)`) is used for edge case discovery on:
+
+- `ValidateResponse` — fuzz with random JSON strings to find panics or unexpected errors
+- `NormalizeWord` / `NormalizeExpression` — fuzz with random strings to find panics
+- `FlattenTranslation` — fuzz with random Translation structs
+
+Fuzz tests complement property tests: property tests verify correctness invariants, fuzz tests discover crashes and panics on adversarial input.
+
+## Named Config Profiles (Issue #23)
+
+### Overview
+
+Extend `internal/config` to support named profiles within `~/.vocabgen/config.yaml`. Each profile holds a complete provider configuration. Users switch profiles via `--profile <name>` on the CLI or a dropdown in the Web UI.
+
+### Config File Format
+
+```yaml
+# Multi-profile format (new)
+default_profile: local
+
+profiles:
+  local:
+    provider: openai
+    base_url: http://localhost:11434/v1
+    model_id: mistral
+  sandbox:
+    provider: bedrock
+    aws_region: eu-west-1
+    model_id: anthropic.claude-3-haiku-20240307-v1:0
+  prod:
+    provider: bedrock
+    aws_region: us-east-1
+    model_id: us.anthropic.claude-sonnet-4-20250514-v1:0
+```
+
+```yaml
+# Flat format (existing, backward compatible — treated as implicit "default" profile)
+provider: bedrock
+aws_region: us-east-1
+default_source_language: nl
+default_target_language: hu
+db_path: ~/.vocabgen/vocabgen.db
+```
+
+### Data Model Changes
+
+```go
+// internal/config/config.go
+
+// ProfileConfig holds provider-related fields for a named profile.
+type ProfileConfig struct {
+    Provider   string `yaml:"provider"`
+    AWSProfile string `yaml:"aws_profile,omitempty"`
+    AWSRegion  string `yaml:"aws_region,omitempty"`
+    ModelID    string `yaml:"model_id,omitempty"`
+    BaseURL    string `yaml:"base_url,omitempty"`
+    GCPProject string `yaml:"gcp_project,omitempty"`
+    GCPRegion  string `yaml:"gcp_region,omitempty"`
+}
+
+// FileConfig represents the multi-profile YAML structure.
+type FileConfig struct {
+    DefaultProfile        string                    `yaml:"default_profile,omitempty"`
+    Profiles              map[string]ProfileConfig  `yaml:"profiles,omitempty"`
+    DefaultSourceLanguage string                    `yaml:"default_source_language"`
+    DefaultTargetLanguage string                    `yaml:"default_target_language"`
+    DBPath                string                    `yaml:"db_path"`
+}
+
+// Config remains the flat runtime struct consumed by the rest of the app.
+// LoadConfig and LoadConfigWithProfile resolve a profile into this struct.
+```
+
+### Key Functions
+
+```go
+// LoadConfigWithProfile loads config and resolves the named profile.
+// Returns error if profile doesn't exist.
+func LoadConfigWithProfile(profileName string) (Config, error)
+
+// ListProfiles returns available profile names and the default profile name.
+func ListProfiles() (profiles []string, defaultProfile string, err error)
+```
+
+### CLI Flag Changes
+
+| Old Flag | New Flag | Purpose |
+|----------|----------|---------|
+| `--profile` | `--aws-profile` | AWS credential profile for Bedrock |
+| (new) | `--profile` | Config profile name (resolves from `profiles:` map) |
+
+### Key Functions (continued)
+
+```go
+// CreateProfile creates a new named profile by copying values from an existing
+// source profile. Returns error if the new name already exists or the source
+// profile is not found. Converts flat configs to multi-profile format if needed.
+func CreateProfile(newName, sourceProfile string) error
+```
+
+### Web UI Changes
+
+- `GET /api/profiles` — returns `{profiles: [...], active: "..."}` JSON
+- `PUT /api/profile/switch` — switches the active profile, reloads in-memory config
+- `POST /api/profiles` — creates a new profile (form fields: `name`, `source_profile`); copies source profile values as defaults, saves to config file, returns HTML snippet confirming creation
+- `config_form.html` — profile selector dropdown is **always visible** (even with a single profile), showing the active profile name. Includes an "Add new profile…" option at the end of the dropdown. When selected, an inline form appears (text input for profile name + "Create" button). On submit, `POST /api/profiles` creates the profile, then the form reloads via HTMX to show the new profile as active.
+
+#### Profile Selector Behavior
+
+1. Dropdown always rendered (no `{{if gt (len .Profiles) 1}}` guard)
+2. Options: all existing profile names + a separator + "Add new profile…"
+3. Selecting an existing profile triggers `PUT /api/profile/switch` + form reload (existing behavior)
+4. Selecting "Add new profile…" shows an inline `<div>` with a text input and "Create" / "Cancel" buttons (JS toggle, no server round-trip to show the form)
+5. "Create" submits `POST /api/profiles` with `name` (user input) and `source_profile` (previously active profile)
+6. On success, the config form reloads with the new profile active
+7. On error (duplicate name, empty name), an error message appears inline
+
+#### `CreateProfile` Logic
+
+1. Read existing config file
+2. If flat format, convert to `FileConfig` with a single `default` profile first
+3. Check if `newName` already exists in `Profiles` map — return error if so
+4. Copy `sourceProfile` values into `Profiles[newName]`
+5. Set `DefaultProfile` to `newName`
+6. Save via `SaveFileConfig`
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Profile scope | Provider fields only | Source/target language and DB path are user-level, not per-profile |
+| Backward compat | Flat format = implicit `default` profile | Existing users don't need to change anything |
+| `--profile` reuse | Rename AWS flag to `--aws-profile` | `--profile` is the natural name for config profiles; AWS profile is less commonly used |
+| Profile storage | Single `config.yaml` file | Solo developer scale — no need for separate files per profile |
+| Profile selector visibility | Always visible | Single-profile users should see which profile is active; hiding the dropdown removes context |
+| Add profile UX | Inline form in dropdown | No modal dialogs or multi-step wizards; pragmatic for solo developer tool |
+| New profile defaults | Copy from active profile, clear ModelID | Provider settings are copied as a starting point; ModelID is cleared because model IDs are provider-specific and not portable |
+
+## One-Click Local LLM Setup (Issue #22)
+
+### Overview
+
+Provide a turnkey Ollama setup via `scripts/setup-local-llm.sh` (CLI) and a Web UI button on the config page (SSE endpoint). Eliminates the API key / provider configuration barrier for non-technical users.
+
+### Shell Script: `scripts/setup-local-llm.sh`
+
+```bash
+#!/usr/bin/env bash
+# One-click local LLM setup via Ollama.
+# Detects OS, installs Ollama if needed, pulls model, writes config.
+
+# Steps:
+# 1. Detect OS (macOS/Linux) via uname
+# 2. Check if ollama is installed (command -v ollama)
+# 3. Install if missing (macOS: brew or curl; Linux: curl installer)
+# 4. Check if Ollama server is running (curl localhost:11434/api/tags)
+# 5. Start if not running (ollama serve &, wait for ready)
+# 6. Pull recommended model (ollama pull mistral)
+# 7. Verify model responds (quick test via OpenAI-compatible endpoint)
+# 8. Write ~/.vocabgen/config.yaml with local profile
+# 9. Print success message
+```
+
+### Web UI: SSE Setup Endpoint
+
+```go
+// internal/web/handlers_setup.go
+
+// handleSetupLocalLLM streams setup progress via SSE.
+// Runs the same logic as the shell script using os/exec.
+func (s *Server) handleSetupLocalLLM(w http.ResponseWriter, r *http.Request)
+```
+
+Route: `GET /api/setup/local-llm`
+
+Template: `partials/setup_local_llm.html` — progress log area with SSE-driven updates, triggered by "Setup Local LLM" button on config page.
+
+### Ollama Detection in Provider Validation
+
+When `provider: openai` and `base_url` contains `localhost:11434`, `validateProviderEnv` checks Ollama reachability instead of requiring `OPENAI_API_KEY`. This allows the config page to show a green status for local Ollama setups.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Default model | `mistral` | Good balance of quality and size for B2-C1 vocabulary tasks |
+| Install method | OS-specific (brew/curl) | Standard Ollama installation paths |
+| Config write | Writes `local` profile into multi-profile format | Integrates with config profiles (#23) |
+| Windows support | Out of scope for shell script | Shell script targets macOS/Linux; Windows users can install Ollama manually |
+
+## E2E Tests Default to Local LLM (Issue #24)
+
+### Overview
+
+Update `scripts/e2e-test.sh` to default to `--profile local` (Ollama) instead of cloud providers. Add `-p PROFILE` flag and `E2E_PROFILE` env var for override.
+
+### Script Changes
+
+```bash
+# New flag parsing (added to existing getopts)
+PROFILE="${E2E_PROFILE:-local}"
+while getopts "s:p:" opt; do
+    case $opt in
+        s) SECTION="$OPTARG" ;;
+        p) PROFILE="$OPTARG" ;;
+    esac
+done
+
+# Pre-flight: Ollama reachability check (when profile is "local")
+if [ "$PROFILE" = "local" ]; then
+    if ! curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; then
+        echo "ERROR: Ollama is not running."
+        echo "Start it with: ollama serve"
+        echo "Or run: scripts/setup-local-llm.sh"
+        exit 1
+    fi
+fi
+
+# Pre-flight: profile existence check
+if ! $BINARY lookup --profile "$PROFILE" --help > /dev/null 2>&1; then
+    echo "ERROR: Profile '$PROFILE' not found in config."
+    echo "Run scripts/setup-local-llm.sh or use -p <profile>"
+    exit 1
+fi
+
+# All LLM-dependent invocations use --profile instead of --model-id
+$BINARY lookup "fiets" -l nl --profile "$PROFILE" $DB
+```
+
+### Makefile Change
+
+```makefile
+e2e:
+	E2E_PROFILE=$(E2E_PROFILE) ./scripts/e2e-test.sh
+```
+
+### Sections Unaffected
+
+Section 11 (Update Checker) builds a separate binary with fake version and doesn't use LLM calls — no profile changes needed.
+
+### Dependency Order
+
+1. Requirement 58 (Config Profiles) must be implemented first — `--profile` flag must exist
+2. Requirement 59 (Local LLM Setup) should be implemented second — creates the `local` profile
+3. Requirement 60 (E2E Local Default) is implemented last — depends on both #58 and #59
+
+## Docker Image Distribution (Requirement 65)
+
+### Overview
+
+Publish multi-arch Docker images to GitHub Container Registry (`ghcr.io/npozs77/vocabgen`) alongside binary releases. No Go code changes — purely infra/config/docs.
+
+### Dockerfile
+
+Multi-stage build: `golang:1.22-alpine` builder → `gcr.io/distroless/static:nonroot` runtime.
+
+```dockerfile
+# Build stage
+FROM golang:1.22-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+ARG VERSION=dev
+COPY . .
+RUN cp CHANGELOG.md docs/changelog.md
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION} -X main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o /vocabgen ./cmd/vocabgen
+
+# Runtime stage
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /vocabgen /vocabgen
+VOLUME /home/nonroot/.vocabgen
+ENV HOME=/home/nonroot
+EXPOSE 8080
+ENTRYPOINT ["/vocabgen"]
+CMD ["serve", "--port", "8080"]
+```
+
+Key decisions:
+- `distroless/static:nonroot` — minimal attack surface, no shell, runs as UID 65534
+- `VERSION` build arg — goreleaser passes the release version at build time
+- `VOLUME /home/nonroot/.vocabgen` — persists config.yaml and vocabgen.db
+- Default CMD is `serve --port 8080` — users can override with any CLI subcommand
+
+### goreleaser Integration
+
+Two `dockers` entries (amd64, arm64) using buildx, plus `docker_manifests` for multi-arch manifest lists:
+
+```yaml
+dockers:
+  - image_templates: ["ghcr.io/npozs77/vocabgen:{{ .Version }}-amd64"]
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates: ["--platform=linux/amd64", "--build-arg=VERSION={{ .Version }}"]
+    goarch: amd64
+    goos: linux
+  - image_templates: ["ghcr.io/npozs77/vocabgen:{{ .Version }}-arm64"]
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates: ["--platform=linux/arm64", "--build-arg=VERSION={{ .Version }}"]
+    goarch: arm64
+    goos: linux
+
+docker_manifests:
+  - name_template: "ghcr.io/npozs77/vocabgen:{{ .Version }}"
+    image_templates: ["...-amd64", "...-arm64"]
+  - name_template: "ghcr.io/npozs77/vocabgen:latest"
+    image_templates: ["...-amd64", "...-arm64"]
+```
+
+### CI/CD Changes
+
+`release.yml` additions (before goreleaser step):
+- `packages: write` permission for GHCR push
+- `docker/login-action@v3` for GHCR authentication
+- `docker/setup-buildx-action@v3` for multi-platform builds
+- `docker/setup-qemu-action@v3` for arm64 emulation on amd64 runners
+
+### Build Context
+
+`.dockerignore` excludes: `.git`, `.github`, `.kiro`, `.vscode`, `reference/`, `coverage.out`, `dist/`, `vocabgen` (local binary).
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `Dockerfile` | New — multi-stage build |
+| `.dockerignore` | New — build context optimization |
+| `.goreleaser.yaml` | Added `dockers` + `docker_manifests` sections |
+| `.github/workflows/release.yml` | Added GHCR auth, Buildx, QEMU steps |
+| `README.md` | Added Docker section |
+| `docs/deployment.md` | Rewrote Docker section with GHCR details |
+| `docs/user-guide.md` | Added Docker installation option |
+| `CHANGELOG.md` | Added Docker entry to 1.2.2 |
+
+
+## Feature: Database Picker and Live Database Switching (#76)
+
+### Overview
+
+The Config page includes a server-side rendered dropdown listing all `.db` files in the config directory. Users can select an existing database or create a new one. Database switches take effect immediately — no server restart needed.
+
+### Components
+
+**`GET /api/databases`** — Scans config directory for `*.db` files, returns JSON array of filenames.
+
+**Server-side dropdown** — The `handleConfigHTML` and `handleSwitchProfile` handlers pass a `Databases []string` field (full paths) to the `config_form` template. The template renders `<option>` elements directly, plus a "Create new…" sentinel option.
+
+**`switchDatabase(newPath string)`** — Method on `Server` that closes the current `db.Store` and opens a new `SQLiteStore` at the given path. Called from `handlePutConfig` and `handleSwitchProfile` when the DB path changes.
+
+**New DB creation** — When `db_path_new_name` is submitted, the handler validates the name (alphanumeric + hyphens/underscores), checks for conflicts with existing files, creates the empty file via `os.Create`, and saves the path to config.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Dropdown rendering | Server-side | HTMX 2.x event API is fragile for JSON parsing; server-side is simpler and more reliable |
+| DB switch | Live (no restart) | Single-user tool — no concurrency concern, better UX |
+| File creation | On save | File must exist for it to appear in the dropdown on next page load |
+
+## Feature: Multiple Meanings / Skip-Cache Lookup (#86)
+
+### Overview
+
+Supports storing multiple meanings for the same headword as separate database rows. A "Skip cache / Add new meaning" mechanism bypasses the cache, requires a context sentence, invokes the LLM for a single specific meaning, and inserts it as a new row. Disambiguation suffixes (`word (1)`, `word (2)`) are applied at display time when 2+ entries exist.
+
+### Components
+
+**`LookupParams.SkipCache`** — When true, the service layer skips the cache check entirely, invokes the LLM with the provided context, and inserts the result as a new row (no conflict resolution). Context is required.
+
+**`--new-meaning` CLI flag** — Sets `SkipCache: true` on `LookupParams`. Validates that `--context` is also provided.
+
+**Web UI checkbox** — "Skip cache / Add new meaning" checkbox on the lookup form. When checked, JavaScript makes the context textarea required. The form sends `skip_cache=on`.
+
+**`DisambiguatedWord(word, index, total)`** — Pure function in `internal/service/disambiguation.go`. Returns `word` when `total <= 1`, or `word (N)` when `total > 1`.
+
+**`disambiguateWords` / `disambiguateExpressions`** — Helpers in `internal/web/disambiguation.go` that count occurrences per headword (case-insensitive) in a result slice and apply `DisambiguatedWord` in-place before template rendering. Applied in: database browser, flashcards, XLSX export.
+
+**Batch support** — `BatchParams.SkipCache` applies the same bypass logic per token. Tokens without context are skipped when skip-cache is active.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Storage model | Same table, multiple rows | No schema migration needed — `FindWords` already returns `[]WordRow` |
+| Disambiguation | Display-layer only | Never modifies stored data; applied before template rendering |
+| Suffix format | `word (N)` | Simple, unambiguous, matches issue spec |
+| Context requirement | Enforced client + server | Prevents accidental duplicate entries without disambiguation context |
+
+### Correctness Properties
+
+- **P18: Disambiguation suffix** — For any word with N meanings (N > 1), all N entries display correct `(1)...(N)` suffixes. Single-meaning words have no suffix.
+- **P67.1–P67.4** — See Requirements 67 properties.

--- a/.kiro/specs/go-vocabulary-generator/requirements.md
+++ b/.kiro/specs/go-vocabulary-generator/requirements.md
@@ -1,0 +1,1212 @@
+# Requirements Document: Go Vocabulary Generator
+
+## Introduction
+
+The Go Vocabulary Generator is a single-binary, multi-platform CLI and web application that automates the creation of structured, nuanced vocabulary lists (B2→C1 level) for language learners. It consolidates vocabulary generation, modular LLM providers, SQLite database storage, and an embedded web UI into one cohesive Go application.
+
+The application uses two unified, language-agnostic prompt templates (words and expressions) parameterized by `{source_language}`, plus a dedicated sentence template for grammar checking and vocabulary extraction, with English JSON field names throughout. The LLM provides native POS labels, register labels, and grammatical categories for each language. Translations are connotation-aware, preserving register and tone via a Core Rule Block and Decision Rubric embedded in each prompt.
+
+Key technical direction: Go with Cobra CLI, embedded web UI via `go:embed` + `net/http`, LLM provider interface (starting with Bedrock, designed for OpenAI/Anthropic/Ollama), SQLite for persistent storage, single binary distribution via cross-compilation, and table-driven tests with `rapid` (Go PBT library) for correctness properties.
+
+## Glossary
+
+- **App**: The Go Vocabulary Generator single-binary application
+- **CLI**: The Cobra-based command-line interface
+- **Web_UI**: The embedded web interface served via `go:embed` + `net/http`, using Go `html/template` and HTMX
+- **Provider**: An LLM API backend that receives prompts and returns text responses (e.g., AWS Bedrock, OpenAI, Anthropic, Ollama)
+- **Provider_Interface**: A Go interface defining the contract all provider implementations must satisfy (client creation, prompt invocation, provider name)
+- **Bedrock_Provider**: Provider implementation for AWS Bedrock
+- **OpenAI_Provider**: Provider implementation for the OpenAI API, also compatible with OpenAI-compatible local servers (Ollama, LM Studio) via custom base URL
+- **Anthropic_Provider**: Provider implementation for the Anthropic Claude direct API
+- **Vertex_AI_Provider**: Provider implementation for Google Vertex AI (Gemini, PaLM, Claude on Vertex)
+- **Provider_Registry**: A map from provider name strings to provider constructor functions
+- **Database**: SQLite file-based database stored at a configurable path (default: `~/.vocabgen/vocabgen.db`)
+- **Word_Entry**: A row in the words table containing vocabulary data plus metadata (source_language, target_language, created_at, updated_at)
+- **Expression_Entry**: A row in the expressions table containing vocabulary data plus metadata
+- **Cache_Layer**: Logic that checks the Database for an existing entry before invoking the LLM provider, returning the cached result when found; bypasses the cache when a context sentence is provided for an existing entry
+- **Conflict_Resolution_Strategy**: The user-selected action when a new LLM result conflicts with an existing database entry: "replace" (update existing), "add" (insert alongside), or "skip" (discard new result)
+- **Input_File**: CSV file containing raw words or expressions in the source language
+- **Prompt_Template**: A parameterized Go string constant sent to the LLM containing instructions for vocabulary generation, with `{source_language}`, `{word}`/`{expression}`, `{context}`, and `{target_language_name}` placeholders
+- **Words_Template**: The unified prompt template for individual word lookups
+- **Expressions_Template**: The unified prompt template for fixed expressions and idioms
+- **Sentence_Template**: The dedicated prompt template for sentence lookups, focused on grammar checking, vocabulary extraction, and contextual analysis (not treating the input as a fixed expression)
+- **English_Schema**: The set of English JSON field names used in LLM responses for words (`word`, `type`, `article`, `definition`, `english_definition`, `example`, `english`, `target_translation`, `notes`, `connotation`, `register`, `collocations`, `contrastive_notes`, `secondary_meanings`), expressions (`expression`, `definition`, `english_definition`, `example`, `english`, `target_translation`, `notes`, `connotation`, `register`, `contrastive_notes`), and sentences (`sentence`, `translation`, `grammar_check`, `vocabulary`)
+- **English_Definition**: An optional field containing an explanation of the word or expression's meaning in English prose (not a translation, but a definition/explanation), supplementing the source-language `definition` field for learners who are not yet advanced enough to fully understand the source-language definition
+- **Validator**: The function that validates LLM JSON responses against English schemas
+- **Field_Mapper**: The function that maps validated JSON to output structs, flattening nested translations
+- **Source_Language**: The language being learned, resolved from the supported languages registry or passed as free-text via CLI
+- **Target_Language**: The user's native language for the second translation column
+- **Supported_Languages**: Single shared registry (Go map) mapping language codes to full names, used for both source and target language selection
+- **Core_Rule_Block**: Instruction section within prompts stating connotation/register/tone preservation principles
+- **Decision_Rubric**: Prioritized criteria for choosing between candidate translations (connotation → register → comprehensibility)
+- **Config_Manager**: Module that reads and writes a local YAML configuration file storing default settings
+- **Config_File**: A YAML file (`~/.vocabgen/config.yaml`) that persists user preferences between sessions
+- **CSV_Importer**: Component that reads CSV files and inserts rows into the Database
+- **Excel_Exporter**: Component that writes Database query results to an .xlsx file for download
+- **Database_Page**: A page in the Web_UI at `/database` for browsing, searching, editing, importing, and exporting vocabulary entries
+- **Store**: Go interface defining all database operations, enabling test doubles without mocking frameworks
+
+## Requirements
+### Requirement 1: Unified Words Prompt Template
+
+**User Story:** As a developer, I want a single words prompt template as a Go string constant parameterized by source language, so that adding new source languages requires zero template changes.
+
+#### Acceptance Criteria
+
+1. WHEN the Words_Template is defined, THE Words_Template SHALL be a Go string constant containing a `{source_language}` placeholder for the source language name (e.g., "Dutch", "Hungarian")
+2. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to return JSON with English field names: `word`, `type`, `article`, `definition`, `english_definition`, `example`, `english`, `target_translation`, `notes`, `connotation`, `register`, `collocations`, `contrastive_notes`, `secondary_meanings`
+3. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to use the source language's standard abbreviated POS label in the `type` field (e.g., "znw", "ww", "bn" for Dutch; "főnév", "ige" for Hungarian) without hardcoding them in the template; when no standard abbreviation exists for a language, the LLM SHALL use the shortest conventional form
+4. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to use the source language's native register labels in the `register` field without hardcoding them in the template
+5. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to provide the `definition` and `example` fields in the source language
+6. WHEN the Words_Template is defined, THE Words_Template SHALL contain `{word}` and `{context}` placeholders for the input token and optional context sentence
+7. WHEN the Words_Template is defined, THE Words_Template SHALL contain `{target_language_name}` placeholder for the target translation language name
+8. WHEN the Words_Template is defined, THE Words_Template SHALL include the Core_Rule_Block and Decision_Rubric
+9. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to return `english` and `target_translation` as objects with `primary` and `alternatives` keys (semicolon-separated alternatives)
+10. WHEN the Words_Template is formatted with any source language name, THE Words_Template SHALL produce a valid prompt that generates correct vocabulary data for that language
+11. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to populate the `connotation` field with a short description of the emotional or evaluative association of the source word
+12. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to list two to four common collocations separated by semicolons in the `collocations` field
+13. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to name one or two near-synonyms and briefly explain how they differ in the `contrastive_notes` field
+14. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to list additional distinct meanings separated by semicolons in the `secondary_meanings` field, or leave empty when the word has only one meaning
+15. WHEN the Words_Template is defined, THE Words_Template SHALL instruct the LLM to provide an `english_definition` field containing a concise English-language explanation of the word's meaning, distinct from the `english` translation field
+
+#### Properties
+
+- P1.1: Template formatting produces valid prompts for any source language name (Req 1, AC 10)
+- P1.2: Formatted template contains no unresolved `{...}` placeholders (Req 1, AC 10)
+- P1.3: Formatted template contains Core Rule Block and Decision Rubric text (Req 1, AC 8)
+
+### Requirement 2: Unified Expressions Prompt Template
+
+**User Story:** As a developer, I want a single expressions prompt template as a Go string constant parameterized by source language, so that expression processing works identically across all languages.
+
+#### Acceptance Criteria
+
+1. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL be a Go string constant containing a `{source_language}` placeholder for the source language name
+2. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL instruct the LLM to return JSON with English field names: `expression`, `definition`, `english_definition`, `example`, `english`, `target_translation`, `notes`, `connotation`, `register`, `contrastive_notes`
+3. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL instruct the LLM to use the source language's native register labels in the `register` field without hardcoding them in the template
+4. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL instruct the LLM to provide the `definition` and `example` fields in the source language
+5. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL contain `{expression}` and `{context}` placeholders for the input token and optional context sentence
+6. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL contain `{target_language_name}` placeholder for the target translation language name
+7. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL include the Core_Rule_Block and Decision_Rubric
+8. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL instruct the LLM to return `english` and `target_translation` as objects with `primary` and `alternatives` keys (semicolon-separated alternatives)
+9. WHEN the Expressions_Template is formatted with any source language name, THE Expressions_Template SHALL produce a valid prompt that generates correct vocabulary data for that language
+10. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL instruct the LLM to populate the `connotation` field with a short description of the emotional or evaluative association
+11. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL instruct the LLM to name one or two near-synonyms and briefly explain how they differ in the `contrastive_notes` field
+12. WHEN the Expressions_Template is defined, THE Expressions_Template SHALL instruct the LLM to provide an `english_definition` field containing a concise English-language explanation of the expression's meaning, distinct from the `english` translation field
+
+#### Properties
+
+- P2.1: Template formatting produces valid prompts for any source language name (Req 2, AC 9)
+- P2.2: Formatted template contains no unresolved `{...}` placeholders (Req 2, AC 9)
+### Requirement 3: JSON Validation with English Schemas
+
+**User Story:** As a developer, I want a single JSON validation function per mode using English field names, so that validation logic is language-agnostic.
+
+#### Acceptance Criteria
+
+1. WHEN the Validator receives a words JSON response, THE Validator SHALL validate against a single words schema with English field names: `word` (string, required), `type` (string, required), `article` (string, required), `definition` (string, required), `english_definition` (string, optional), `example` (string, required), `english` (string or object, required), `target_translation` (string or object, required), `notes` (string, optional), `connotation` (string, optional), `register` (string, optional), `collocations` (string, optional), `contrastive_notes` (string, optional), `secondary_meanings` (string, optional)
+2. WHEN the Validator receives an expressions JSON response, THE Validator SHALL validate against a single expressions schema with English field names: `expression` (string, required), `definition` (string, required), `english_definition` (string, optional), `example` (string, required), `english` (string or object, required), `target_translation` (string or object, required), `notes` (string, optional), `connotation` (string, optional), `register` (string, optional), `contrastive_notes` (string, optional)
+3. WHEN the Validator receives `english` or `target_translation` fields, THE Validator SHALL accept either a plain string or a JSON object with `primary` and `alternatives` keys
+4. WHEN a plain string is provided for `english` or `target_translation`, THE Validator SHALL normalize it into an object with `primary` set to the string and `alternatives` set to empty string
+5. WHEN an optional field is absent from the response, THE Validator SHALL default it to empty string
+6. WHEN a required field is missing, THE Validator SHALL return an error listing the missing fields
+7. WHEN an optional field is present but has a non-string value, THE Validator SHALL return an error
+8. WHEN a translation field contains a nested object, THE Validator SHALL verify that `primary` is a string and `alternatives` is a string when present
+9. IF a translation field contains neither a string nor a valid object with a string `primary` key, THEN THE Validator SHALL return an error identifying the malformed field
+10. WHEN the Validator receives a sentence JSON response, THE Validator SHALL validate against the sentence schema with English field names: `sentence` (string, required), `translation` (string, required), `grammar_check` (object, required — containing `has_errors` boolean, `corrected_sentence` string, `errors` array of objects with `original`, `corrected`, `explanation` strings), `vocabulary` (array, required — each item with `word`, `type`, `definition`, `english` strings)
+
+#### Properties
+
+- P3.1: Translation field normalization produces consistent object format (Req 3, AC 3–4)
+- P3.2: Optional fields default to empty string when absent (Req 3, AC 5)
+- P3.3: Missing required fields return validation error listing all missing fields (Req 3, AC 6)
+- P3.4: Any valid English-schema JSON passes validation without error (Req 3, AC 1–2)
+
+### Requirement 4: Language Configuration
+
+**User Story:** As a developer, I want a minimal language configuration using Go maps and constants, so that the codebase has no per-language duplication and new languages need only a registry entry.
+
+#### Acceptance Criteria
+
+1. WHEN the App is compiled, THE App SHALL contain exactly 3 prompt template constants: one for words, one for expressions, and one for sentences
+2. WHEN the App is compiled, THE App SHALL contain exactly 3 JSON schema definitions (as Go structs or maps): one for words, one for expressions, and one for sentences
+3. WHEN the App is compiled, THE App SHALL NOT contain per-language prompt template constants
+4. WHEN a source language has no entry in Supported_Languages, THE prompt builder function SHALL still generate a valid prompt using the language name directly
+5. WHEN the App is compiled, THE App SHALL contain a single Supported_Languages map (Go `map[string]string`) mapping language codes to full names, used for both source and target language resolution
+
+### Requirement 5: Field Mapping and Translation Flattening
+
+**User Story:** As a developer, I want a language-agnostic field mapper that passes through English fields and flattens nested translations, so that the service layer has no per-language branches.
+
+#### Acceptance Criteria
+
+1. WHEN the LLM returns JSON with English field names, THE Field_Mapper SHALL pass through the fields directly without language-specific mapping
+2. WHEN the Field_Mapper receives nested translation objects (`english` and `target_translation`), THE Field_Mapper SHALL flatten them from `{primary} (alternatives)` format to a single string for output
+3. WHEN the Field_Mapper processes any input, THE Field_Mapper SHALL NOT contain separate code branches for individual languages
+4. WHEN the Field_Mapper processes any source language, THE Field_Mapper SHALL work identically without code changes
+5. WHEN the Field_Mapper receives both flat string and nested object translation fields, THE Field_Mapper SHALL handle both without errors
+
+#### Properties
+
+- P5.1: Field mapper pass-through preserves non-translation fields (Req 5, AC 1)
+- P5.2: Translation flattening produces correct format for objects and strings (Req 5, AC 2, 5)
+### Requirement 6: Prompt Builder Function
+
+**User Story:** As a developer, I want a `BuildPrompt` function that accepts a source language name or code and injects all parameters into the template, so that any language can be used without pre-registration.
+
+#### Acceptance Criteria
+
+1. WHEN a source language name or code is provided, THE `BuildPrompt` function SHALL accept it as a parameter
+2. WHEN a known language code is provided (nl, hu, it, ru, etc.), THE `BuildPrompt` function SHALL resolve the code to the full language name
+3. WHEN an unknown language code or name is provided, THE `BuildPrompt` function SHALL use the provided value directly as the source language name in the prompt
+4. WHEN a mode parameter is provided, THE `BuildPrompt` function SHALL select the words, expressions, or sentence template based on the mode parameter
+5. WHEN all parameters are provided, THE `BuildPrompt` function SHALL inject `source_language`, `word`/`expression`, `context`, and `target_language_name` into the template
+6. WHEN an optional `context` parameter is provided, THE `BuildPrompt` function SHALL inject it into the prompt template
+7. WHEN an invalid mode value is provided, THE `BuildPrompt` function SHALL return an error
+
+#### Properties
+
+- P6.1: BuildPrompt injects all parameters into output for any source language, mode, token, context, and target language (Req 6, AC 1–6)
+- P6.2: BuildPrompt returns error for invalid mode values (Req 6, AC 7)
+
+### Requirement 7: LLM Provider Interface
+
+**User Story:** As a developer, I want a common Go interface for LLM providers, so that I can add new providers without modifying calling code.
+
+#### Acceptance Criteria
+
+1. WHEN a provider is invoked, THE Provider_Interface SHALL define a method to invoke the provider with a `context.Context`, a prompt string, and a model ID, returning a response string and an error
+2. WHEN a provider name is requested, THE Provider_Interface SHALL define a method to return the provider name as a string identifier
+3. WHEN a provider receives a successful response, THE provider SHALL extract the text content and return it as a string, stripping any provider-specific envelope
+4. IF a provider returns an empty or missing text response, THEN THE provider SHALL return a descriptive error
+5. WHEN a new provider struct implements the Provider_Interface, THE Provider_Interface SHALL require no changes to service layer call sites
+6. WHEN a provider is constructed, THE provider SHALL be constructed via a dedicated constructor function (e.g., `NewBedrockProvider(...)`) that returns a concrete struct satisfying the Provider_Interface, following the Go convention of "accept interfaces, return structs"
+
+#### Properties
+
+- P7.1: Provider interface consistency — invoking with same prompt and model returns string or error, never both nil; name returns non-empty string (Req 7, AC 1–2, 4)
+
+### Requirement 8: Bedrock Provider Implementation
+
+**User Story:** As a user, I want the existing Bedrock functionality as a provider implementation, so that current workflows work from day one.
+
+#### Acceptance Criteria
+
+1. WHEN the Bedrock_Provider is used, THE Bedrock_Provider SHALL implement the Provider_Interface
+2. WHEN the Bedrock_Provider is configured, THE Bedrock_Provider SHALL accept AWS credentials and region for client creation
+3. WHEN the Bedrock_Provider is invoked, THE Bedrock_Provider SHALL support Claude and Cohere model families via the Bedrock Runtime API
+4. WHEN the Bedrock_Provider encounters throttling or timeout errors, THE Bedrock_Provider SHALL retry up to a configurable maximum
+5. WHEN the Bedrock_Provider is selected, THE App SHALL require AWS authentication (profile or default credential chain)
+6. WHEN the Bedrock_Provider creates a client, THE Bedrock_Provider SHALL validate that the specified region supports Bedrock before creating a client
+
+### Requirement 9: OpenAI Provider Implementation
+
+**User Story:** As a user, I want to use OpenAI/ChatGPT models or OpenAI-compatible local servers (Ollama, LM Studio), so that I can choose a different LLM backend including self-hosted models.
+
+#### Acceptance Criteria
+
+1. WHEN the OpenAI_Provider is used, THE OpenAI_Provider SHALL implement the Provider_Interface
+2. WHEN the OpenAI_Provider authenticates, THE OpenAI_Provider SHALL use an API key sourced from an environment variable or CLI flag
+3. WHEN no API key is available and no custom base URL is set, THE OpenAI_Provider SHALL return a descriptive authentication error before attempting invocation
+4. WHEN a model is specified, THE OpenAI_Provider SHALL support specifying an OpenAI model name (e.g., "gpt-4o", "gpt-4o-mini") via the `--model-id` flag
+5. WHEN the OpenAI_Provider encounters rate-limit errors, THE OpenAI_Provider SHALL retry up to a configurable maximum
+6. WHEN a base URL is configured, THE OpenAI_Provider SHALL accept an optional base URL via the `--base-url` CLI flag or the `OPENAI_BASE_URL` environment variable to target OpenAI-compatible servers
+7. WHEN a custom base URL is provided, THE OpenAI_Provider SHALL use that URL instead of the default OpenAI API endpoint
+8. WHEN a custom base URL is provided and no API key is set, THE OpenAI_Provider SHALL allow invocation without an API key
+9. WHEN configured with a compatible endpoint, THE OpenAI_Provider SHALL be compatible with Azure OpenAI Service, Ollama (`http://localhost:11434/v1`), LM Studio, vLLM, and any other server implementing the OpenAI chat completions API
+
+### Requirement 10: Anthropic Provider Implementation
+
+**User Story:** As a user, I want to use the Anthropic Claude API directly, so that I can access Claude models without going through AWS Bedrock.
+
+#### Acceptance Criteria
+
+1. WHEN the Anthropic_Provider is used, THE Anthropic_Provider SHALL implement the Provider_Interface
+2. WHEN the Anthropic_Provider authenticates, THE Anthropic_Provider SHALL use an API key sourced from an environment variable or CLI flag
+3. WHEN no API key is available, THE Anthropic_Provider SHALL return a descriptive authentication error before attempting invocation
+4. WHEN a model is specified, THE Anthropic_Provider SHALL support specifying an Anthropic model name (e.g., "claude-sonnet-4-20250514") via the `--model-id` flag
+5. WHEN the Anthropic_Provider encounters rate-limit errors, THE Anthropic_Provider SHALL retry up to a configurable maximum
+### Requirement 11: Provider Selection and Registry
+
+**User Story:** As a user, I want to select the LLM provider at runtime via a CLI flag, so that I can switch providers without changing code.
+
+#### Acceptance Criteria
+
+1. WHEN the CLI is invoked, THE CLI SHALL accept a `--provider` flag with valid values including "bedrock", "openai", "anthropic", and "vertexai"
+2. WHEN no `--provider` flag is specified, THE CLI SHALL default to "bedrock"
+3. WHEN an unsupported provider name is specified, THE CLI SHALL display an error listing valid provider names and exit with a non-zero code
+4. WHEN the Provider_Registry is queried, THE Provider_Registry SHALL map string identifiers to their corresponding provider constructor functions
+5. WHEN a new provider is added, THE Provider_Registry SHALL require only adding a new entry to the map and the provider implementation file
+
+### Requirement 12: Provider-Specific Authentication
+
+**User Story:** As a user, I want each provider to handle its own authentication method, so that I only need to configure credentials for the provider I am using.
+
+#### Acceptance Criteria
+
+1. WHEN the "bedrock" provider is selected, THE App SHALL use the AWS authentication flow (profile or default credential chain)
+2. WHEN the "openai" provider is selected, THE App SHALL accept an API key via the `--api-key` flag or the `OPENAI_API_KEY` environment variable
+3. WHEN the "anthropic" provider is selected, THE App SHALL accept an API key via the `--api-key` flag or the `ANTHROPIC_API_KEY` environment variable
+4. IF both `--api-key` and the corresponding environment variable are set, THEN THE App SHALL prefer the `--api-key` flag value
+5. WHEN the "bedrock" provider is selected, THE App SHALL ignore the `--api-key` flag
+6. WHEN the "openai" or "anthropic" provider is selected, THE App SHALL ignore the `--profile` flag
+7. WHEN the "vertexai" provider is selected, THE App SHALL use Google Application Default Credentials and accept a project ID via `--gcp-project` or `GCP_PROJECT` environment variable
+
+### Requirement 13: Error Handling Across Providers
+
+**User Story:** As a user, I want clear error messages regardless of which provider fails, so that I can diagnose and fix issues quickly.
+
+#### Acceptance Criteria
+
+1. WHEN a provider invocation fails, THE provider SHALL return an error that includes the provider name and a descriptive message
+2. WHEN authentication fails for a provider, THE provider SHALL return an error that specifies which credential is missing or invalid
+3. IF a provider encounters a rate-limit error and retries are exhausted, THEN THE provider SHALL return an error indicating throttling and the number of retries attempted
+4. WHEN errors are returned by any provider, THE error types SHALL be wrappable by a single sentinel error type in calling code
+
+### Requirement 14: Parse Input CSV Files
+
+**User Story:** As a language learner, I want the app to parse raw word lists from CSV files, so that I can process vocabulary from my textbook chapters.
+
+#### Acceptance Criteria
+
+1. WHEN an input file is provided, THE App SHALL read the file using UTF-8 encoding
+2. WHEN an input line is empty or whitespace-only, THE App SHALL skip the line
+3. WHEN an input file does not exist, THE App SHALL exit with a non-zero exit code and error message
+4. WHEN an input file is empty after skipping blank lines, THE App SHALL exit with an error message
+5. WHEN an input CSV has two columns, THE App SHALL treat the second column as the context sentence for each word or expression
+6. WHEN an input CSV has a single column, THE App SHALL work without errors
+7. WHEN an input CSV is parsed, THE App SHALL treat all non-empty lines as data rows (no header detection or skipping)
+
+#### Properties
+
+- P14.1: CSV parsing returns exactly the non-empty lines as (token, context) pairs; two-column lines return both, single-column lines return token with empty context (Req 14, AC 2, 5–7)
+
+### Requirement 15: Normalize Word Tokens
+
+**User Story:** As a language learner, I want the app to extract canonical word forms, so that my vocabulary list contains clean lemmas.
+
+#### Acceptance Criteria
+
+1. WHEN a word token contains quotes, THE App SHALL remove the quotes
+2. WHEN a word token contains multiple spaces, THE App SHALL normalize to single spaces
+3. WHEN a word token contains parentheses with inflection info (no commas), THE App SHALL preserve the parenthetical content (e.g., `(ergens)`, `(zich)`)
+4. WHEN a word token is processed, THE App SHALL strip leading and trailing whitespace
+5. WHEN a word token contains digits or special characters (anything other than letters, spaces, hyphens, apostrophes, or parentheses), THE App SHALL reject the token with an error before invoking the LLM provider
+6. WHEN a word token contains vocabulary-list markers (`*` prefix/suffix, `>` prefix, `(sep.)` annotation), THE App SHALL strip these markers before processing
+7. WHEN a word token contains conjugation annotations (parenthetical groups with commas, e.g., `(kwam uit, is uitgekomen)`), THE App SHALL strip these annotations before processing
+8. WHEN a word token starts with a Dutch article (`de`, `het`, `een`), THE App SHALL strip the article since it is stored in a separate database field
+
+#### Properties
+
+- P15.1: Token normalization is idempotent — normalizing an already-normalized token produces the same result (Req 15, AC 1–4, 6–8)
+- P15.2: Words containing digits or special characters are rejected before LLM invocation (Req 15, AC 5)
+- P15.3: Vocabulary-list markers and leading articles are stripped from word tokens (Req 15, AC 6–8)
+
+### Requirement 16: Normalize Expression Tokens
+
+**User Story:** As a language learner, I want the app to clean expression text, so that my vocabulary list contains properly formatted expressions.
+
+#### Acceptance Criteria
+
+1. WHEN an expression token contains quotes, THE App SHALL remove the quotes
+2. WHEN an expression token contains multiple spaces, THE App SHALL normalize to single spaces
+3. WHEN an expression token is empty after normalization, THE App SHALL skip the token
+4. WHEN an expression token contains vocabulary-list markers (`*` prefix/suffix, `>` prefix, `(sep.)` annotation), THE App SHALL strip these markers before processing
+5. WHEN an expression token contains conjugation annotations (parenthetical groups with commas), THE App SHALL strip these annotations before processing
+
+#### Properties
+
+- P16.1: Token normalization is idempotent — normalizing an already-normalized expression produces the same result (Req 16, AC 1–2, 4–5)
+- P16.2: Vocabulary-list markers are stripped from expression tokens (Req 16, AC 4–5)
+### Requirement 17: SQLite Database Schema and Initialization
+
+**User Story:** As a developer, I want a structured SQLite database with separate tables for words and expressions, so that I can store and query vocabulary data efficiently.
+
+#### Acceptance Criteria
+
+1. WHEN the application starts, THE Database SHALL create the SQLite file and tables if they do not already exist
+2. WHEN storing word entries, THE Database SHALL store Word_Entry rows in a `words` table with columns: id (INTEGER PRIMARY KEY AUTOINCREMENT), word (TEXT NOT NULL), part_of_speech (TEXT), article (TEXT), definition (TEXT), english_definition (TEXT), example (TEXT), english (TEXT), target_translation (TEXT), notes (TEXT), connotation (TEXT), register (TEXT), collocations (TEXT), contrastive_notes (TEXT), secondary_meanings (TEXT), tags (TEXT), source_language (TEXT NOT NULL), target_language (TEXT NOT NULL), created_at (TEXT NOT NULL), updated_at (TEXT NOT NULL)
+3. WHEN storing expression entries, THE Database SHALL store Expression_Entry rows in an `expressions` table with columns: id (INTEGER PRIMARY KEY AUTOINCREMENT), expression (TEXT NOT NULL), definition (TEXT), english_definition (TEXT), example (TEXT), english (TEXT), target_translation (TEXT), notes (TEXT), connotation (TEXT), register (TEXT), contrastive_notes (TEXT), tags (TEXT), source_language (TEXT NOT NULL), target_language (TEXT NOT NULL), created_at (TEXT NOT NULL), updated_at (TEXT NOT NULL)
+4. WHEN the Database is initialized, THE Database SHALL create an index on (source_language, word) in the words table and (source_language, expression) in the expressions table
+5. WHEN the Database path is resolved, THE Database SHALL use the path configured in Config_Manager, defaulting to `~/.vocabgen/vocabgen.db`
+
+### Requirement 18: Cache Layer for LLM Lookups
+
+**User Story:** As a user, I want the system to check the database before calling the LLM provider, so that I save time and API costs on words already processed.
+
+#### Acceptance Criteria
+
+1. WHEN a lookup request is received and no context sentence is provided, THE Cache_Layer SHALL query the Database for a matching entry (by word/expression text and source_language) before invoking the LLM provider
+2. WHEN a matching entry exists in the Database and no context sentence is provided, THE Cache_Layer SHALL return the cached result without calling the LLM provider
+3. WHEN no matching entry exists in the Database, THE Cache_Layer SHALL invoke the LLM provider, store the result in the Database, and return the result
+4. WHEN a batch process runs, THE Cache_Layer SHALL check each token against the Database before invoking the LLM provider for that token
+5. WHEN a lookup is served, THE Cache_Layer SHALL log whether each lookup was served from cache or from the LLM provider
+6. WHEN a lookup request is received with a context sentence and a matching entry already exists in the Database, THE Cache_Layer SHALL invoke the LLM provider (bypassing the cache) and return the new result alongside the existing entry metadata, so the user can decide how to handle the conflict
+7. WHEN multiple entries exist for the same word/expression and source_language, THE Cache_Layer `FindWords`/`FindExpressions` functions SHALL return all matching entries as a slice
+
+#### Properties
+
+- P18.1: Database cache idempotency — looking up a token twice results in one LLM invocation and one cache hit with identical data (Req 18, AC 1–4)
+
+### Requirement 19: LLM Results Integration with Database
+
+**User Story:** As a user, I want LLM lookup results to be automatically saved to the database, so that my vocabulary collection grows with each query.
+
+#### Acceptance Criteria
+
+1. WHEN a single lookup returns a result from the LLM provider and no existing entry conflicts, THE App SHALL insert the result into the Database
+2. WHEN a batch process completes, THE App SHALL insert all successful results into the Database
+3. WHEN an entry is inserted, THE App SHALL record the source_language and target_language for each inserted entry
+4. WHEN an entry is inserted, THE App SHALL set created_at and updated_at timestamps on each inserted entry
+5. WHEN a lookup returns a result and an existing entry for the same word/expression and source_language exists, THE App SHALL apply the user-selected conflict resolution strategy (replace, add, or skip) before persisting
+6. WHEN the "replace" strategy is selected, THE App SHALL update the existing entry in-place using `UpdateWord`/`UpdateExpression` by ID and set the updated_at timestamp
+7. WHEN the "add" strategy is selected, THE App SHALL insert the new result as a separate entry alongside the existing one, allowing multiple versions of the same word/expression
+
+### Requirement 20: Service Layer
+
+**User Story:** As a developer, I want business logic separated from the CLI and HTTP layers, so that the same logic can be called from the CLI, the web UI, and tests.
+
+#### Acceptance Criteria
+
+1. WHEN a lookup is requested, THE App SHALL expose a `Lookup` function that accepts a `context.Context`, a source language code, a lookup type (word, expression, or sentence), the input text, a provider instance, a model ID, an optional context sentence, a target language, and optional tags, and returns a validated and mapped vocabulary struct
+2. WHEN a batch is requested, THE App SHALL expose a `ProcessBatch` function that accepts a `context.Context`, a source language code, a mode (words or expressions), a list of raw tokens with contexts, a provider instance, a model ID, a target language, and optional tags, and returns a list of result structs and a list of error tuples
+3. WHEN supported languages are requested, THE App SHALL expose a `GetSupportedLanguages` function that returns the list of supported language codes and names
+4. WHEN the `Lookup` function is called, THE App SHALL perform language resolution, prompt building, LLM invocation, JSON validation, and field mapping without depending on Cobra or net/http
+5. IF the LLM invocation fails during a service call, THEN THE App SHALL return a typed error with the failure details
+6. IF JSON validation fails during a service call, THEN THE App SHALL return a typed validation error with the details
+7. WHEN the LLM returns a response for a word lookup, THE App SHALL check if the LLM recognized the input as a non-word (type="—", definition contains "not a valid"/"geen geldig", or example="—") and if so, return a warning and skip the database insert
+8. WHEN the LLM returns a response for a word lookup, THE App SHALL check if the input token appears in the example sentence and if not, return a hallucination warning (the entry is still saved but flagged)
+9. WHEN the LLM returns a response for an expression lookup, THE App SHALL skip the hallucination check (expressions are naturally conjugated/modified in example sentences) but still perform the non-word check
+10. WHEN the `Lookup` function is called with `LookupType` "sentence", THE App SHALL skip the cache check, invoke the LLM with the sentence template, validate with `ValidateSentenceResponse`, and return the result without writing to the Database
+
+### Requirement 21: Cobra CLI Interface
+
+**User Story:** As a language learner, I want to control app behavior via command-line arguments, so that I can process different chapters and modes.
+
+#### Acceptance Criteria
+
+1. WHEN the App is built, THE App SHALL use Cobra for CLI argument parsing
+2. WHEN the CLI is invoked, THE CLI SHALL accept a required `--source-language` / `-l` flag accepting any string (known codes resolved to full names)
+3. WHEN the CLI is invoked, THE CLI SHALL accept a `--mode` flag with values "words" or "expressions" (not required in lookup subcommand)
+4. WHEN the CLI is invoked, THE CLI SHALL accept a `--input-file` flag specifying the input CSV path (not required in lookup subcommand)
+5. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--model-id` flag specifying the LLM model ID
+6. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--limit` flag to process only the first N items
+7. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--verbose` / `-v` flag to enable debug logging
+8. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--dry-run` flag to preview processing without LLM calls
+9. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--provider` flag (default: "bedrock")
+10. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--api-key` flag for OpenAI/Anthropic authentication
+11. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--base-url` flag for OpenAI-compatible server endpoints
+12. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--profile` flag for AWS profile authentication
+13. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--region` / `-r` flag (default: "us-east-1")
+14. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--target-language` flag (default: "hu")
+15. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--context` flag for context sentence in lookup mode
+16. WHEN the CLI is invoked, THE CLI SHALL provide a `lookup` subcommand for quick single-item lookups (word, expression, or sentence)
+17. WHEN the CLI is invoked, THE CLI SHALL provide a `batch` subcommand for batch CSV processing
+18. WHEN the CLI is invoked, THE CLI SHALL provide a `serve` subcommand to start the embedded web server
+19. WHEN the `serve` subcommand is invoked, THE CLI SHALL accept an optional `--port` flag (default: 8080)
+20. WHEN required arguments are missing, THE CLI SHALL print usage help and exit with non-zero code
+21. WHEN `--help` is provided, THE CLI SHALL show all available arguments
+22. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--tags` flag containing a comma-separated list of tags to apply to entries created during the session
+23. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--timeout` flag specifying the LLM request timeout in seconds (default: 60)
+24. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--gcp-project` flag for Vertex AI project ID
+25. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--gcp-region` flag for Vertex AI region (default: "us-central1")
+26. WHEN the CLI is invoked, THE CLI SHALL provide a `backup` subcommand for database backup
+27. WHEN the CLI is invoked, THE CLI SHALL provide a `restore` subcommand that accepts a backup file path for database restore
+28. WHEN the CLI is invoked, THE CLI SHALL provide a `version` subcommand that prints version information
+29. WHEN `--version` is provided on the root command, THE CLI SHALL print the version and exit
+
+### Requirement 22: Quick Lookup Mode
+
+**User Story:** As a language learner, I want to quickly look up a single word, expression, or sentence without writing to CSV, so that I can test the LLM output or check vocabulary on the fly.
+
+#### Acceptance Criteria
+
+1. WHEN the `lookup` subcommand is invoked, THE `lookup` subcommand SHALL accept a positional argument for the text to look up
+2. WHEN the `lookup` subcommand is invoked, THE `lookup` subcommand SHALL accept a `--type` flag with values "word", "expression", or "sentence" (default: "word")
+3. WHEN the `lookup` subcommand is invoked, THE App SHALL invoke the LLM provider with the provided text
+4. WHEN the `lookup` subcommand completes, THE App SHALL print the JSON response to console in formatted output
+5. WHEN the `lookup` subcommand completes and no existing entry exists, THE App SHALL save the result to the Database
+6. WHEN the `lookup` subcommand is invoked, THE `lookup` subcommand SHALL accept an optional `--context` flag for disambiguation
+7. WHEN the `lookup` subcommand is invoked with a `--context` flag and an existing entry is found, THE App SHALL invoke the LLM provider with the context, display both the existing and new results, and prompt the user to choose a conflict resolution strategy (replace, add, or skip)
+8. WHEN the `lookup` subcommand is invoked with an `--on-conflict` flag, THE App SHALL apply the specified strategy without interactive prompting
+
+### Requirement 23: Batch Processing Mode
+
+**User Story:** As a language learner, I want to process entire CSV files of vocabulary, so that I can build comprehensive vocabulary lists from textbook chapters.
+
+#### Acceptance Criteria
+
+1. WHEN the `batch` subcommand is invoked, THE `batch` subcommand SHALL accept `--input-file` and `--mode` as required flags
+2. WHEN processing a batch, THE App SHALL check the Database cache for each token before invoking the LLM provider
+3. WHEN a token exists in the Database cache, THE App SHALL skip LLM invocation for that token
+4. WHEN skipping a token, THE App SHALL log a skip message
+5. WHEN processing completes, THE App SHALL print a summary with counts of processed, cached, and failed items
+6. WHEN `--limit N` is provided, THE App SHALL process at most N new items (excluding cached items)
+
+#### Properties
+
+- P23.1: Limit enforcement — for limit N and M tokens (M > N), processing invokes the LLM for at most N tokens excluding cached items (Req 23, AC 6)
+### Requirement 24: Embedded Web UI Server
+
+**User Story:** As a language learner, I want to start a web server from the binary and use a browser-based interface, so that I can do lookups and batch processing without the terminal.
+
+#### Acceptance Criteria
+
+1. WHEN the `serve` subcommand is invoked, THE App SHALL start an HTTP server on a configurable port (default: 8080)
+2. WHEN the App is built, THE App SHALL embed HTML templates and static assets using Go's `go:embed` directive
+3. WHEN the Web_UI renders pages, THE Web_UI SHALL use Go `html/template` for server-side rendering and HTMX for dynamic interactions
+4. WHEN the Web_UI renders pages, THE Web_UI SHALL use Tailwind CSS (via CDN or embedded) for styling
+5. WHEN the App is run, THE App SHALL serve all web UI assets from the single binary with no external file dependencies
+6. WHEN the `serve` subcommand receives OS interrupt signals (SIGINT, SIGTERM), THE App SHALL perform graceful HTTP server shutdown using `context.Context`, allowing in-flight requests to complete before exiting
+
+### Requirement 25: Web UI — Lookup Page
+
+**User Story:** As a language learner, I want a web page where I can type a word, expression, or sentence and see the vocabulary entry rendered in a clean layout.
+
+#### Acceptance Criteria
+
+1. WHEN the Web_UI serves the lookup page, THE Web_UI SHALL serve it at `/` with a form containing a text input, source language selector, target language selector, lookup type selector (word, expression, sentence), and optional tags input
+2. WHEN the user submits the lookup form, THE Web_UI SHALL use HTMX to POST to the API endpoint and swap the result into the page without a full reload
+3. WHEN the lookup request is in progress, THE Web_UI SHALL display a loading spinner indicator
+4. WHEN the API returns an error, THE Web_UI SHALL display the error message inline
+5. WHEN the language selectors are rendered, THE Web_UI SHALL populate them from the Supported_Languages registry
+
+### Requirement 26: Web UI — Batch Page
+
+**User Story:** As a language learner, I want to upload a CSV file through the web interface and see the processing results.
+
+#### Acceptance Criteria
+
+1. WHEN the Web_UI serves the batch page, THE Web_UI SHALL serve it at `/batch` with a CSV file upload form, source language selector, target language selector, mode selector (words or expressions), and optional tags input
+2. WHEN the user submits the batch form, THE Web_UI SHALL POST the file to the batch API endpoint
+3. WHEN the batch API processes items, THE batch API endpoint SHALL use Server-Sent Events (SSE) to stream progress updates to the Web_UI as each item is processed
+4. WHEN batch processing is in progress, THE Web_UI SHALL display a progress bar showing the number of processed items out of the total, and the current token being processed
+5. WHEN batch processing completes, THE Web_UI SHALL display counts of processed, cached, and failed items
+6. WHEN errors occur for specific items, THE Web_UI SHALL display the failed items list
+7. WHEN batch processing is in progress, THE Web_UI SHALL display a cancel button that stops processing remaining items
+
+### Requirement 27: Web UI — Config Page
+
+**User Story:** As a language learner, I want a settings page in the web interface to configure my LLM provider, credentials, and preferences.
+
+#### Acceptance Criteria
+
+1. WHEN the Web_UI serves the config page, THE Web_UI SHALL serve it at `/config` with form fields for provider (dropdown: bedrock, openai, anthropic, vertexai), aws_profile (text input, shown for bedrock), aws_region (text input, shown for bedrock), gcp_project (text input, shown for vertexai), gcp_region (text input, shown for vertexai), model_id (text input), base_url (text input, shown for openai), default_source_language (dropdown), and default_target_language (dropdown); each provider section SHALL display an informational note about which environment variable or credential source is required
+2. WHEN the config page loads, THE Web_UI SHALL populate the form fields from the current configuration
+3. WHEN the user saves settings, THE Web_UI SHALL validate that the required environment variables or credentials are available for the selected provider and display a clear error message if missing; IF validation passes, THE Web_UI SHALL update the Config_File and display a success message inline
+4. WHEN the user clicks "Test Connection", THE Config page SHALL test the current provider configuration using API keys resolved from environment variables and display the result inline
+5. WHEN the config page renders, THE Config page SHALL display the current database path as a read-only field
+
+### Requirement 28: Web UI — Database Page
+
+**User Story:** As a user, I want a dedicated database page in the web UI to browse, search, and manage my vocabulary entries.
+
+#### Acceptance Criteria
+
+1. WHEN the Web_UI serves the database page, THE Database_Page SHALL be accessible at the `/database` URL
+2. WHEN the Web_UI renders navigation, THE Database_Page SHALL display a navigation link in the shared nav bar alongside Lookup, Batch, and Config
+3. WHEN the Database_Page renders entries, THE Database_Page SHALL display vocabulary entries in a paginated table with 50 rows per page
+4. WHEN the Database_Page renders filters, THE Database_Page SHALL provide filter controls for source_language, target_language, entry type (words or expressions), and tags
+5. WHEN a user types in the search field, THE Database_Page SHALL filter entries by matching against the word/expression, definition, english, and tags columns with a debounce delay of 300 milliseconds
+6. WHEN entries are displayed, THE Database_Page SHALL display the total count of matching entries
+7. WHEN a user clicks an entry row, THE Database_Page SHALL display an edit form with all fields pre-populated
+8. WHEN a user submits the edit form, THE App SHALL update the corresponding row in the Database and set the updated_at timestamp
+9. WHEN a user clicks a delete button on an entry, THE Database_Page SHALL ask for confirmation before deleting
+10. WHEN the user confirms deletion, THE App SHALL remove the entry from the Database
+### Requirement 29: Import into Database
+
+**User Story:** As a user, I want to import my existing vocabulary files into the database, so that I can consolidate scattered vocabulary data.
+
+#### Acceptance Criteria
+
+1. WHEN the Database_Page renders import controls, THE Database_Page SHALL provide an import form with file upload (accepting .csv and .xlsx), source_language selector, target_language selector, and entry type selector (words or expressions)
+2. WHEN a CSV file is uploaded, THE Importer SHALL validate UTF-8 encoding and reject non-UTF-8 files with a descriptive error message suggesting XLSX import instead
+3. WHEN an XLSX file is uploaded, THE Importer SHALL read the "Words" or "Expressions" sheet by name (falling back to the first sheet) and parse rows with header detection
+4. WHEN the import file contains a header row with recognized column names (word, expression, definition, english, type), THE Importer SHALL map columns by header name
+5. WHEN a row matches an existing entry (same word/expression and source_language), THE Importer SHALL skip that row and count it as a duplicate
+6. WHEN the import completes, THE Database_Page SHALL display a summary showing the count of imported, skipped, and failed rows
+7. IF a row has missing required fields (word/expression), THEN THE Importer SHALL skip that row and include it in the failed count
+8. WHEN an import file contains a tags column, THE Importer SHALL support the optional tags column and apply the tags to imported entries
+9. WHEN a row contains encoding garbage (U+FFFD replacement characters), THE Importer SHALL skip that row and report the count of skipped encoding errors
+
+### Requirement 30: Excel Export from Database
+
+**User Story:** As a user, I want to export database entries to an Excel file, so that I can use the data in spreadsheet tools or Anki.
+
+#### Acceptance Criteria
+
+1. WHEN the Database_Page renders export controls, THE Database_Page SHALL provide an export button that downloads an .xlsx file
+2. WHEN the export is triggered, THE Excel_Exporter SHALL apply the current filter and search criteria to determine which entries to export
+3. WHEN the export generates a file, THE Excel_Exporter SHALL include column headers matching the database field names
+4. WHEN the export generates a file, THE Excel_Exporter SHALL name the downloaded file using the pattern `vocabgen-{source_language}-{date}.xlsx`
+5. WHEN the export generates a file, THE Excel_Exporter SHALL write words to a "Words" sheet and expressions to an "Expressions" sheet in the same file
+6. WHEN no entries match the current filters, THE Database_Page SHALL disable the export button
+
+### Requirement 31: REST API Endpoints
+
+**User Story:** As a developer, I want HTTP endpoints backing the web UI, so that the HTMX frontend can interact with the service layer.
+
+#### Acceptance Criteria
+
+1. WHEN a POST request is sent to `/api/lookup` with a JSON body containing `source_language`, `lookup_type`, `text`, and optional `context`, `target_language`, and `tags`, THE App SHALL return a JSON response with the vocabulary entry
+2. WHEN a POST request is sent to `/api/batch` with a multipart form containing a CSV file, source_language, target_language, mode, and optional tags, THE App SHALL parse the CSV, process the batch, and return a JSON response with results and errors
+3. WHEN a GET request is sent to `/api/config`, THE App SHALL return the current configuration as JSON
+4. WHEN a PUT request is sent to `/api/config` with a JSON body, THE App SHALL update the Config_File and return the updated configuration
+5. WHEN a GET request is sent to `/api/languages`, THE App SHALL return the list of supported language codes and names
+6. WHEN a GET request is sent to `/api/health`, THE App SHALL return HTTP 200 with `{"status": "ok"}`
+7. WHEN a POST request is sent to `/api/test-connection`, THE App SHALL attempt to create an authenticated provider client using API keys resolved from environment variables and return the result
+8. WHEN a POST request is sent to `/api/batch` with a file exceeding 10 MB, THE App SHALL reject the upload with HTTP 413 and a descriptive error message
+
+### Requirement 32: Actionable API Error Messages
+
+**User Story:** As a user of the web UI, I want error messages that tell me what went wrong and what to do next, so that I can resolve issues without checking server logs.
+
+#### Acceptance Criteria
+
+1. WHEN the API returns an error response (HTTP 400, 502, or 500), THE App SHALL include a JSON body with a `detail` field containing a human-readable, actionable error message
+2. IF authentication fails during an API request, THEN THE App SHALL return an error message that identifies the failure reason and suggests a corrective action
+3. IF an LLM invocation fails due to throttling, THEN THE App SHALL return an error message suggesting the user retry after a short wait
+4. IF JSON validation of an LLM response fails, THEN THE App SHALL return an error message identifying the token that failed
+
+### Requirement 33: Config Manager
+
+**User Story:** As a user, I want my provider, credentials, region, and model preferences saved locally, so that I do not need to specify them as CLI flags every session.
+
+#### Acceptance Criteria
+
+1. WHEN the Config_Manager reads configuration, THE Config_Manager SHALL read from a YAML file at `~/.vocabgen/config.yaml`
+2. WHEN the Config_Manager loads configuration, THE Config_Manager SHALL expose a `LoadConfig` function that returns a configuration struct with fields: provider, aws_profile, aws_region, model_id, base_url, gcp_project, gcp_region, default_source_language, default_target_language, db_path
+3. WHEN the Config_Manager saves configuration, THE Config_Manager SHALL expose a `SaveConfig` function that accepts a configuration struct and writes it to the Config_File
+4. WHEN the Config_File does not exist, THE `LoadConfig` function SHALL return a struct with default values (provider: "bedrock", aws_region: "us-east-1", default_source_language: "nl", default_target_language: "hu", db_path: "~/.vocabgen/vocabgen.db")
+5. WHEN the `SaveConfig` function is called, THE Config_Manager SHALL create the `~/.vocabgen/` directory if it does not exist
+6. WHEN the Config_File is written, THE Config_File SHALL contain only non-sensitive settings; THE Config_Manager SHALL NOT store API keys or AWS secrets in the YAML file
+7. WHEN the Config_Manager serializes configuration, THE Config_Manager SHALL NOT serialize the `api_key` field to the YAML file; API keys are runtime-only values sourced from environment variables or CLI flags
+8. WHEN the CLI is invoked without explicit flags, THE CLI SHALL load defaults from the Config_Manager
+9. WHEN the CLI is invoked with explicit flags, THE CLI SHALL use the provided flag values and ignore the Config_File values for those flags
+
+### Requirement 34: Config File Round-Trip Integrity
+
+**User Story:** As a developer, I want to be confident that saving and loading configuration produces identical data, so that user settings are never silently corrupted.
+
+#### Acceptance Criteria
+
+1. FOR ALL valid configuration structs, saving via `SaveConfig` then loading via `LoadConfig` SHALL produce a struct equal to the original
+2. WHEN `SaveConfig` writes a file, THE `SaveConfig` function SHALL produce a valid YAML file that the `LoadConfig` function can parse without error
+
+#### Properties
+
+- P34.1: Config file round-trip — for any valid config struct, SaveConfig then LoadConfig produces an equal struct (Req 34, AC 1–2)
+### Requirement 35: Single Binary Distribution
+
+**User Story:** As a language learner, I want to download a single binary for my platform and run it immediately, so that I do not need to install Go, Python, or any dependencies.
+
+#### Acceptance Criteria
+
+1. WHEN the App is compiled, THE App SHALL compile to a single binary with all templates, static assets, and SQLite driver embedded
+2. WHEN the App is released, THE App SHALL cross-compile for macOS (amd64, arm64), Linux (amd64, arm64), and Windows (amd64)
+3. WHEN the App is compiled, THE App SHALL use `go:embed` to embed HTML templates and static assets into the binary
+4. WHEN the App is compiled, THE App SHALL use a pure-Go or CGo-compatible SQLite driver that compiles into the binary
+5. WHEN the binary is run on a supported platform, THE App SHALL require no external runtime dependencies
+
+### Requirement 36: Handle Errors Gracefully
+
+**User Story:** As a language learner, I want the app to continue processing after errors, so that I can manually fix failed items later.
+
+#### Acceptance Criteria
+
+1. WHEN an LLM invocation fails, THE App SHALL log the error
+2. WHEN a JSON parsing error occurs, THE App SHALL log the raw response at debug level
+3. WHEN an error occurs during batch processing, THE App SHALL continue processing remaining items
+4. WHEN processing completes, THE App SHALL print a summary report listing all failed items
+5. WHEN authentication fails, THE App SHALL exit with a non-zero exit code and a clear error message suggesting corrective action
+
+#### Properties
+
+- P36.1: Error resilience — for any list of tokens containing both valid and invalid items, processing completes all valid items even when errors occur for some (Req 36, AC 3)
+
+### Requirement 37: Dry-Run Mode
+
+**User Story:** As a language learner, I want to preview what will be processed without spending API credits, so that I can verify parsing logic before running.
+
+#### Acceptance Criteria
+
+1. WHEN `--dry-run` flag is provided, THE App SHALL parse and normalize all input tokens
+2. WHEN `--dry-run` flag is provided, THE App SHALL print normalized tokens to console
+3. WHEN `--dry-run` flag is provided, THE App SHALL not invoke the LLM provider
+4. WHEN `--dry-run` flag is provided, THE App SHALL not write to the Database
+5. WHEN `--dry-run` flag is provided, THE App SHALL print a summary of what would be processed
+
+#### Properties
+
+- P37.1: Dry-run no side effects — for any input file, dry-run mode does not write to the Database, does not invoke the LLM provider, and does not modify any persistent state (Req 37, AC 3–4)
+
+### Requirement 38: Progress Feedback
+
+**User Story:** As a language learner, I want to see processing progress, so that I know the app is working and how much is left.
+
+#### Acceptance Criteria
+
+1. WHEN processing items, THE App SHALL log each processed item
+2. WHEN skipping cached items, THE App SHALL log skip messages
+3. WHEN `--verbose` flag is provided, THE App SHALL log prompts at debug level
+4. WHEN `--verbose` flag is provided, THE App SHALL log raw LLM responses at debug level
+5. WHEN processing completes, THE App SHALL print a summary with counts of processed, cached, and failed items
+
+### Requirement 39: Handle UTF-8 Encoding
+
+**User Story:** As a language learner, I want proper handling of special characters (ë, ï, ü, ő, ű, à, è, ì, ò, ù, я, ё, etc.), so that my vocabulary data displays correctly.
+
+#### Acceptance Criteria
+
+1. WHEN reading input files, THE App SHALL use UTF-8 encoding
+2. WHEN writing to the Database, THE App SHALL preserve UTF-8 characters
+3. WHEN serving web UI responses, THE App SHALL set Content-Type with charset=utf-8
+4. WHEN logging to console, THE App SHALL handle UTF-8 characters without errors
+
+#### Properties
+
+- P39.1: UTF-8 round-trip consistency — for any text containing special characters, reading from UTF-8 source then writing to Database then reading back preserves the exact character sequence (Req 39, AC 1–2)
+
+### Requirement 40: Configurable Target Translation Language
+
+**User Story:** As a language learner sharing this tool with classmates, I want to configure which language appears as the second translation column, so that each user can choose their own native language for translations.
+
+#### Acceptance Criteria
+
+1. WHEN the CLI is invoked, THE App SHALL accept an optional `--target-language` CLI flag specifying the second translation language code (default: "hu" for Hungarian)
+2. WHEN `--target-language` is provided, THE App SHALL use the specified language for the second translation field in prompts
+3. WHEN a target language is specified, THE App SHALL support any language in Supported_Languages as target language
+4. WHEN `--target-language` is not provided, THE App SHALL default to Hungarian ("hu")
+
+### Requirement 41: Maintain Output Quality Parity
+
+**User Story:** As a language learner, I want the prompts to produce vocabulary data of high quality for any source language, so that my vocabulary lists are useful.
+
+#### Acceptance Criteria
+
+1. WHEN processing a word in any supported language, THE LLM response SHALL contain native POS labels, native definitions, native example sentences, and native register labels for that language
+2. WHEN the prompt templates are defined, THE prompt templates SHALL include the Core_Rule_Block, Decision_Rubric, and all field-level quality instructions
+3. WHEN the prompt templates produce output, THE prompt templates SHALL produce output compatible with the English_Schema
+
+### Requirement 42: Context Sentence Support in Prompts
+
+**User Story:** As a language learner, I want to provide an optional context sentence alongside each word or expression, so that the LLM can disambiguate polysemous words and produce connotation-accurate translations.
+
+#### Acceptance Criteria
+
+1. WHEN the Prompt_Template is defined, THE Prompt_Template SHALL include a `{context}` placeholder that, when populated, provides the LLM with the sentence in which the word or expression appears
+2. WHEN a context sentence is provided, THE Prompt_Template SHALL instruct the LLM to use the context to determine the correct sense, connotation, and register
+3. WHEN no context sentence is provided, THE Prompt_Template SHALL instruct the LLM to infer the most typical B2–C1 textbook sense and note polysemy if the word is highly polysemous
+4. WHEN the `BuildPrompt` function is called, THE `BuildPrompt` function SHALL accept an optional context parameter and inject it into the prompt template
+### Requirement 43: Testing Strategy
+
+**User Story:** As a developer, I want a comprehensive test suite using table-driven tests and property-based tests with the `rapid` library, so that correctness properties from the Python prototype are carried forward.
+
+#### Acceptance Criteria
+
+1. WHEN tests are written, THE test suite SHALL use Go table-driven tests for unit tests
+2. WHEN correctness properties are tested, THE test suite SHALL use the `rapid` library (pgregory.net/rapid) for property-based tests verifying formal correctness properties
+3. WHEN edge cases are discovered, THE test suite SHALL use Go's built-in fuzz testing (`func FuzzXxx(f *testing.F)`) for edge case discovery on parsers and validators
+4. WHEN the test suite is designed, THE test suite SHALL carry forward all correctness properties from the Python prototype design document
+5. WHEN templates are tested, THE test suite SHALL test the unified templates with language parameters
+6. WHEN validation is tested, THE test suite SHALL use English field names in validation tests
+7. WHEN BuildPrompt is tested, THE test suite SHALL include at least one test per supported language verifying that `BuildPrompt` produces a valid prompt containing the correct source language name
+8. WHEN the Validator is tested, THE test suite SHALL include tests verifying that the Validator accepts both flat string and nested object translation fields
+9. WHEN the Field_Mapper is tested, THE test suite SHALL include tests verifying that the Field_Mapper correctly flattens nested translation objects
+10. WHEN round-trip validation is tested, THE test suite SHALL include a round-trip property test verifying that a valid JSON response passes validation and field mapping without error for all supported languages and both modes
+
+### Requirement 44: Structured Logging
+
+**User Story:** As a developer, I want all application logging to use `log/slog` with structured fields, so that log output is consistent, parseable, and free of `fmt.Println` in production code.
+
+#### Acceptance Criteria
+
+1. WHEN the App logs messages, THE App SHALL use `log/slog` for all production logging (no `fmt.Println` or `fmt.Printf` for log output)
+2. WHEN the App starts, THE App SHALL configure the slog handler at startup based on the `--verbose` flag: text handler with INFO level by default, DEBUG level when verbose
+3. WHEN the App logs messages, THE App SHALL include structured fields where applicable (e.g., `slog.String("word", token)`, `slog.String("provider", name)`)
+4. WHEN the App processes items normally, THE App SHALL log at INFO level for: processed items, skip/cache messages, progress, summaries
+5. WHEN the App processes LLM interactions in verbose mode, THE App SHALL log at DEBUG level for: prompts sent to LLM, raw LLM responses
+6. WHEN the App encounters failures, THE App SHALL log at ERROR level for: authentication failures, LLM invocation errors, validation errors
+
+### Requirement 45: Build and CI Tooling
+
+**User Story:** As a developer, I want a Makefile and CI configuration that enforces code quality gates, so that every commit is vetted before merge.
+
+#### Acceptance Criteria
+
+1. WHEN the repository is set up, THE repository SHALL include a Makefile with targets: `build`, `test`, `lint`, `vet`, `fmt-check`
+2. WHEN the `test` target is run, THE `test` target SHALL run `go test -race ./...`
+3. WHEN the `lint` target is run, THE `lint` target SHALL run `staticcheck ./...`
+4. WHEN the `vet` target is run, THE `vet` target SHALL run `go vet ./...`
+5. WHEN the `fmt-check` target is run, THE `fmt-check` target SHALL verify all Go files are formatted with `gofmt` and fail if any are not
+6. WHEN the `build` target is run, THE `build` target SHALL compile the binary with `go build -o vocabgen ./cmd/vocabgen`
+7. WHEN a release is prepared, THE repository SHALL maintain a `CHANGELOG.md` file following Keep a Changelog format, with entries grouped per release under Added/Changed/Fixed sections
+
+### Requirement 46: Database Schema Migration
+
+**User Story:** As a developer, I want a lightweight schema migration mechanism, so that I can evolve the database schema without losing user data.
+
+#### Acceptance Criteria
+
+1. WHEN the Database stores schema information, THE Database SHALL store a `schema_version` integer in a `metadata` table
+2. WHEN the Database is first created, THE Database SHALL set `schema_version` to 1 for the initial schema creation
+3. WHEN the application starts and the existing `schema_version` is less than the current version, THE Database SHALL apply migration steps sequentially
+4. WHEN a migration step fails, THE Database SHALL return an error and not apply subsequent steps
+5. WHEN a migration step runs, THE migration step SHALL run inside a transaction so that a failed step leaves the database unchanged
+
+### Requirement 47: Entry Tagging
+
+**User Story:** As a language learner, I want to tag vocabulary entries with labels like "chapter-3" or "business-dutch", so that I can organize and filter my vocabulary by project, topic, or source.
+
+#### Acceptance Criteria
+
+1. WHEN the Database stores entries, THE Database SHALL store a `tags` TEXT column on both the words and expressions tables, containing comma-separated tag strings
+2. WHEN the `--tags` CLI flag is provided, THE App SHALL apply the specified tags to all entries created during that session
+3. WHEN a lookup or batch result is saved to the Database, THE App SHALL store the tags value (or empty string if no tags provided)
+4. WHEN the Web_UI renders lookup and batch forms, THE Web_UI SHALL include an optional tags text input
+5. WHEN the Database_Page renders filters, THE Database_Page SHALL include a tags filter that matches entries containing the specified tag
+6. WHEN the Database_Page renders the edit form, THE Database_Page SHALL allow editing the tags field
+7. WHEN the Excel_Exporter generates a file, THE Excel_Exporter SHALL include the tags column in exported files
+8. WHEN the CSV_Importer parses a file, THE CSV_Importer SHALL support an optional tags column in imported files
+### Requirement 48: Database Backup and Restore
+
+**User Story:** As a user, I want to back up and restore my vocabulary database, so that I can recover from corruption or accidental deletion.
+
+#### Acceptance Criteria
+
+1. WHEN the `backup` subcommand is invoked, THE App SHALL copy the current SQLite database file to a timestamped backup file in the same directory (e.g., `vocabgen.db.2026-03-30T14-00-00.bak`)
+2. WHEN the `restore` subcommand is invoked, THE App SHALL accept a backup file path and replace the current database with the backup
+3. WHEN the `restore` subcommand is invoked, THE App SHALL verify the backup file is a valid SQLite database before replacing the current one
+4. WHEN the `restore` subcommand is invoked, THE App SHALL create a backup of the current database before overwriting it
+5. WHEN the `backup` subcommand completes, THE App SHALL print the path of the created backup file
+6. WHEN the `restore` subcommand completes, THE App SHALL print a confirmation message after successful restore
+
+### Requirement 49: Version Command
+
+**User Story:** As a user, I want to check which version of the tool I'm running, so that I can report issues or verify I have the latest release.
+
+#### Acceptance Criteria
+
+1. WHEN the `version` subcommand is invoked, THE CLI SHALL print the application version, Go version, and build date
+2. WHEN `--version` is provided on the root command, THE CLI SHALL print the version and exit
+3. WHEN the binary is built, THE version string SHALL be injected at build time via Go linker flags (`-ldflags`)
+
+### Requirement 50: LLM Request Timeout
+
+**User Story:** As a user, I want LLM requests to time out after a reasonable period, so that the app doesn't hang indefinitely on unresponsive providers.
+
+#### Acceptance Criteria
+
+1. WHEN an LLM provider is invoked, THE App SHALL apply a configurable timeout to each invocation (default: 60 seconds)
+2. WHEN the CLI is invoked, THE CLI SHALL accept an optional `--timeout` flag specifying the timeout in seconds
+3. WHEN a provider invocation exceeds the timeout, THE App SHALL cancel the request and return a timeout error
+4. WHEN the timeout is applied, THE timeout SHALL be implemented via `context.WithTimeout` on the context passed to the Provider's Invoke method
+
+### Requirement 51: Vertex AI Provider Implementation
+
+**User Story:** As a user with Google Cloud access, I want to use Vertex AI models (Gemini, PaLM, Claude on Vertex), so that I can leverage my existing GCP infrastructure.
+
+#### Acceptance Criteria
+
+1. WHEN the Vertex_AI_Provider is used, THE Vertex_AI_Provider SHALL implement the Provider_Interface
+2. WHEN the Vertex_AI_Provider authenticates, THE Vertex_AI_Provider SHALL use Google Application Default Credentials (ADC) or a service account key file
+3. WHEN no valid GCP credentials are available, THE Vertex_AI_Provider SHALL return a descriptive authentication error before attempting invocation
+4. WHEN a GCP project is specified, THE Vertex_AI_Provider SHALL accept a GCP project ID via the `--gcp-project` CLI flag or the `GCP_PROJECT` environment variable
+5. WHEN a GCP region is specified, THE Vertex_AI_Provider SHALL accept a GCP region via the `--gcp-region` CLI flag (default: "us-central1")
+6. WHEN a model is specified, THE Vertex_AI_Provider SHALL support specifying a Vertex AI model name (e.g., "gemini-2.0-flash", "gemini-2.5-pro") via the `--model-id` flag
+7. WHEN the Vertex_AI_Provider encounters rate-limit errors, THE Vertex_AI_Provider SHALL retry up to a configurable maximum
+
+### Requirement 52: English Definition Field
+
+**User Story:** As a language learner who is not yet advanced enough to fully understand source-language definitions, I want an English-language explanation of each word or expression's meaning, so that I can comprehend the definition even when the source-language version is too difficult.
+
+#### Acceptance Criteria
+
+1. WHEN the English_Schema is defined, THE English_Schema SHALL include an optional `english_definition` field (string) for both words and expressions
+2. WHEN the `english_definition` field is populated, THE field SHALL contain a concise English-language explanation of the word or expression's meaning, distinct from the `english` translation field (which provides a direct translation) and the `definition` field (which provides the explanation in the source language)
+3. WHEN the LLM returns a response with an `english_definition` field, THE Validator SHALL accept the field as a string and pass it through
+4. WHEN the LLM returns a response without an `english_definition` field, THE Validator SHALL default the field to an empty string
+5. WHEN an entry is stored, THE Database SHALL store the `english_definition` value in the `english_definition` column of both the words and expressions tables
+6. WHEN a lookup result is displayed, THE Web_UI lookup result partial SHALL display the `english_definition` field when it is non-empty
+7. WHEN the Database_Page renders an entry, THE Database_Page entry view and edit form SHALL include the `english_definition` field
+8. WHEN the Excel_Exporter generates a file, THE Excel_Exporter SHALL include the `english_definition` column in exported files
+9. WHEN the CSV_Importer parses a file, THE CSV_Importer SHALL support an optional `english_definition` column in imported files
+10. WHEN the Field_Mapper processes an entry, THE Field_Mapper SHALL pass through the `english_definition` field from the validated entry to the output Entry struct without transformation
+### Requirement 53: Multi-Version Vocabulary Entries
+
+**User Story:** As a language learner, I want to store multiple versions of the same word when it has distinct meanings (e.g., "werk" as noun "work" and "werk" as verb "to work"), so that my vocabulary database captures all relevant senses of polysemous words.
+
+#### Acceptance Criteria
+
+1. WHEN entries are stored, THE Database SHALL allow multiple rows with the same word/expression text and source_language in the words and expressions tables (no unique constraint on the (source_language, word) or (source_language, expression) pair)
+2. WHEN multiple entries exist for the same word/expression and source_language, THE Database_Page SHALL display all versions as separate rows in the table
+3. WHEN multiple entries exist for the same word/expression, THE Excel_Exporter SHALL include all versions as separate rows in the exported file
+4. WHEN the user selects the "add" conflict resolution strategy, THE App SHALL insert the new LLM result as a new row without modifying or removing the existing entry
+5. WHEN the Database_Page displays entries that share the same word/expression text, THE Database_Page SHALL visually distinguish them (e.g., by displaying the part_of_speech or a version indicator) so the user can tell them apart
+
+#### Properties
+
+- P53.1: Multi-version entry integrity — "add" results in N+1 entries, "replace" targeting ID K updates K and leaves others unchanged, "skip" results in no modifications; FindWords/FindExpressions returns all N entries (Req 53, AC 1, 4)
+
+### Requirement 54: Conflict Resolution Strategy
+
+**User Story:** As a language learner, I want to choose whether to replace an existing entry, add a new version alongside it, or skip saving when I re-query a word with different context, so that I control how my vocabulary database evolves.
+
+#### Acceptance Criteria
+
+1. WHEN a conflict is detected, THE App SHALL support three conflict resolution strategies: "replace" (update the existing entry with the new LLM result), "add" (insert the new result as a separate entry), and "skip" (discard the new result and keep the existing entry unchanged)
+2. WHEN the CLI `lookup` subcommand detects an existing entry and no `--on-conflict` flag is provided, THE CLI SHALL prompt the user interactively to choose replace, add, or skip, displaying a summary of the existing entry and the new result
+3. WHEN the `--on-conflict` flag is provided, THE CLI SHALL apply the specified strategy without interactive prompting
+4. WHEN the Web_UI lookup detects an existing entry and a context sentence was provided, THE Web_UI SHALL display both the existing entry and the new result side by side, with buttons for "Replace", "Add as New Version", and "Skip"
+5. WHEN the Web_UI lookup detects an existing entry and no context sentence was provided, THE Web_UI SHALL return the cached result without invoking the LLM (existing behavior)
+6. WHEN multiple existing entries match the word/expression and source_language, THE App SHALL display all existing entries so the user can choose which one to replace, or add a new version alongside all of them
+
+### Requirement 55: Context-Aware Cache Bypass
+
+**User Story:** As a language learner, I want the cache to be bypassed when I provide a context sentence for a word that already exists in the database, so that the LLM can produce a meaning specific to the context I provide.
+
+#### Acceptance Criteria
+
+1. WHEN a lookup request includes a non-empty context sentence and at least one matching entry exists in the Database, THE App SHALL invoke the LLM provider with the context sentence regardless of the cache hit
+2. WHEN a lookup request includes no context sentence and a matching entry exists in the Database, THE App SHALL return the cached entry without invoking the LLM provider (existing behavior)
+3. WHEN a lookup request includes a non-empty context sentence and no matching entry exists in the Database, THE App SHALL invoke the LLM provider and insert the result directly (no conflict resolution needed)
+4. WHEN a cache bypass occurs due to a context sentence, THE App SHALL log the bypass including the word/expression text and the context sentence at DEBUG level
+
+#### Properties
+
+- P55.1: Context-aware cache bypass — lookup with empty context returns cached entry without LLM invocation; lookup with non-empty context invokes LLM regardless of cache state; final database state is consistent with selected conflict resolution strategy (Req 55, AC 1–3)
+
+### Requirement 56: Batch Conflict Resolution
+
+**User Story:** As a language learner running batch processing with context sentences, I want a default conflict resolution strategy for the batch, so that I do not have to answer prompts for every word that already exists.
+
+#### Acceptance Criteria
+
+1. WHEN the `batch` subcommand is invoked, THE `batch` subcommand SHALL accept an optional `--on-conflict` flag with values "replace", "add", or "skip" (default: "skip")
+2. WHEN a batch token has a context sentence (from the CSV second column) and an existing entry is found, THE App SHALL apply the batch-level `--on-conflict` strategy automatically
+3. WHEN a batch token has no context sentence and an existing entry is found, THE App SHALL skip the token (existing cache behavior, regardless of `--on-conflict` setting)
+4. WHEN the Web_UI renders the batch form, THE Web_UI SHALL include a conflict resolution dropdown (replace, add, skip) that applies to all tokens in the batch
+5. WHEN batch processing completes, THE batch summary SHALL include a count of replaced entries and added entries in addition to the existing processed, cached, and failed counts
+
+### Requirement 57: Database Store Interface Updates for Multi-Version Support
+
+**User Story:** As a developer, I want the database Store interface to support querying and managing multiple entries per word, so that the service layer can implement conflict resolution logic.
+
+#### Acceptance Criteria
+
+1. WHEN multiple entries are queried, THE Store interface SHALL expose a `FindWords(ctx, word, sourceLang)` function that returns a slice of all matching WordRow entries
+2. WHEN multiple entries are queried, THE Store interface SHALL expose a `FindExpressions(ctx, expr, sourceLang)` function that returns a slice of all matching ExpressionRow entries
+3. WHEN no matching entries exist, THE `FindWords`/`FindExpressions` functions SHALL return an empty slice and no error
+4. WHEN backward compatibility is needed, THE existing `FindWord`/`FindExpression` functions SHALL remain available, returning the first matching entry or nil
+5. WHEN the "replace" strategy targets a specific entry, THE `UpdateWord`/`UpdateExpression` functions SHALL accept an entry ID to update a specific version among multiple versions
+### Requirement 58: Named Config Profiles
+
+**User Story:** As a user with multiple LLM setups (local Ollama, sandbox Bedrock, production Bedrock), I want named configuration profiles in `config.yaml`, so that I can switch between them instantly via `--profile <name>` without editing the config file.
+
+#### Acceptance Criteria
+
+1. WHEN the Config_File contains a `profiles:` key, THE Config_Manager SHALL parse it as a `map[string]ProfileConfig` where each profile holds provider-related fields (provider, aws_profile, aws_region, model_id, base_url, gcp_project, gcp_region)
+2. WHEN the Config_File contains a `default_profile:` key, THE Config_Manager SHALL use the named profile when no `--profile` flag is provided
+3. WHEN the `--profile <name>` CLI flag is provided, THE Config_Manager SHALL resolve the named profile and populate the runtime `Config` struct from it
+4. WHEN the `--profile` flag specifies a profile name that does not exist in the Config_File, THE Config_Manager SHALL return a descriptive error listing available profile names
+5. WHEN the Config_File does NOT contain a `profiles:` key (flat format), THE Config_Manager SHALL treat the entire file as a single implicit `default` profile for backward compatibility
+6. WHEN `SaveConfig` is called on a multi-profile config, THE Config_Manager SHALL preserve the multi-profile YAML structure (not flatten to single-profile format)
+7. WHEN the Web_UI config page loads, THE Config_Page SHALL always display a profile selector dropdown showing the active profile name, regardless of how many profiles exist (including single-profile configs)
+8. WHEN the user switches profiles in the Web_UI, THE Config_Page SHALL reload the form with the selected profile's values
+9. WHEN the existing `--profile` flag (currently mapped to AWS profile) conflicts with the new config profile flag, THE CLI SHALL rename the existing flag to `--aws-profile` and use `--profile` for config profiles
+10. WHEN the user selects "Add new profile" from the profile selector dropdown, THE Config_Page SHALL display an inline form prompting for a profile name
+11. WHEN the user submits a new profile name via the inline form, THE Config_Manager SHALL create a new profile copying the current active profile's values as defaults, add it to the Config_File, and switch to the new profile
+12. WHEN the user submits a profile name that already exists, THE Config_Manager SHALL return a descriptive error and not overwrite the existing profile
+13. WHEN the user submits an empty profile name, THE Config_Page SHALL display a validation error without making a server request
+
+#### Properties
+
+- P58.1: Multi-profile config round-trip — save then load preserves all profiles and default_profile (Req 58, AC 1, 6)
+- P58.2: Unknown profile name always returns error listing available profiles (Req 58, AC 4)
+- P58.3: Flat config backward compatibility — old format loads as implicit `default` profile (Req 58, AC 5)
+- P58.4: CreateProfile with duplicate name returns error without modifying existing profiles (Req 58, AC 12)
+- P58.5: CreateProfile copies source profile values into new profile and adds it to FileConfig (Req 58, AC 11)
+
+### Requirement 59: One-Click Local LLM Setup
+
+**User Story:** As a non-technical user (e.g., a classmate), I want a one-click setup for a local LLM via Ollama, so that I can use VocabGen without cloud API keys, costs, or configuration knowledge.
+
+#### Acceptance Criteria
+
+1. WHEN the user runs `scripts/setup-local-llm.sh`, THE script SHALL detect the OS (macOS or Linux via `uname`)
+2. WHEN Ollama is not installed, THE script SHALL download and install Ollama using the appropriate method for the detected OS
+3. WHEN Ollama is already installed, THE script SHALL skip installation and proceed to model setup
+4. WHEN Ollama is not running, THE script SHALL start the Ollama server (`ollama serve &`) and wait for it to become reachable
+5. WHEN the Ollama server is running, THE script SHALL pull a recommended model (e.g., `mistral`) suitable for B2-C1 vocabulary tasks
+6. WHEN the model is pulled, THE script SHALL verify the model responds by sending a quick test prompt via the OpenAI-compatible endpoint
+7. WHEN verification succeeds, THE script SHALL write `~/.vocabgen/config.yaml` with a `local` profile: `provider: openai`, `base_url: http://localhost:11434/v1`, `model_id: mistral`, and set `default_profile: local`
+8. WHEN the Web_UI config page is displayed, THE Config_Page SHALL include a "Setup Local LLM" button that triggers a backend SSE endpoint running the same setup logic
+9. WHEN the SSE setup endpoint runs, THE endpoint SHALL stream progress events (detecting OS, checking Ollama, installing, pulling model, verifying, writing config) to the Web_UI
+10. WHEN the setup completes successfully, THE Web_UI SHALL update the in-memory config and display a success message
+11. WHEN the `openai` provider is configured with `base_url` pointing to `localhost:11434`, THE `validateProviderEnv` function SHALL check Ollama reachability instead of requiring `OPENAI_API_KEY`
+
+#### Properties
+
+- P59.1: Setup script always produces a valid config — provider, base_url, and model_id are all non-empty after successful setup (Req 59, AC 7)
+
+### Requirement 60: E2E Tests Default to Local LLM
+
+**User Story:** As a developer, I want E2E tests to default to the local Ollama profile, so that test runs are free, offline, and don't consume cloud API credits.
+
+#### Acceptance Criteria
+
+1. WHEN `scripts/e2e-test.sh` is invoked without a `-p` flag, THE script SHALL default to `--profile local` for all LLM-dependent test sections
+2. WHEN the `-p PROFILE` flag is provided, THE script SHALL use the specified profile instead of `local`
+3. WHEN the `E2E_PROFILE` environment variable is set, THE script SHALL use it as the profile (flag takes precedence over env var)
+4. WHEN the profile is `local` and Ollama is not reachable at `http://localhost:11434/api/tags`, THE script SHALL print an actionable error message pointing to `scripts/setup-local-llm.sh` and exit 1
+5. WHEN the `local` profile does not exist in the config, THE script SHALL print an actionable error message and exit 1
+6. WHEN the Makefile `e2e` target is invoked, THE Makefile SHALL pass through the `E2E_PROFILE` environment variable to the script
+
+#### Properties
+
+- P60.1: E2E script defaults to local profile — invocation without flags passes `--profile local` to all LLM-dependent binary calls (Req 60, AC 1)
+
+### Requirement 61: Dedicated Sentence Prompt Template
+
+**User Story:** As a language learner, I want sentence lookups to use a dedicated prompt template that analyzes my sentence for grammar errors and extracts key vocabulary, so that I get useful feedback on sentences I write rather than having them treated as fixed expressions.
+
+#### Acceptance Criteria
+
+1. WHEN the Sentence_Template is defined, THE Sentence_Template SHALL be a Go string constant containing `{source_language}`, `{sentence}`, `{context}`, and `{target_language_name}` placeholders
+2. WHEN the Sentence_Template is defined, THE Sentence_Template SHALL instruct the LLM to return JSON with English field names: `sentence` (string, required — the original sentence), `translation` (string, required — full sentence translation into the target language), `grammar_check` (object, required — containing `has_errors` boolean, `corrected_sentence` string, and `errors` array), and `vocabulary` (array, required — key vocabulary items extracted from the sentence)
+3. WHEN the Sentence_Template is defined, THE Sentence_Template SHALL instruct the LLM to check for grammatical errors including word order, verb conjugation, spelling, case/gender agreement, and preposition usage
+4. WHEN the Sentence_Template is defined, THE Sentence_Template SHALL instruct the LLM to provide a corrected version of the sentence when errors are found, and explain each error (what went wrong, why, and the correct form)
+5. WHEN the Sentence_Template is defined, THE Sentence_Template SHALL instruct the LLM to extract key vocabulary items from the sentence, each with `word`, `type` (POS in source language terminology), `definition` (in source language), and `english` (English translation) fields
+6. WHEN the Sentence_Template is formatted with any source language name, THE Sentence_Template SHALL produce a valid prompt that generates correct sentence analysis for that language
+7. WHEN `BuildPrompt` is called with mode `"sentence"`, THE `BuildPrompt` function SHALL select the Sentence_Template and inject all parameters
+8. WHEN `ValidateResponse` is called with mode `"sentence"`, THE Validator SHALL validate against the sentence schema: `sentence` (string, required), `translation` (string, required), `grammar_check` (object, required with `has_errors` bool, `corrected_sentence` string, `errors` array), `vocabulary` (array, required)
+9. WHEN the `grammar_check.errors` array contains entries, THE Validator SHALL verify each entry has `original` (string), `corrected` (string), and `explanation` (string) fields
+10. WHEN the `mode()` function in the service layer receives `"sentence"`, THE function SHALL return `"sentence"` (not `"expressions"`)
+
+#### Properties
+
+- P61.1: Sentence template formatting produces valid prompts for any source language name — contains resolved name, sentence, target language, no unresolved placeholders (Req 61, AC 1, 6)
+- P61.2: BuildPrompt with mode "sentence" selects the Sentence_Template and produces distinct output from words and expressions modes (Req 61, AC 7)
+- P61.3: ValidateResponse with mode "sentence" validates against the sentence schema and rejects responses missing required fields (Req 61, AC 8, 9)
+
+### Requirement 62: Sentence Lookups Are Ephemeral
+
+**User Story:** As a language learner, I want sentence lookups to be rendered directly without being saved to the database, so that my vocabulary database contains only reusable word and expression entries, not one-off sentence analyses.
+
+#### Acceptance Criteria
+
+1. WHEN a sentence lookup completes, THE App SHALL NOT write the result to the Database
+2. WHEN a sentence lookup completes, THE App SHALL render the result directly to CLI output or Web UI and then discard it
+3. WHEN a sentence lookup is requested, THE App SHALL NOT check the Database cache (sentences are always fresh LLM invocations)
+4. WHEN a sentence lookup is requested via the Web_UI, THE Web_UI SHALL display the grammar check results, corrected sentence, error explanations, and extracted vocabulary in a structured layout
+5. WHEN a sentence lookup is requested via the CLI, THE CLI SHALL print the sentence analysis as formatted JSON
+
+#### Properties
+
+- P62.1: Sentence lookup ephemeral — sentence lookups never write to the Database and never read from the cache; the LLM is always invoked (Req 62, AC 1, 3)
+
+### Requirement 63: Bulk Delete Database Entries
+
+**User Story:** As a language learner, I want to select multiple database entries and delete them in one action, so that I can clean up my vocabulary database efficiently.
+
+#### Acceptance Criteria
+
+1. WHEN the Database_Page is displayed, THE Web_UI SHALL show a checkbox next to each entry row
+2. WHEN the user clicks a "select all" checkbox, THE Web_UI SHALL toggle all visible entry checkboxes
+3. WHEN one or more entries are selected, THE Web_UI SHALL display a bulk delete action bar
+4. WHEN the user confirms bulk delete, THE Web_UI SHALL send a single DELETE request with all selected entry IDs
+5. WHEN the bulk delete API receives a list of IDs, THE Store SHALL delete all entries matching those IDs
+6. WHEN the bulk delete completes, THE Web_UI SHALL refresh the entry table to reflect the deletions
+
+### Requirement 64: Batch Processing Cancellation
+
+**User Story:** As a language learner, I want to cancel a running batch from the Web UI, so that I can stop processing without losing partial results.
+
+#### Acceptance Criteria
+
+1. WHEN a batch is processing in the Web_UI, THE Web_UI SHALL display a Cancel button
+2. WHEN the user clicks Cancel, THE Web_UI SHALL abort the fetch request via AbortController
+3. WHEN the server detects context cancellation during batch processing, THE service layer SHALL stop processing remaining tokens
+4. WHEN batch processing is cancelled, THE server SHALL emit a `cancelled` SSE event with partial results
+5. WHEN batch processing is cancelled, THE Web_UI SHALL display partial results with a cancellation notice
+6. WHEN batch processing is cancelled, THE entries processed before cancellation SHALL remain in the Database
+
+## Correctness Properties
+
+*Carried forward from the Python prototype and adapted for Go. Each property is tested with `rapid` (Go PBT library) using table-driven test patterns. Properties are also documented inline under their respective requirements above.*
+
+| ID | Property | Validates |
+|---|---|---|
+| P1 | Template formatting produces valid prompts for any source language — contains resolved name, token, target language, no unresolved placeholders, Core Rule Block, Decision Rubric (words/expressions) or grammar check instructions (sentence) | Req 1, 2, 6, 61 |
+| P2 | Translation field normalization — plain string or object with `primary`/`alternatives` normalizes to consistent object format | Req 3.3, 3.4 |
+| P3 | Optional fields default to empty string when absent | Req 3.5 |
+| P4 | Missing required fields return validation error listing all missing fields | Req 3.6, 3.7, 3.9 |
+| P5 | BuildPrompt injects all parameters (source language, token, context, target language) into output | Req 6.1–6.7 |
+| P6 | CSV parsing returns exactly the non-empty lines as (token, context) pairs | Req 14.2, 14.5, 14.6 |
+| P7 | Field mapper pass-through preserves non-translation fields | Req 5.1 |
+| P8 | Translation flattening — `{primary} (alternatives)` when alternatives non-empty, `primary` when empty | Req 5.2, 5.5 |
+| P9 | Validation accepts any valid English-schema JSON for matching mode | Req 3.1, 3.2, 43.10 |
+| P10 | Token normalization is idempotent — `normalize(normalize(x)) == normalize(x)` | Req 15, 16 |
+| P11 | Database cache idempotency — two lookups = one LLM call + one cache hit, identical data | Req 18.1–18.4 |
+| P12 | UTF-8 round-trip consistency — read → write to DB → read back preserves exact characters | Req 39 |
+| P13 | Dry-run no side effects — no DB writes, no LLM invocations, no persistent state changes | Req 37 |
+| P14 | Config file round-trip — `SaveConfig` then `LoadConfig` produces equal struct | Req 34 |
+| P15 | Limit enforcement — for limit N and M tokens (M > N), at most N LLM invocations (excluding cached) | Req 23.6 |
+| P16 | Error resilience — valid items complete even when errors occur for other items in batch | Req 36.3 |
+| P17 | Provider interface consistency — invoke returns string or error (never both nil); name returns non-empty string | Req 7.2, 7.3, 7.6 |
+| P18 | Multi-version entry integrity — "add" = N+1 entries, "replace" by ID = N entries with target updated, "skip" = no changes; FindWords/FindExpressions returns all entries | Req 53, 54, 57 |
+| P19 | Context-aware cache bypass — empty context returns cache without LLM; non-empty context invokes LLM regardless; DB state consistent with conflict strategy | Req 55, 18.6 |
+| P20 | Multi-profile config round-trip — save then load preserves all profiles and default_profile setting | Req 58, 34 |
+| P21 | Unknown profile name returns error — loading with non-existent profile name always returns descriptive error | Req 58.4 |
+| P22 | Flat config backward compat — old single-profile format loads as implicit `default` profile without error | Req 58.5 |
+| P24 | CreateProfile duplicate name error — creating a profile with an existing name returns error without modifying profiles | Req 58.12 |
+| P25 | CreateProfile copies source — new profile contains same values as source profile and is added to FileConfig | Req 58.11 |
+| P23 | Local LLM setup produces valid config — after successful setup, config contains non-empty provider, base_url, and model_id | Req 59.7 |
+| P26 | Sentence template formatting produces valid prompts for any source language — no unresolved placeholders, distinct from words/expressions | Req 61.1, 61.6, 61.7 |
+| P27 | Sentence validation accepts valid sentence JSON and rejects missing required fields | Req 61.8, 61.9 |
+| P28 | Sentence lookup ephemeral — never writes to DB, never reads cache, always invokes LLM | Req 62.1, 62.3 |
+
+### Requirement 65: Docker Image Distribution
+
+**User Story:** As a user, I want to run VocabGen as a Docker container, so that I can use it on any Docker-capable host (NAS, home server, CI) without downloading platform-specific binaries.
+
+#### Acceptance Criteria
+
+1. WHEN `docker build` is run on the repository, THE Dockerfile SHALL produce a working image using a multi-stage build (Go builder → distroless runtime)
+2. WHEN the image is built, THE binary SHALL be compiled with `CGO_ENABLED=0` and ldflags for version injection via a `VERSION` build arg
+3. WHEN the container starts without arguments, THE entrypoint SHALL default to `vocabgen serve --port 8080`
+4. WHEN the container runs, THE image SHALL expose port 8080 and declare a volume for `~/.vocabgen/` persistence
+5. WHEN the image is inspected, THE runtime stage SHALL use `gcr.io/distroless/static:nonroot` (no shell, no root user)
+6. WHEN a `v*` tag is pushed, THE goreleaser config SHALL build Docker images for both `linux/amd64` and `linux/arm64` and push to `ghcr.io/npozs77/vocabgen`
+7. WHEN images are pushed, THE goreleaser config SHALL create multi-arch manifest lists for both `:<version>` and `:latest` tags
+8. WHEN the release workflow runs, THE job SHALL have `packages: write` permission and authenticate with GHCR via `docker/login-action`
+9. WHEN the release workflow runs, THE job SHALL set up Docker Buildx and QEMU for cross-platform builds
+10. WHEN `docker build` runs, THE `.dockerignore` SHALL exclude `.git`, `.github`, `.kiro`, `.vscode`, `reference/`, `coverage.out`, `dist/`, and the local binary
+11. WHEN a user reads the README, THE Docker section SHALL show a `docker run` command with port mapping, volume mount, and env var for API keys
+12. WHEN a user reads `docs/deployment.md`, THE Docker section SHALL document image tags, volume mount path, CLI commands via Docker, and local build instructions
+13. WHEN a user reads `docs/user-guide.md`, THE Installation section SHALL mention Docker as an alternative to binary download
+
+#### Properties
+
+- P65.1: Image builds successfully from clean checkout (Req 65, AC 1)
+- P65.2: Default CMD starts web server on port 8080 (Req 65, AC 3)
+- P65.3: Container runs as nonroot user (Req 65, AC 5)
+
+**Property coverage**: 28 properties across 65 requirements. Requirements without dedicated properties are either structural (CLI flags, UI layout), integration-level (tested via integration tests with mocks), or covered transitively by properties on their dependencies.
+
+## Non-Functional Requirements
+
+### Usability
+
+- WHEN the App returns an error, THE error message SHALL be actionable — identifying what failed and suggesting corrective action
+- WHEN the CLI is invoked with `--help`, THE output SHALL clearly describe all flags, subcommands, and defaults
+- WHEN the Web_UI displays forms, THE forms SHALL pre-populate defaults from the Config_Manager
+- WHEN batch processing runs, THE App SHALL provide real-time progress feedback (CLI: log lines; Web: SSE progress bar)
+
+### Performance
+
+- WHEN local operations run (parsing, validation, DB queries), THE operations SHALL complete in negligible time relative to LLM latency
+- WHEN the Database is queried, THE Cache_Layer SHALL return cached results without perceptible delay for databases up to 50,000 entries
+- WHEN batch processing runs, THE App SHALL not introduce overhead beyond LLM API latency per item
+
+### Maintainability
+
+- WHEN new source languages are added, THE App SHALL require only a registry entry (no template or schema changes)
+- WHEN new LLM providers are added, THE App SHALL require only a new provider file and a registry entry
+- WHEN the codebase is maintained, THE App SHALL use `log/slog` structured logging (no `fmt.Println` in production code)
+- WHEN tests are written, THE test suite SHALL use table-driven tests and `rapid` PBT — no mocking frameworks
+
+### Compatibility
+
+- WHEN the App is distributed, THE App SHALL run on macOS (amd64, arm64), Linux (amd64, arm64), and Windows (amd64) as a single binary
+- WHEN the App is distributed, THE App SHALL also be available as a multi-arch Docker image (`linux/amd64`, `linux/arm64`) on GitHub Container Registry
+- WHEN the App is compiled, THE App SHALL use a pure-Go SQLite driver compatible with cross-compilation
+- WHEN the App connects to LLM providers, THE App SHALL support Bedrock, OpenAI, Anthropic, Vertex AI, and OpenAI-compatible servers (Ollama, LM Studio)
+- WHEN the App is built, THE App SHALL require Go 1.22+ and no external runtime dependencies
+
+## Constraints
+
+1. **No API Keys in Config**: API keys and AWS secrets SHALL NOT be stored in `config.yaml`; use environment variables or `--api-key` CLI flag
+2. **No Per-Language Code Branches**: Templates, validation, and field mapping SHALL be language-agnostic; no per-language prompt constants or schema definitions
+3. **No Web Framework**: Use stdlib `net/http` — no gin, echo, fiber, or other HTTP frameworks
+4. **No ORM**: Use `database/sql` with parameterized queries — no GORM, sqlx, or similar
+5. **No Mocking Frameworks**: Use Go interfaces and manual test doubles — no gomock, testify/mock
+6. **No fmt.Println in Production**: All logging via `log/slog`
+7. **Pure-Go SQLite**: Use a pure-Go or CGo-compatible SQLite driver (e.g., modernc.org/sqlite) — no CGo-only drivers that break cross-compilation
+8. **Single Binary**: All templates, static assets, and the SQLite driver SHALL be embedded in the binary via `go:embed`
+9. **Reference Directory Read-Only**: The `reference/` directory contains the Python prototype and is for reference only — never modify
+10. **Solo Developer Scale**: Optimized for personal use and occasional sharing with classmates — not enterprise
+
+## Success Criteria
+
+The Go Vocabulary Generator is successfully implemented when:
+
+1. All 65 requirements have passing acceptance criteria verified by tests
+2. All 28 correctness properties pass with `rapid` PBT
+3. `go test -race ./...` passes with zero failures
+4. `go vet ./...` and `staticcheck ./...` report zero issues
+5. The binary cross-compiles for all 5 target platforms (macOS amd64/arm64, Linux amd64/arm64, Windows amd64)
+6. CLI subcommands (`lookup`, `batch`, `serve`, `backup`, `restore`, `version`, `update`) work end-to-end
+7. Web UI pages (Lookup, Batch, Config, Database) render and function correctly with HTMX interactions
+8. LLM provider interface works with at least Bedrock and one API-key provider (OpenAI or Anthropic)
+9. SQLite cache eliminates duplicate LLM calls for previously looked-up tokens
+10. Documentation covers CLI usage (via Cobra `--help`) and godoc comments on all exported symbols
+11. Named config profiles allow switching between providers via `--profile <name>` on CLI and dropdown in Web UI
+12. `scripts/setup-local-llm.sh` installs Ollama, pulls a model, and writes a working `local` profile
+13. E2E tests default to the `local` profile and run without cloud API costs when Ollama is available
+14. Docker images are published to GHCR on tagged releases with multi-arch support (amd64/arm64)
+
+
+### Requirement 66: Database Picker and Live Database Switching
+
+**User Story:** As a language learner, I want to select or create databases from the Web UI Config page and have the switch take effect immediately, so that I can manage per-course or per-project vocabulary without restarting the server.
+
+#### Acceptance Criteria
+
+1. WHEN the Config page loads, THE database picker dropdown SHALL list all `.db` files found in the config directory
+2. WHEN the user selects an existing database from the dropdown and saves, THE server SHALL close the current database connection and open the selected database immediately (no restart required)
+3. WHEN the user selects "Create new…" and enters a valid name, THE server SHALL create the empty `.db` file on save and switch to it immediately
+4. WHEN the user enters an invalid database name (containing characters other than letters, numbers, hyphens, underscores), THE server SHALL display a validation error
+5. WHEN the user enters a name that conflicts with an existing `.db` file, THE server SHALL display a conflict error
+6. WHEN the user switches config profiles and the new profile has a different `db_path`, THE server SHALL switch to the new database immediately
+7. WHEN `db_path` is set to `__new__` without a `db_path_new_name`, THE server SHALL fall back to the current database path
+8. WHEN the database picker dropdown is rendered, THE dropdown SHALL be populated server-side (not via client-side HTMX/JS fetch)
+
+#### Properties
+
+- P66.1: Database picker lists all .db files in config directory (Req 66, AC 1)
+- P66.2: Live database switch closes old connection and opens new one (Req 66, AC 2, 6)
+- P66.3: New database file is created on disk when "Create new" is saved (Req 66, AC 3)
+- P66.4: Invalid names are rejected with clear error (Req 66, AC 4, 5)
+
+### Requirement 67: Multiple Meanings / Skip-Cache Lookup
+
+**User Story:** As a language learner, I want to add multiple meanings for the same word (e.g., "beslaan" as "to fog up", "to occupy", "to shoe a horse"), each with its own context sentence, so that polysemous words are captured as separate, properly contextualized entries.
+
+#### Acceptance Criteria
+
+1. WHEN the user checks "Skip cache / Add new meaning" in the Web UI lookup form, THE system SHALL bypass the SQLite cache entirely and invoke the LLM
+2. WHEN skip-cache is active, THE context sentence field SHALL be required (enforced client-side and server-side)
+3. WHEN skip-cache is active and a context sentence is provided, THE system SHALL insert the LLM result as a new row without conflict resolution
+4. WHEN the user uses `--new-meaning` on the CLI, THE system SHALL require `--context` and return an error if missing
+5. WHEN a word has 2 or more entries in the database, THE disambiguation display SHALL show numeric suffixes: `word (1)`, `word (2)`, etc.
+6. WHEN a word has exactly 1 entry, THE disambiguation display SHALL NOT show any suffix
+7. WHEN disambiguation is applied, THE suffixes SHALL appear in the database browser, flashcards, and XLSX export
+8. WHEN skip-cache is active in batch mode, THE system SHALL skip tokens without a context sentence and insert new rows for tokens with context
+9. WHEN the `SkipCache` field is false (default), THE system SHALL behave identically to the existing cache-first flow
+
+#### Properties
+
+- P67.1: Skip-cache with context always inserts a new row (Req 67, AC 3)
+- P67.2: Skip-cache without context returns error (Req 67, AC 2, 4)
+- P67.3: Disambiguation suffix appears only when total > 1 (Req 67, AC 5, 6)
+- P67.4: DisambiguatedWord is idempotent for display — never modifies stored data (Req 67, AC 7)
+
+### Requirement 68: Database Detail Panel Toggle
+
+**User Story:** As a user browsing the database, I want to click an expanded word/expression detail panel to collapse it, so that I can manage screen space without scrolling.
+
+#### Acceptance Criteria
+
+1. WHEN the user clicks an expanded detail panel in the database view, THE panel SHALL collapse (toggle behavior)
+2. WHEN the user clicks a collapsed entry, THE detail panel SHALL expand as before

--- a/.kiro/specs/go-vocabulary-generator/tasks.md
+++ b/.kiro/specs/go-vocabulary-generator/tasks.md
@@ -1,0 +1,1054 @@
+# Implementation Plan: Go Vocabulary Generator
+
+## Overview
+
+Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary generation. Implementation follows dependency order: project scaffolding → foundational packages (config, language, parsing) → providers (llm) → storage (db) → business logic (service) → output → interfaces (CLI, web) → operational (backup, build). Each task includes co-located tests (property-based with `rapid`, table-driven, and fuzz where applicable).
+
+## Tasks
+
+- [x] 1. Project scaffolding and build tooling
+  - [x] 1.1 Initialize Go module and directory structure
+    - Run `go mod init` with the project module path
+    - Create directory skeleton: `cmd/vocabgen/`, `internal/config/`, `internal/db/`, `internal/language/`, `internal/llm/`, `internal/output/`, `internal/parsing/`, `internal/service/`, `internal/web/templates/`, `internal/web/templates/partials/`
+    - Create placeholder `main.go` in `cmd/vocabgen/` with a minimal `func main()` that prints "vocabgen" and exits
+    - Add `go.sum` by running `go mod tidy`
+    - _Requirements: 35.1, 35.3_
+    - _Design: Package Layout section_
+  - [x] 1.2 Create Makefile with build, test, lint, vet, and fmt-check targets
+    - `build`: `go build -o vocabgen ./cmd/vocabgen`
+    - `test`: `go test -race ./...`
+    - `lint`: `staticcheck ./...`
+    - `vet`: `go vet ./...`
+    - `fmt-check`: verify all `.go` files are `gofmt`-formatted, fail if not
+    - Add a `clean` target to remove the binary
+    - _Requirements: 45.1–45.6_
+    - _Design: Operational Procedures section_
+  - [x] 1.3 Add core dependencies to go.mod
+    - `github.com/spf13/cobra` (CLI framework)
+    - `pgregory.net/rapid` (property-based testing)
+    - `modernc.org/sqlite` (pure-Go SQLite driver)
+    - `gopkg.in/yaml.v3` (YAML config)
+    - `github.com/xuri/excelize/v2` (Excel export)
+    - Run `go mod tidy` to resolve all transitive dependencies
+    - _Requirements: 35.4_
+    - _Design: Design Decisions table_
+
+- [x] 2. Checkpoint — Verify project builds and `make test` passes
+  - Ensure `make build` produces a binary, `make test` runs (even with no tests yet), `make vet` passes. Ask the user if questions arise.
+  - **Go Learning**: Explain Go modules (`go.mod`/`go.sum`), the `internal/` encapsulation pattern (compiler-enforced), and how `go build`/`go test` work. Ask the user if they have questions before proceeding.
+  - **Microstudy**: Write `reference/learning-go-microstudy/01-modules-and-build.md` — generic Go reference covering modules, `internal/`, `go build`, `go test`, and Python→Go comparison. No project-specific references.
+
+- [x] 3. Config package (`internal/config/`)
+  - [x] 3.1 Implement Config struct, DefaultConfig, LoadConfig, and SaveConfig
+    - Define `Config` struct with YAML tags: provider, aws_profile, aws_region, model_id, base_url, gcp_project, gcp_region, default_source_language, default_target_language, db_path
+    - `DefaultConfig()` returns: provider "bedrock", aws_region "us-east-1", default_source_language "nl", default_target_language "hu", db_path "~/.vocabgen/vocabgen.db"
+    - `LoadConfig()` reads `~/.vocabgen/config.yaml`, returns `DefaultConfig()` if file missing
+    - `SaveConfig(cfg)` writes YAML to `~/.vocabgen/config.yaml`, creates directory if needed
+    - `SaveConfig` must NOT serialize any `api_key` field — API keys are runtime-only
+    - _Requirements: 33.1–33.9, 34.1–34.2_
+    - _Design: Section 7 — internal/config_
+  - [x] 3.2 Write property test P14: Config file round-trip
+    - **Property 14: Config file round-trip**
+    - Generate random valid `Config` structs with `rapid`, save via `SaveConfig` to a temp dir, load via `LoadConfig`, assert equality
+    - Use a temp directory to avoid touching the real `~/.vocabgen/`
+    - **Validates: Requirements 34.1, 34.2**
+  - [x] 3.3 Write table-driven tests for config defaults and no-secrets
+    - Test `LoadConfig` returns `DefaultConfig()` when file is missing
+    - Test `SaveConfig` output YAML does not contain `api_key`
+    - Test `SaveConfig` creates directory if it doesn't exist
+    - _Requirements: 33.4, 33.6, 33.7_
+
+- [x] 4. Language package (`internal/language/`)
+  - [x] 4.1 Implement SupportedLanguages registry and ResolveLanguageName
+    - Define `SupportedLanguages` map: nl→Dutch, hu→Hungarian, it→Italian, ru→Russian, en→English, de→German, fr→French, es→Spanish, pt→Portuguese, pl→Polish, tr→Turkish
+    - `ResolveLanguageName(code)` returns full name for known codes, returns input as-is for unknown codes/names
+    - _Requirements: 4.5, 6.2, 6.3_
+    - _Design: Section 2 — registry.go_
+  - [x] 4.2 Write table-driven tests for language resolution
+    - Test all 11 known codes resolve correctly (nl→Dutch, hu→Hungarian, etc.)
+    - Test unknown code "xx" passes through as "xx"
+    - Test full name "German" passes through as "German"
+    - Test non-Latin name "日本語" passes through
+    - _Requirements: 6.2, 6.3, 43.6_
+  - [x] 4.3 Implement WordsTemplate, ExpressionsTemplate constants and BuildPrompt function
+    - Define `WordsTemplate` as a Go string constant with `{source_language}`, `{word}`, `{context}`, `{target_language_name}` placeholders, including Core Rule Block and Decision Rubric
+    - Define `ExpressionsTemplate` as a Go string constant with `{source_language}`, `{expression}`, `{context}`, `{target_language_name}` placeholders, including Core Rule Block and Decision Rubric
+    - `BuildPrompt(sourceLang, mode, token, context, targetLang)` resolves language names, selects template by mode, replaces all placeholders via `strings.NewReplacer`
+    - Return error for invalid mode values (not "words" or "expressions")
+    - WordsTemplate must instruct the LLM to return an `english_definition` field (concise English-language explanation of the word's meaning)
+    - ExpressionsTemplate must instruct the LLM to return an `english_definition` field (concise English-language explanation of the expression's meaning)
+    - _Requirements: 1.1–1.15, 2.1–2.12, 4.1–4.4, 6.1–6.7, 40.1–40.4, 41.1–41.3, 42.1–42.4_
+    - _Design: Section 2 — templates.go_
+  - [x] 4.4 Write property test P1: Template formatting produces valid prompts
+    - **Property 1: Template formatting produces valid prompts for any source language**
+    - Generate random source language strings (known codes, arbitrary names, Unicode), random tokens, random context strings, random target language codes
+    - Assert output contains: resolved source language name, token, target language name, Core Rule Block text, Decision Rubric text, no unresolved `{...}` placeholders
+    - **Validates: Requirements 1.10, 2.9, 4.5**
+  - [x] 4.5 Write property test P5: BuildPrompt injects all parameters
+    - **Property 5: BuildPrompt injects all parameters into output**
+    - Generate random source language, mode (sampled from "words"/"expressions"), token, context, target language
+    - Assert output contains resolved source language name, token, context (when non-empty), resolved target language name
+    - **Validates: Requirements 6.1–6.7, 42.1–42.4**
+  - [x] 4.6 Write table-driven tests for template content and BuildPrompt mode selection
+    - Test WordsTemplate contains all 14 English field names from the schema (including `english_definition`)
+    - Test ExpressionsTemplate contains all 10 English field names from the schema (including `english_definition`)
+    - Test BuildPrompt with mode "words" uses WordsTemplate, mode "expressions" uses ExpressionsTemplate
+    - Test BuildPrompt with invalid mode returns error
+    - Test BuildPrompt for each supported language produces prompt containing correct language name
+    - _Requirements: 1.2, 2.2, 6.4, 6.7, 43.4, 43.6_
+  - [x] 4.7 Implement ValidateResponse, ValidatedEntry, Translation types, and ValidationError
+    - Define `Translation` struct with `Primary` and `Alternatives` string fields
+    - Define `ValidatedEntry` struct with all word/expression fields using `Translation` for english/target_translation; include `EnglishDefinition string` field
+    - Define `ValidationError` with `Message` and `Fields` slice
+    - `ValidateResponse(mode, rawJSON)` parses JSON, validates required fields per mode, normalizes translation fields (plain string → `{primary: s, alternatives: ""}`), defaults optional fields to `""`
+    - Words required: word, type, article, definition, example, english, target_translation
+    - Expressions required: expression, definition, example, english, target_translation
+    - Words optional: english_definition, notes, connotation, register, collocations, contrastive_notes, secondary_meanings
+    - Expressions optional: english_definition, notes, connotation, register, contrastive_notes
+    - Return `ValidationError` listing missing required fields or malformed translation fields
+    - _Requirements: 3.1–3.9_
+    - _Design: Section 2 — validation.go_
+  - [x] 4.8 Write property test P2: Translation field normalization
+    - **Property 2: Translation field normalization**
+    - Generate random translation values: either plain strings or JSON objects with `primary` (string) and optional `alternatives` (string)
+    - Assert normalization produces `{Primary: string, Alternatives: string}` with alternatives defaulting to `""`
+    - **Validates: Requirements 3.3, 3.4**
+  - [x] 4.9 Write property test P3: Optional fields default to empty string
+    - **Property 3: Optional fields default to empty string**
+    - Generate valid JSON with random subsets of optional fields removed
+    - Assert validator succeeds and missing optional fields are `""` in the returned struct
+    - **Validates: Requirement 3.5**
+  - [x] 4.10 Write property test P4: Missing required fields return validation error
+    - **Property 4: Missing required fields and malformed values return validation error**
+    - Generate valid JSON, then remove a random non-empty subset of required fields
+    - Assert `ValidateResponse` returns a `ValidationError` whose message mentions every removed field name
+    - Also test non-string values for optional fields and malformed translation fields (neither string nor valid object)
+    - **Validates: Requirements 3.6, 3.7, 3.8, 3.9**
+  - [x] 4.11 Write property test P9: Validation accepts any valid English-schema JSON
+    - **Property 9: Validation accepts any valid English-schema JSON**
+    - Generate complete valid JSON objects with all required English fields as strings, translation fields as string or valid object
+    - Assert `ValidateResponse` succeeds for both "words" and "expressions" modes
+    - Assert round-trip through `ValidateResponse` then `MapFields` produces no error
+    - **Validates: Requirements 3.1, 3.2, 43.10**
+  - [x] 4.12 Write fuzz tests for ValidateResponse
+    - `FuzzValidateResponse` — fuzz with random JSON strings to find panics or unexpected behavior
+    - Seed corpus with valid words JSON, valid expressions JSON, empty string, `{}`, `[]`, malformed JSON
+    - _Requirements: 43.3_
+    - _Design: Fuzz Testing section_
+
+- [x] 5. Parsing package (`internal/parsing/`)
+  - [x] 5.1 Implement ReadInputFile and TokenWithContext
+    - Define `TokenWithContext` struct with `Token` and `Context` string fields
+    - `ReadInputFile(path)` reads CSV using UTF-8 encoding, returns `[]TokenWithContext`
+    - Skip empty/whitespace-only lines
+    - Single-column lines: token with empty context
+    - Two-column lines: token and context
+    - All non-empty lines treated as data (no header detection)
+    - Return error for file not found or empty file (after skipping blanks)
+    - _Requirements: 14.1–14.7_
+    - _Design: Section 3 — csv.go_
+  - [x] 5.2 Implement NormalizeWord and NormalizeExpression
+    - `NormalizeWord(raw)`: strip quotes, vocabulary-list markers (`*`, `>`, `(sep.)`), conjugation annotations (parenthetical groups with commas), collapse multiple spaces to single, strip leading/trailing whitespace, preserve simple parenthetical info (e.g., `(ergens)`, `(zich)`)
+    - `NormalizeExpression(raw)`: strip quotes, vocabulary-list markers, conjugation annotations, collapse multiple spaces to single, strip leading/trailing whitespace
+    - Both return empty string for whitespace-only input
+    - _Requirements: 15.1–15.7, 16.1–16.5_
+    - _Design: Section 3 — normalize.go_
+  - [x] 5.3 Write property test P6: CSV parsing
+    - **Property 6: CSV parsing**
+    - Generate lists of CSV lines: mix of empty lines, single-column data, two-column data
+    - Write to temp file, read with `ReadInputFile`
+    - Assert returned count equals non-empty line count; two-column lines have both token and context; single-column lines have empty context
+    - **Validates: Requirements 14.2, 14.5, 14.6**
+  - [x] 5.4 Write property test P10: Token normalization idempotence
+    - **Property 10: Token normalization consistency (idempotence)**
+    - Generate random strings with quotes, spaces, parentheses mixed in
+    - Assert `NormalizeWord(NormalizeWord(x)) == NormalizeWord(x)` and same for `NormalizeExpression`
+    - **Validates: Requirements 15.1–15.4, 16.1–16.3**
+  - [x] 5.5 Write table-driven tests for parsing edge cases
+    - Test file not found returns error
+    - Test empty file returns error
+    - Test whitespace-only lines are skipped
+    - Test nested parentheses preserved in NormalizeWord
+    - Test mixed quotes removed
+    - Test whitespace-only input returns empty string
+    - _Requirements: 14.3, 14.4, 15.3_
+  - [x] 5.6 Write fuzz tests for NormalizeWord and NormalizeExpression
+    - `FuzzNormalizeWord` — fuzz with random strings to find panics
+    - `FuzzNormalizeExpression` — fuzz with random strings to find panics
+    - Seed corpus with: empty string, quotes, parentheses, Unicode, mixed whitespace
+    - _Requirements: 43.3_
+    - _Design: Fuzz Testing section_
+
+- [x] 6. Checkpoint — Foundational packages complete
+  - Ensure all tests pass with `make test`. Verify `internal/config`, `internal/language`, and `internal/parsing` compile and tests pass. Ask the user if questions arise.
+  - **Go Learning**: Explain Go error handling patterns (errors as values, `fmt.Errorf` with `%w`, `errors.Is`/`errors.As`), struct tags (YAML, JSON), `strings.NewReplacer` for template formatting, and the table-driven test pattern (`[]struct` + `t.Run`). Explain how `rapid.Check` works for property-based testing vs table-driven tests. Ask the user if they have questions before proceeding.
+  - **Microstudy**: Write `reference/learning-go-microstudy/02-errors-structs-and-testing.md` — generic Go reference covering error handling patterns, struct tags, `strings.NewReplacer`, table-driven tests, and `rapid.Check` PBT. No project-specific references.
+
+- [x] 7. LLM provider package (`internal/llm/`)
+  - [x] 7.1 Implement Provider interface, ProviderError, ProviderOptions, and Registry
+    - Define `Provider` interface with `Invoke(ctx context.Context, prompt, modelID string) (string, error)` and `Name() string`
+    - Define `ProviderError` struct with `Provider`, `Message`, `Err` fields; implement `Error()` and `Unwrap()`
+    - Define `NewProviderFunc` type and `ProviderOptions` struct (APIKey, BaseURL, Region, Profile, GCPProject)
+    - Define `Registry` map with entries for "bedrock", "openai", "anthropic", "vertexai"
+    - _Requirements: 7.1–7.7, 11.4–11.5, 13.1–13.4_
+    - _Design: Section 1 — provider.go_
+  - [x] 7.2 Implement BedrockProvider
+    - `NewBedrockProvider(opts)` creates AWS SDK v2 Bedrock Runtime client using credential chain and region
+    - `Invoke` sends prompt via Bedrock Runtime API, extracts text from response, strips provider envelope
+    - Retry once on throttling/timeout errors (1 second delay)
+    - Return `ProviderError` on empty response, auth failure, or exhausted retries
+    - Validate region supports Bedrock before creating client
+    - _Requirements: 8.1–8.6, 12.1, 12.5_
+    - _Design: Section 1 — bedrock.go_
+  - [x] 7.3 Implement OpenAIProvider
+    - `NewOpenAIProvider(opts)` creates HTTP client; validates API key present (unless custom base URL set)
+    - `Invoke` sends chat completion request to OpenAI API (or custom base URL), extracts text content
+    - Support custom base URL for Azure, Ollama, LM Studio, vLLM compatibility
+    - Allow invocation without API key when custom base URL is set
+    - Retry once on HTTP 429 rate-limit (1 second delay)
+    - Return `ProviderError` on auth failure, empty response, or exhausted retries
+    - _Requirements: 9.1–9.9, 12.2, 12.4, 12.6_
+    - _Design: Section 1 — openai.go_
+  - [x] 7.4 Implement AnthropicProvider
+    - `NewAnthropicProvider(opts)` creates HTTP client; validates API key present
+    - `Invoke` sends messages API request to Anthropic, extracts text content
+    - Retry once on HTTP 429 rate-limit (1 second delay)
+    - Return `ProviderError` on auth failure, empty response, or exhausted retries
+    - _Requirements: 10.1–10.5, 12.3, 12.4, 12.6_
+    - _Design: Section 1 — anthropic.go_
+  - [x] 7.5 Implement mock provider for testing (internal, unexported)
+    - Create `mock_test.go` with `mockProvider` struct: configurable response, error, invocation counter
+    - Create `failingMockProvider` variant that fails on specific tokens (for P16 error resilience tests)
+    - Both implement `Provider` interface
+    - _Design: Mock Provider for Testing section_
+  - [x] 7.6 Write property test P17: Provider interface consistency
+    - **Property 17: Provider interface consistency**
+    - Test against mock provider: `Invoke` returns either (non-empty string, nil error) or (empty string, non-nil error) — never both nil, never non-empty string with non-nil error
+    - `Name()` returns non-empty string
+    - Errors are wrappable as `*ProviderError`
+    - **Validates: Requirements 7.2, 7.3, 13.1, 13.4**
+  - [x] 7.7 Write table-driven tests for provider registry and error formatting
+    - Test Registry contains entries for "bedrock", "openai", "anthropic", "vertexai"
+    - Test `ProviderError.Error()` includes provider name in message
+    - Test `ProviderError.Unwrap()` returns underlying error
+    - Test OpenAI provider allows nil API key when base URL is set
+    - Test OpenAI provider rejects nil API key when no base URL
+    - Test Anthropic provider rejects nil API key
+    - _Requirements: 11.3, 13.1, 13.2_
+  - [ ]* 7.8 Implement VertexAIProvider (optional — can be deferred)
+    - `NewVertexAIProvider(opts)` creates HTTP client using Google ADC; validates GCP project ID present
+    - `Invoke` sends request to Vertex AI Gemini API, extracts text content
+    - Retry once on rate-limit errors (1 second delay)
+    - Return `ProviderError` on auth failure, empty response, or exhausted retries
+    - _Requirements: 51.1–51.7, 12.7_
+    - _Design: Section 1 — vertexai.go_
+
+- [x] 8. Database package (`internal/db/`)
+  - [x] 8.1 Implement SQLiteStore, schema migration, and models
+    - Define `WordRow` and `ExpressionRow` structs with all columns from the SQLite schema (including `EnglishDefinition string` field)
+    - Define `Store` interface with: FindWord, FindExpression, FindWords, FindExpressions, InsertWord, InsertExpression, ListWords, ListExpressions, UpdateWord, UpdateExpression, DeleteWord, DeleteExpression, ImportWords, ImportExpressions, Close, BackupTo, RestoreFrom
+    - Define `ListFilter` struct with SourceLang, TargetLang, Search, Page, PageSize fields
+    - `NewSQLiteStore(dbPath)` opens/creates SQLite DB, runs migrations, returns `*SQLiteStore`
+    - Implement `Migrate()`: create metadata table with schema_version=1, words table (including `english_definition TEXT` column), expressions table (including `english_definition TEXT` column), indexes on (source_language, word) and (source_language, expression)
+    - Each migration step runs in a transaction; failed step leaves DB unchanged
+    - Use parameterized queries for all SQL operations (no string concatenation)
+    - _Requirements: 17.1–17.5, 46.1–46.5, 47.1, 52_
+    - _Design: Section 6 — store.go, sqlite.go, schema.go, models.go_
+  - [x] 8.2 Implement CRUD operations (FindWord, InsertWord, FindExpression, InsertExpression, Update, Delete)
+    - `FindWord(ctx, word, sourceLang)` queries by word text and source_language, returns first match or nil
+    - `InsertWord(ctx, row)` inserts with created_at and updated_at timestamps (RFC3339)
+    - Same pattern for expressions
+    - `UpdateWord(ctx, id, row)` updates entry by ID, sets updated_at timestamp
+    - `UpdateExpression(ctx, id, row)` updates entry by ID, sets updated_at timestamp
+    - `DeleteWord/DeleteExpression` removes by ID
+    - All queries use parameterized `?` placeholders
+    - _Requirements: 18.1–18.3, 19.1–19.6_
+    - _Design: Section 6 — sqlite.go_
+  - [x] 8.8 Implement FindWords and FindExpressions (multi-version slice returns)
+    - `FindWords(ctx, word, sourceLang)` returns `[]WordRow` — all matching entries for a given word and source_language
+    - `FindExpressions(ctx, expr, sourceLang)` returns `[]ExpressionRow` — all matching entries
+    - Return empty slice (not nil) when no entries exist
+    - Retain `FindWord`/`FindExpression` (single-result) for backward compatibility
+    - No unique constraint on (source_language, word) or (source_language, expression) — multiple rows allowed
+    - _Requirements: 57.1–57.4, 53.1, 18.7_
+    - _Design: Section 6 — store.go FindWords/FindExpressions_
+  - [x] 8.3 Implement ListWords, ListExpressions with pagination and filtering
+    - Support filtering by source_language, target_language, search text (LIKE match against word/expression, definition, english, tags)
+    - Return paginated results (default 50 per page) and total count
+    - _Requirements: 28.3–28.6_
+    - _Design: Section 6 — store.go ListFilter_
+  - [x] 8.4 Implement ImportWords, ImportExpressions for bulk CSV import
+    - Bulk insert rows, skip duplicates (same word/expression + source_language)
+    - Return counts: imported, skipped, failed
+    - _Requirements: 29.2–29.6_
+    - _Design: Section 6 — store.go ImportWords/ImportExpressions_
+  - [x] 8.5 Implement BackupTo and RestoreFrom
+    - `BackupTo(ctx, destPath)` copies the SQLite file to a timestamped backup path
+    - `RestoreFrom(ctx, srcPath)` verifies backup is valid SQLite, creates backup of current DB, then replaces
+    - _Requirements: 48.1–48.6_
+    - _Design: Section 6 — store.go BackupTo/RestoreFrom_
+  - [x] 8.6 Write property test P12: UTF-8 round-trip consistency
+    - **Property 12: UTF-8 round-trip consistency**
+    - Generate random strings with Unicode characters (ë, ï, ü, ő, ű, à, è, ì, ò, ù, я, ё, etc.)
+    - Insert as word entry, read back via FindWord, assert exact character preservation
+    - Use in-memory or temp-file SQLite database
+    - **Validates: Requirements 39.1, 39.2**
+  - [x] 8.7 Write table-driven tests for schema migration and CRUD
+    - Test tables and indexes exist after migration
+    - Test InsertWord + FindWord round-trip
+    - Test InsertExpression + FindExpression round-trip
+    - Test FindWord returns nil for non-existent entry
+    - Test FindWords returns empty slice for non-existent entry
+    - Test FindWords returns all matching entries when multiple exist (multi-version)
+    - Test FindExpressions returns all matching entries when multiple exist
+    - Test UpdateWord by ID sets updated_at and updates correct entry among multiple versions
+    - Test DeleteWord removes entry by ID without affecting other versions
+    - Test ListWords pagination returns correct page size and total count
+    - Test ImportWords skips duplicates
+    - _Requirements: 17.1–17.5, 18.1–18.3, 46.1–46.5, 53.1, 57.1–57.5_
+
+- [x] 9. Checkpoint — Storage layer complete
+  - Ensure all tests pass with `make test`. Verify `internal/db` compiles and all CRUD, migration, and property tests pass. Ask the user if questions arise.
+  - **Go Learning**: Explain Go interfaces (implicit satisfaction, "accept interfaces, return structs"), `context.Context` (cancellation, timeouts, first parameter convention), `database/sql` patterns (parameterized queries, `sql.NullString`), and the `defer` pattern for resource cleanup (`defer db.Close()`). Ask the user if they have questions before proceeding.
+  - **Microstudy**: Write `reference/learning-go-microstudy/03-interfaces-context-and-sql.md` — generic Go reference covering implicit interfaces, `context.Context`, `database/sql` patterns, and `defer` for cleanup. No project-specific references.
+
+- [x] 10. Output package (`internal/output/`)
+  - [x] 10.1 Implement Entry struct, MapFields, and FlattenTranslation
+    - Define `Entry` struct with JSON tags for all output fields (word, expression, type, article, definition, english_definition, example, english, target_translation, notes, connotation, register, collocations, contrastive_notes, secondary_meanings, tags)
+    - `FlattenTranslation(t Translation)` returns `"primary (alternatives)"` when alternatives non-empty, else `"primary"`
+    - `MapFields(v *ValidatedEntry, mode string)` converts validated entry to output Entry, flattening translation objects; mode determines which fields are populated (words vs expressions)
+    - No per-language code branches — purely structural mapping
+    - _Requirements: 5.1–5.5_
+    - _Design: Section 5 — mapper.go_
+  - [x] 10.2 Implement ExportToExcel
+    - `ExportToExcel(entries []Entry, mode string)` writes entries to xlsx bytes using excelize
+    - Include column headers matching database field names
+    - Mode determines which columns to include (words have collocations, secondary_meanings; expressions don't)
+    - _Requirements: 30.1–30.4_
+    - _Design: Section 5 — excel.go_
+  - [x] 10.3 Write property test P7: Field mapper pass-through preserves non-translation fields
+    - **Property 7: Field mapper pass-through preserves non-translation fields**
+    - Generate random `ValidatedEntry` structs with random string field values
+    - Assert every non-translation field in the output `Entry` equals the corresponding input field
+    - **Validates: Requirement 5.1**
+  - [x] 10.4 Write property test P8: Translation flattening
+    - **Property 8: Translation flattening**
+    - Generate random `Translation` structs with random primary and alternatives strings
+    - Assert `FlattenTranslation` returns `"p (a)"` when alternatives non-empty, `"p"` when empty
+    - **Validates: Requirements 5.2, 5.5**
+  - [x] 10.5 Write table-driven tests for MapFields and FlattenTranslation
+    - Test FlattenTranslation with empty alternatives returns primary only
+    - Test FlattenTranslation with non-empty alternatives returns "primary (alternatives)"
+    - Test MapFields in words mode populates collocations and secondary_meanings
+    - Test MapFields in expressions mode omits collocations and secondary_meanings
+    - _Requirements: 5.2, 5.3, 5.4_
+  - [x] 10.6 Write fuzz test for FlattenTranslation
+    - `FuzzFlattenTranslation` — fuzz with random Translation structs to find panics
+    - Seed corpus with: empty strings, long strings, Unicode, special characters
+    - _Requirements: 43.3_
+    - _Design: Fuzz Testing section_
+
+- [x] 11. Service package (`internal/service/`)
+  - [x] 11.1 Implement ConflictStrategy type and ParseConflictStrategy
+    - Define `ConflictStrategy` type (`string`) with constants: `ConflictReplace`, `ConflictAdd`, `ConflictSkip`
+    - `ParseConflictStrategy(s string)` converts string to `ConflictStrategy`, returns error for invalid values
+    - _Requirements: 54.1_
+    - _Design: Section 4 — conflict.go_
+  - [x] 11.2 Implement LookupResult struct and Lookup function with conflict detection
+    - Define `LookupParams` struct: SourceLang, LookupType, Text, Provider, ModelID, Context, TargetLang, Tags, DryRun, Timeout, OnConflict, ReplaceID
+    - Define `LookupResult` struct: Entry, Existing (slice), ExistingIDs (slice), NeedsResolution (bool), FromCache (bool)
+    - `Lookup(ctx, store, params)` performs: normalize token → `FindWords`/`FindExpressions` (slice return) → if no entries, invoke LLM and insert → if entries exist and no context, return first cached → if entries exist and context provided, invoke LLM (cache bypass), return `LookupResult` with `NeedsResolution=true`
+    - When `OnConflict` is pre-set, apply strategy automatically without requiring caller intervention
+    - In dry-run mode: normalize and return without LLM invocation or DB write
+    - Return typed errors: `ProviderError` for LLM failures, `ValidationError` for JSON failures
+    - _Requirements: 20.1, 20.4–20.6, 18.1–18.3, 18.6–18.7, 19.1–19.7, 37.3, 37.4, 50.1, 50.4, 55.1–55.4_
+    - _Design: Section 4 — service.go, Data Flow: Single Lookup_
+  - [x] 11.3 Implement ResolveConflict function
+    - `ResolveConflict(ctx, store, strategy, mode, entry, targetID, sourceLang, targetLang, tags)` applies conflict resolution after a cache-bypass lookup
+    - "replace": calls `UpdateWord`/`UpdateExpression` on the target ID with new entry data
+    - "add": calls `InsertWord`/`InsertExpression` to add new entry alongside existing ones
+    - "skip": no-op, returns nil
+    - _Requirements: 54.1, 19.5–19.7_
+    - _Design: Section 4 — service.go ResolveConflict_
+  - [x] 11.4 Implement ProcessBatch function with conflict resolution
+    - Define `BatchParams` struct: SourceLang, Mode, Tokens, Provider, ModelID, TargetLang, Tags, Limit, DryRun, Timeout, OnConflict (default: "skip")
+    - Define `BatchResult` struct: Results, Errors, Processed, Cached, Failed, Skipped, Replaced, Added counts
+    - Define `BatchError` struct: Token, Message
+    - `ProcessBatch(ctx, store, params)` iterates tokens: normalize → skip empty → `FindWords`/`FindExpressions` → if entries exist and no context, count as cached → if entries exist and context provided, invoke LLM and apply `OnConflict` strategy → if no entries, invoke LLM and insert → collect results/errors
+    - Continue on per-item errors (error resilience)
+    - In dry-run mode: normalize all tokens, skip LLM and DB, return what would be processed
+    - Respect `--limit N`: process at most N new items (cached items don't count toward limit)
+    - _Requirements: 20.2, 23.1–23.6, 36.1–36.4, 37.1–37.5, 38.1–38.5, 50.1, 56.1–56.5_
+    - _Design: Section 4 — service.go, Data Flow: Batch Processing_
+  - [x] 11.5 Implement GetSupportedLanguages helper
+    - Returns `[]LanguageInfo` (Code, Name pairs) from the language registry
+    - _Requirements: 20.3_
+    - _Design: Section 4 — service.go_
+  - [x] 11.6 Write property test P11: Database cache idempotency
+    - **Property 11: Database cache idempotency**
+    - Generate random tokens, use mock provider with real temp SQLite store
+    - Call `Lookup` twice for same token (no context); assert provider invoked exactly once, second call is cache hit, both results identical
+    - **Validates: Requirements 18.1–18.4, 19.1–19.4**
+  - [x] 11.7 Write property test P13: Dry-run no side effects
+    - **Property 13: Dry-run no side effects**
+    - Generate random token lists, use mock provider that panics if `Invoke` is called
+    - Call `ProcessBatch` with DryRun=true; assert provider invocations == 0, DB has no new entries
+    - **Validates: Requirements 37.1–37.4**
+  - [x] 11.8 Write property test P15: Limit enforcement
+    - **Property 15: Limit enforcement**
+    - Generate random limit N and token list of size M > N (no cached items), use counting mock provider
+    - Call `ProcessBatch` with Limit=N; assert provider invocations <= N
+    - **Validates: Requirement 23.6**
+  - [x] 11.9 Write property test P16: Error resilience
+    - **Property 16: Error resilience**
+    - Generate random token list, use `failingMockProvider` that fails on a random subset
+    - Call `ProcessBatch`; assert results count + errors count == non-empty, non-cached input tokens (up to limit)
+    - **Validates: Requirement 36.3**
+  - [x] 11.10 Write property test P18: Multi-version entry integrity
+    - **Property 18: Multi-version entry integrity**
+    - Generate random word with N existing entries (N ≥ 1) in a temp SQLite store
+    - Test "add" strategy: call `ResolveConflict` with `ConflictAdd`, assert `FindWords` returns N+1 entries, all original entries unchanged
+    - Test "replace" strategy: call `ResolveConflict` with `ConflictReplace` targeting entry ID K, assert `FindWords` returns N entries, entry K updated, others unchanged
+    - Test "skip" strategy: call `ResolveConflict` with `ConflictSkip`, assert `FindWords` returns N entries with no modifications
+    - Test `FindWords`/`FindExpressions` returns empty slice when no entries exist
+    - **Validates: Requirements 53.1, 53.4, 54.1, 57.1, 57.2, 57.3, 19.5, 19.6, 19.7**
+  - [x] 11.11 Write property test P19: Context-aware cache bypass
+    - **Property 19: Context-aware cache bypass**
+    - Generate random word with at least one existing entry in a temp SQLite store, use counting mock provider
+    - Test: `Lookup` with empty context → returns cached entry, provider invocation count = 0
+    - Test: `Lookup` with non-empty context → invokes provider exactly once, returns `LookupResult` with `NeedsResolution=true` and populated `Existing` slice
+    - Test: `Lookup` with no existing entry (with or without context) → invokes provider exactly once, inserts result
+    - Verify final DB state is consistent with the selected conflict resolution strategy
+    - **Validates: Requirements 55.1, 55.2, 55.3, 18.6**
+  - [x] 11.12 Write integration test: full lookup flow with mock provider
+    - Create mock provider returning valid JSON, real temp SQLite store
+    - Call `Lookup`, assert returned Entry has expected fields, DB contains the entry
+    - _Requirements: 20.1, 20.4_
+  - [x] 11.13 Write integration test: batch processing with cache hits
+    - Process tokens, then re-process same tokens
+    - Assert second run has all cache hits, provider invocation count matches first run only
+    - _Requirements: 18.4, 23.2–23.4_
+  - [x] 11.14 Write integration test: conflict resolution flows
+    - Test lookup with context on existing entry returns `NeedsResolution=true` with existing entries
+    - Test `ResolveConflict` with "replace" updates correct entry
+    - Test `ResolveConflict` with "add" inserts new entry alongside existing
+    - Test batch with `OnConflict=replace` and context CSV updates existing entries
+    - Test batch with `OnConflict=skip` and context CSV skips conflicting tokens
+    - Test batch summary includes Replaced and Added counts
+    - _Requirements: 54.1–54.6, 55.1–55.3, 56.1–56.5_
+
+- [x] 12. Checkpoint — Core business logic complete
+  - Ensure all tests pass with `make test`. Verify `internal/output` and `internal/service` compile and all property, table-driven, and integration tests pass. Ask the user if questions arise.
+  - **Go Learning**: Explain Go interface-based test doubles (mock structs implementing interfaces, no mocking frameworks), `context.WithTimeout` for request deadlines, and how the service layer pattern decouples business logic from CLI/HTTP. Explain `t.Helper()` and `t.Cleanup()` for test utilities. Ask the user if they have questions before proceeding.
+  - **Microstudy**: Write `reference/learning-go-microstudy/04-mocks-timeouts-and-service-layer.md` — generic Go reference covering interface-based test doubles, `context.WithTimeout`, service layer decoupling, `t.Helper()`, and `t.Cleanup()`. No project-specific references.
+
+- [x] 13. Cobra CLI (`cmd/vocabgen/`)
+  - [x] 13.1 Implement root command with persistent flags and config loading
+    - Create root Cobra command with persistent flags: `--verbose`/`-v`, `--provider`, `--region`/`-r`, `--timeout`, `--tags`, `--version`, `--source-language`/`-l`, `--target-language`, `--model-id`, `--api-key`, `--base-url`, `--profile`, `--gcp-project`, `--gcp-region`
+    - In `PersistentPreRun`: load config via `config.LoadConfig()`, apply CLI flag overrides, configure `log/slog` handler (INFO default, DEBUG with --verbose)
+    - Version injected via `ldflags` at build time; `--version` flag prints version and exits
+    - _Requirements: 21.1–21.29, 33.8–33.9, 44.1–44.3, 49.1–49.3_
+    - _Design: Section 9 — main.go_
+  - [x] 13.2 Implement `lookup` subcommand
+    - Positional argument for text to look up
+    - Flags: `--type` (word/expression/sentence, default "word"), `--context`, `--on-conflict` (replace/add/skip, optional)
+    - Resolve provider from config/flags, create provider instance via Registry
+    - Call `service.Lookup()`, handle `LookupResult`:
+      - If `NeedsResolution=true` and no `--on-conflict` flag: prompt user interactively to choose replace/add/skip, displaying existing entry summary and new result
+      - If `NeedsResolution=true` and `--on-conflict` flag set: call `service.ResolveConflict()` with the pre-selected strategy
+      - If `FromCache=true`: print cached result
+    - Print formatted JSON result to stdout
+    - _Requirements: 22.1–22.8, 12.1–12.7, 54.2–54.3, 55.1–55.3_
+    - _Design: Section 9 — lookupCmd_
+  - [x] 13.3 Implement `batch` subcommand
+    - Required flags: `--input-file`, `--mode` (words/expressions)
+    - Optional: `--limit`, `--dry-run`, `--on-conflict` (replace/add/skip, default: "skip")
+    - Read CSV via `parsing.ReadInputFile`, create provider, call `service.ProcessBatch()` with `OnConflict` from flag
+    - Log progress (processed items, cache hits, errors) via slog
+    - Print summary report on completion: processed/cached/failed/replaced/added counts, failed items list
+    - _Requirements: 23.1–23.6, 36.1–36.5, 37.1–37.5, 38.1–38.5, 56.1–56.5_
+    - _Design: Section 9 — batchCmd_
+  - [x] 13.4 Implement `serve` subcommand
+    - Optional flag: `--port` (default 8080)
+    - Create SQLiteStore, create web.Server, call `ListenAndServe`
+    - Handle SIGINT/SIGTERM for graceful shutdown via `context.Context`
+    - _Requirements: 24.1, 24.6_
+    - _Design: Section 9 — serveCmd_
+  - [x] 13.5 Implement `backup` and `restore` subcommands
+    - `backup`: call `store.BackupTo()` with timestamped path, print backup path
+    - `restore`: accept backup file path argument, call `store.RestoreFrom()`, print confirmation
+    - _Requirements: 48.1–48.6_
+    - _Design: Section 9 — backupCmd, restoreCmd_
+  - [x] 13.6 Implement `version` subcommand
+    - Print app version, Go version (`runtime.Version()`), build date
+    - Version string injected via `-ldflags "-X main.version=..."` at build time
+    - _Requirements: 49.1–49.3_
+    - _Design: Section 9 — versionCmd_
+  - [x] 13.7 Write table-driven tests for CLI flag parsing and validation
+    - Test required `--source-language` flag is enforced for lookup and batch
+    - Test `--mode` flag accepts only "words" or "expressions"
+    - Test `--provider` flag rejects unsupported values with error listing valid names
+    - Test `--type` flag accepts "word", "expression", "sentence"
+    - Test `--on-conflict` flag accepts "replace", "add", "skip" and rejects invalid values
+    - Test `--on-conflict` flag defaults to "skip" for batch subcommand
+    - Test default values applied correctly (provider=bedrock, region=us-east-1, target-language=hu, port=8080, timeout=60)
+    - Test `--version` flag prints version and exits
+    - _Requirements: 11.2, 11.3, 21.20, 21.21, 22.8, 56.1_
+
+- [x] 14. Checkpoint — CLI complete
+  - Ensure all tests pass with `make test`. Verify `vocabgen lookup`, `vocabgen batch`, `vocabgen serve`, `vocabgen backup`, `vocabgen restore`, and `vocabgen version` subcommands are wired and `--help` works. Ask the user if questions arise.
+  - **Go Learning**: Explain Cobra patterns (root command, subcommands, persistent flags, `PersistentPreRun`), `log/slog` structured logging (handlers, levels, structured fields), and Go build-time variable injection via `-ldflags`. Explain signal handling with `os/signal` and `context.Context` for graceful shutdown. Ask the user if they have questions before proceeding.
+  - **Microstudy**: Write `reference/learning-go-microstudy/05-cobra-slog-and-ldflags.md` — generic Go reference covering Cobra patterns, `log/slog` structured logging, `-ldflags` build-time injection, and signal handling with `os/signal`. No project-specific references.
+
+- [x] 15. Web UI — Server, templates, and core pages (`internal/web/`)
+  - [x] 15.1 Implement web Server struct, route registration, and graceful shutdown
+    - Define `Server` struct with `store db.Store`, `cfg *config.Config`, `mux *http.ServeMux`, `logger *slog.Logger`
+    - `NewServer(store, cfg, logger)` registers all routes on the mux
+    - `ListenAndServe(ctx, addr)` starts HTTP server, blocks until ctx cancelled, then graceful shutdown
+    - Set `Content-Type: text/html; charset=utf-8` for HTML responses, `application/json; charset=utf-8` for API responses
+    - _Requirements: 24.1, 24.5, 24.6, 39.3_
+    - _Design: Section 8 — server.go_
+  - [x] 15.2 Create embedded HTML templates with go:embed
+    - Create `base.html` with shared layout: DOCTYPE, head (HTMX CDN, Tailwind CDN), nav bar (Lookup, Batch, Config, Database), main content block
+    - Create `lookup.html`, `batch.html`, `config.html`, `database.html` page templates
+    - Create partials: `lookup_result.html`, `lookup_conflict.html`, `batch_summary.html`, `config_form.html`, `entry_edit.html`, `entry_table.html`
+    - `lookup_conflict.html`: side-by-side display of existing entry/entries (left) and new LLM result (right), with "Replace" (entry selector dropdown when multiple exist), "Add as New Version", and "Skip" buttons; each button triggers `hx-post="/api/lookup/resolve"` with strategy and target ID
+    - Embed via `//go:embed templates/*.html templates/partials/*.html`
+    - Parse templates once at startup
+    - _Requirements: 24.2–24.4, 35.3, 54.4, 54.6_
+    - _Design: Section 8 — templates.go, Template File Structure_
+  - [x] 15.3 Implement page handlers (GET /, /batch, /config, /database)
+    - Each handler renders the corresponding page template with data from config and language registry
+    - Language selectors populated from `SupportedLanguages`
+    - Batch page form includes conflict resolution dropdown (skip/replace/add, default: skip)
+    - Database page table visually distinguishes entries sharing the same word/expression text (e.g., POS badge or version count indicator)
+    - _Requirements: 25.1, 25.5, 26.1, 27.1–27.2, 28.1–28.2, 53.2, 53.5, 56.4_
+    - _Design: Section 8 — routes.go, Page Designs_
+  - [x] 15.4 Implement lookup API handlers (POST /api/lookup, POST /api/lookup/html, POST /api/lookup/resolve, POST /api/lookup/resolve/html)
+    - JSON endpoint: parse request body, call `service.Lookup()`, return JSON response
+    - HTMX endpoint: same logic; when `LookupResult.NeedsResolution=true`, render `lookup_conflict.html` partial (side-by-side existing vs new); otherwise render `lookup_result.html` partial
+    - Resolve JSON endpoint (POST /api/lookup/resolve): accept strategy ("replace"/"add"/"skip"), target entry ID, and new entry data; call `service.ResolveConflict()`; return JSON result
+    - Resolve HTMX endpoint (POST /api/lookup/resolve/html): same logic, render final `lookup_result.html` partial showing the saved entry
+    - Return `{"detail": "..."}` JSON on errors with appropriate HTTP status codes (400, 502, 500)
+    - _Requirements: 25.2–25.4, 31.1, 32.1–32.4, 54.4–54.6, 55.1–55.3_
+    - _Design: Section 8 — HTMX Interaction Patterns, routes.go_
+  - [x] 15.5 Implement batch API handlers (POST /api/batch/html, GET /api/batch/stream)
+    - Multipart upload handler: parse CSV file, source_lang, target_lang, mode, tags, on_conflict (replace/add/skip, default: skip)
+    - Reject uploads > 10 MB with HTTP 413
+    - Pass `OnConflict` strategy from form to `service.ProcessBatch()`
+    - SSE endpoint streams progress events (`event: progress`, `event: complete`) as each item is processed
+    - `batch_summary.html` partial displays processed/cached/failed/replaced/added counts and failed items list
+    - _Requirements: 26.1–26.7, 31.2, 31.8, 56.4–56.5_
+    - _Design: Section 8 — Batch Page, SSE_
+  - [x] 15.6 Implement config API handlers (GET /api/config, PUT /api/config, POST /api/test-connection, GET /api/config/html)
+    - GET returns current config as JSON
+    - PUT updates config file, returns updated config
+    - Test connection: create provider with current config, attempt a simple invocation, return result
+    - HTMX partial: render config form with conditional fields based on selected provider
+    - _Requirements: 27.1–27.5, 31.3–31.4, 31.7_
+    - _Design: Section 8 — Config Page_
+  - [x] 15.7 Implement database API handlers (GET /api/words, GET /api/expressions, PUT /api/words/{id}, DELETE /api/words/{id}, POST /api/import, GET /api/export)
+    - List endpoints: paginated, filtered by source_lang, target_lang, search, tags
+    - Update endpoints: update entry, set updated_at
+    - Delete endpoints: remove entry by ID
+    - Import: multipart CSV upload, call store.ImportWords/ImportExpressions, return summary
+    - Export: query entries with current filters, generate xlsx via `output.ExportToExcel`, return as download with filename pattern `vocabgen-{lang}-{type}-{date}.xlsx`
+    - _Requirements: 28.3–28.10, 29.1–29.6, 30.1–30.5, 31.5–31.6_
+    - _Design: Section 8 — Database Page, routes.go_
+  - [x] 15.8 Implement health and languages API handlers (GET /api/health, GET /api/languages)
+    - Health: return `{"status": "ok"}` with HTTP 200
+    - Languages: return supported languages list from `service.GetSupportedLanguages()`
+    - _Requirements: 31.5, 31.6_
+    - _Design: Section 8 — routes.go_
+  - [x] 15.9 Write integration tests for web API endpoints using httptest
+    - Test POST /api/lookup returns vocabulary entry JSON with mock provider
+    - Test POST /api/lookup/html returns `lookup_conflict.html` partial when context triggers cache bypass with existing entry
+    - Test POST /api/lookup/resolve applies conflict strategy and returns resolved entry
+    - Test POST /api/lookup/resolve/html returns `lookup_result.html` partial after resolution
+    - Test POST /api/batch with multipart upload and on_conflict field returns summary JSON with replaced/added counts
+    - Test GET/PUT /api/config round-trip
+    - Test GET /api/health returns 200 `{"status": "ok"}`
+    - Test GET /api/languages returns supported languages
+    - Test 413 response for oversized batch upload
+    - Test error responses include `{"detail": "..."}` format
+    - _Requirements: 31.1–31.8, 32.1–32.4, 54.4–54.6, 56.4–56.5_
+
+- [x] 16. Checkpoint — Web UI complete
+  - Ensure all tests pass with `make test`. Verify `vocabgen serve` starts the web server and all page routes and API endpoints respond correctly. Ask the user if questions arise.
+  - **Go Learning**: Explain `go:embed` (compile-time file embedding), `html/template` (template composition with `define`/`template`, auto-escaping), `net/http` patterns (ServeMux, HandlerFunc, middleware), `httptest` for testing HTTP handlers, and Server-Sent Events (SSE) with `http.Flusher`. Ask the user if they have questions before proceeding.
+  - **Microstudy**: Write `reference/learning-go-microstudy/06-embed-templates-and-http.md` — generic Go reference covering `go:embed`, `html/template` composition, `net/http` patterns, `httptest`, and SSE with `http.Flusher`. No project-specific references.
+
+- [x] 17. Structured logging integration
+  - [x] 17.1 Wire slog throughout all packages
+    - Configure slog handler in CLI root command `PersistentPreRun`: text handler, INFO level default, DEBUG level with `--verbose`
+    - Replace any `fmt.Println`/`fmt.Printf` in production code with `slog.Info`, `slog.Debug`, `slog.Error`
+    - Add structured fields: `slog.String("word", token)`, `slog.String("provider", name)`, `slog.Int("processed", count)`, etc.
+    - Log at INFO: processed items, cache hits/misses, progress, summaries
+    - Log at DEBUG: prompts sent to LLM, raw LLM responses (only with --verbose)
+    - Log at ERROR: auth failures, LLM errors, validation errors, DB errors
+    - _Requirements: 44.1–44.6, 38.1–38.5_
+    - _Design: Logging Strategy section_
+
+- [x] 18. Final integration and wiring
+  - [x] 18.1 Wire CLI commands to service layer with real providers and DB
+    - Ensure `lookup` command: loads config → creates provider via Registry → opens SQLiteStore → calls `service.Lookup()` → prints JSON → exits
+    - Ensure `batch` command: loads config → creates provider → opens store → reads CSV → calls `service.ProcessBatch()` → logs progress → prints summary → exits
+    - Ensure `serve` command: opens store → creates web.Server → starts HTTP server → handles graceful shutdown
+    - Ensure `backup`/`restore` commands: open store → call BackupTo/RestoreFrom → print result
+    - Ensure provider selection respects `--provider` flag and config defaults
+    - Ensure `--api-key` flag overrides env var; `--profile` ignored for non-bedrock providers; `--base-url` passed to OpenAI provider
+    - _Requirements: 11.1–11.5, 12.1–12.7, 21.1–21.29_
+    - _Design: Data Flow diagrams_
+  - [x] 18.2 Verify error handling end-to-end
+    - Authentication errors exit non-zero with corrective action message
+    - Input errors (file not found, empty file) exit non-zero
+    - LLM/validation errors during batch: logged, processing continues, summary includes failures
+    - DB errors: exit non-zero
+    - _Requirements: 13.1–13.4, 36.1–36.5_
+    - _Design: Error Handling section_
+
+- [x] 19. Final checkpoint — Full integration
+  - Ensure `make build` produces a working binary. Run `make test` — all property, table-driven, fuzz, and integration tests pass. Run `make vet` and `make lint` with no issues. Verify `vocabgen --help` shows all subcommands and flags. Ask the user if questions arise.
+
+- [x] 20. Documentation
+  - [x] 20.1 Create README.md
+    - Project overview (one paragraph)
+    - Quick start: download binary, run `vocabgen lookup "word" -l nl`, run `vocabgen serve`
+    - CLI usage: all subcommands (`lookup`, `batch`, `serve`, `backup`, `restore`, `version`) with example commands
+    - Provider configuration: Bedrock (AWS creds), OpenAI (API key), Anthropic (API key), Vertex AI (GCP ADC), Ollama/Azure (base URL)
+    - Configuration: `~/.vocabgen/config.yaml` fields and defaults
+    - Environment variables: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GCP_PROJECT`
+    - Build from source: `make build`, `make test`
+    - _Keep it scannable: tables, code blocks, no tutorials_
+  - [x] 20.2 Create docs/architecture.md
+    - System architecture diagram (copy from design.md)
+    - Package layout with one-line descriptions
+    - Data flow: lookup and batch (copy sequence diagrams from design.md)
+    - Provider interface pattern (brief)
+    - _Reference-focused: find any answer in <30 seconds_
+  - [x] 20.3 Create docs/deployment.md
+    - Cross-compilation with goreleaser: `goreleaser release --snapshot`
+    - GitHub Actions CI: build + test + lint pipeline
+    - Release process: tag → goreleaser → GitHub Release
+    - Docker usage (optional): `FROM scratch` Dockerfile, volume mount for `~/.vocabgen/`
+    - Platform support: macOS (amd64/arm64), Linux (amd64/arm64), Windows (amd64)
+    - _Requirements: 35.1–35.5_
+  - [x] 20.4 Create docs/user-guide.md
+    - Installation: download binary for your platform
+    - First run: `vocabgen lookup "uitkomen" -l nl` — what to expect
+    - Batch processing: prepare CSV, run `vocabgen batch --input-file ch1.csv --mode words -l nl --tags "chapter-1"`
+    - Web UI: `vocabgen serve --port 8080`, open browser, walkthrough of each page
+    - Tags: how to tag entries, filter by tags
+    - Database management: backup (`vocabgen backup`), restore (`vocabgen restore <file>`), import CSV, export Excel
+    - Provider switching: `--provider openai --api-key ...`, `--provider openai --base-url http://localhost:11434/v1` for Ollama
+    - Dry-run: `vocabgen batch --dry-run ...` to preview without API costs
+    - _Keep it practical: commands the user can copy-paste_
+  - [x] 20.5 Add godoc comments to all exported symbols
+    - Ensure every exported function, type, method, and package declaration has a doc comment starting with the symbol name
+    - Run `go doc ./internal/...` to verify all packages have documentation
+    - _Go convention: doc comments are mandatory for exported symbols_
+
+- [-] 21. Named config profiles (`internal/config/`, CLI, Web UI) — Issue #23
+  - [x] 21.1 Add `ProfileConfig` and `FileConfig` structs to `internal/config/config.go`
+    - Define `ProfileConfig` struct with provider-related YAML fields (provider, aws_profile, aws_region, model_id, base_url, gcp_project, gcp_region)
+    - Define `FileConfig` struct with `DefaultProfile string`, `Profiles map[string]ProfileConfig`, plus shared fields (default_source_language, default_target_language, db_path)
+    - _Requirements: 58.1, 58.2_
+    - _Design: Named Config Profiles — Data Model Changes_
+
+  - [x] 21.2 Update `LoadConfig` for format detection and backward compatibility
+    - Detect multi-profile format: if YAML contains `profiles:` key, parse as `FileConfig` and resolve the `default_profile` (or first profile if unset) into the flat `Config` struct
+    - If no `profiles:` key, parse as flat `Config` (existing behavior — implicit `default` profile)
+    - Apply defaults for missing fields as before
+    - _Requirements: 58.1, 58.2, 58.5_
+
+  - [x] 21.3 Implement `LoadConfigWithProfile(profileName string) (Config, error)`
+    - Parse YAML as `FileConfig`, look up the named profile, populate `Config` from it
+    - Return descriptive error listing available profiles if name not found
+    - For flat format, only accept `"default"` as profile name
+    - _Requirements: 58.3, 58.4_
+
+  - [x] 21.4 Implement `ListProfiles() ([]string, string, error)`
+    - Return available profile names and the default profile name
+    - For flat format, return `["default"]` with default `"default"`
+    - _Requirements: 58.7_
+
+  - [x] 21.5 Update `SaveConfig` to preserve multi-profile structure
+    - When saving, detect if the loaded config was multi-profile and preserve the `FileConfig` structure
+    - Add `SaveFileConfig(fc FileConfig) error` for saving the full multi-profile format
+    - _Requirements: 58.6_
+
+  - [x] 21.6 Write property tests P20, P21, P22 for config profiles
+    - P20: Multi-profile round-trip — generate random `FileConfig` with 1-5 profiles, save, load, verify equality
+    - P21: Unknown profile name — generate random strings not in profiles map, verify error returned
+    - P22: Flat config backward compat — generate flat `Config`, save in old format, load, verify works as `default` profile
+    - Table-driven: `LoadConfigWithProfile("sandbox")` returns correct profile values
+    - Table-driven: `ListProfiles()` returns expected names
+    - _Requirements: 58.1–58.6_
+    - _Properties: P20, P21, P22_
+
+  - [x] 21.7 Rename `--profile` CLI flag to `--aws-profile` and add new `--profile` for config profiles
+    - In `cmd/vocabgen/main.go`: rename existing `--profile` persistent flag to `--aws-profile`
+    - Add new `--profile` persistent flag (string, default empty) for config profile selection
+    - Update `PersistentPreRunE`: if `--profile` is set, call `LoadConfigWithProfile(name)` instead of `LoadConfig()`
+    - Update `createProvider`: use `appConfig.AWSProfile` (from renamed flag) for Bedrock
+    - _Requirements: 58.3, 58.9_
+
+  - [x] 21.8 Write CLI tests for `--profile` flag resolution
+    - Table-driven: `--profile local` resolves to local profile config
+    - Table-driven: `--profile nonexistent` returns error
+    - Table-driven: no `--profile` flag uses `default_profile` from config
+    - _Requirements: 58.3, 58.4_
+
+  - [x] 21.9 Add profile selector to Web UI config page
+    - Add `GET /api/profiles` endpoint returning `{profiles: [...], active: "..."}` JSON
+    - Add `PUT /api/profile/switch` endpoint — switches active profile, reloads in-memory `s.cfg`
+    - Update `config_form.html`: add profile selector dropdown above provider field, `hx-get` reload on change
+    - Pass active profile and profile list into `pageData` for config page
+    - _Requirements: 58.7, 58.8_
+
+  - [x] 21.10 Write integration tests for profile Web UI endpoints
+    - Test `GET /api/profiles` returns profile list
+    - Test `PUT /api/profile/switch` changes active config
+    - Test config form renders with profile selector
+    - Regression: existing `TestPropertyConfigRoundTrip` still passes
+    - _Requirements: 58.7, 58.8_
+
+  - [x] 21.11 Update E2E tests for config profiles
+    - Add section 12 to `scripts/e2e-test.sh`: Config Profiles
+    - Test `--profile` flag with a temp multi-profile config
+    - Test `--profile nonexistent` returns non-zero exit
+    - Test `--aws-profile` flag exists and is accepted
+    - Update section count in script header comment
+    - _Requirements: 58.3, 58.4, 58.9_
+
+  - [x] 21.12 Update CHANGELOG.md for v1.2.0 and close GitHub issue #23
+    - Add `## [1.2.0]` section to CHANGELOG.md with Added entry for named config profiles
+    - Close GitHub issue #23 after implementation is verified
+    - _Requirements: 58.1–58.9_
+
+  - [x] 21.13 Always show profile selector in `config_form.html`
+    - Remove the `{{if gt (len .Profiles) 1}}` / `{{end}}` guard around the profile selector dropdown
+    - Profile selector is always rendered, showing the active profile name even for single-profile configs
+    - _Requirements: 58.7 (updated), 58.10_
+
+  - [x] 21.14 Add "Add new profile" option and inline form to `config_form.html`
+    - Add an `<option value="__new__">Add new profile…</option>` at the end of the profile selector dropdown
+    - When "Add new profile…" is selected, show an inline `<div>` with a text input for profile name and "Create" / "Cancel" buttons (JS toggle, no server round-trip to show the form)
+    - "Cancel" hides the inline form and resets the dropdown to the active profile
+    - Client-side validation: empty name shows error without server request
+    - "Create" submits `POST /api/profiles` with `name` (user input) and `source_profile` (active profile) via HTMX
+    - On success, reload the config form to show the new profile as active
+    - Update `docs/user-guide.md` with first-time use note: on first launch the "default" profile is shown; edit fields and Save to configure your provider; use "Add new profile" to create additional setups
+    - _Requirements: 58.10, 58.11, 58.13_
+
+  - [x] 21.15 Add `CreateProfile` function to `internal/config/config.go`
+    - Implement `CreateProfile(newName, sourceProfile string) error`
+    - Read existing config; if flat format, convert to `FileConfig` with implicit `default` profile
+    - Return error if `newName` already exists in `Profiles` map
+    - Copy `sourceProfile` values into `Profiles[newName]`
+    - Set `DefaultProfile` to `newName`
+    - Save via `SaveFileConfig`
+    - _Requirements: 58.11, 58.12_
+
+  - [x] 21.16 Add `POST /api/profiles` endpoint to `internal/web/handlers_config.go`
+    - Parse form fields `name` and `source_profile`
+    - Validate `name` is non-empty
+    - Call `config.CreateProfile(name, sourceProfile)`
+    - On success, reload in-memory config via `LoadConfigWithProfile(name)` and return HTML snippet triggering config form reload
+    - On error (duplicate name, empty name, source not found), return HTML error message
+    - Register route in `server.go`
+    - _Requirements: 58.10, 58.11, 58.12_
+
+  - [x] 21.17 Write tests for `CreateProfile` and `POST /api/profiles`
+    - Table-driven: `CreateProfile("new", "default")` on flat config creates multi-profile config with "new" profile
+    - Table-driven: `CreateProfile("existing", "default")` returns error when "existing" already exists
+    - Table-driven: `CreateProfile("new", "nonexistent")` returns error when source profile not found
+    - Property test P24: duplicate name always returns error without modifying profiles
+    - Property test P25: new profile contains same values as source profile
+    - Integration test: `POST /api/profiles` with valid name returns success and new profile is active
+    - Integration test: `POST /api/profiles` with duplicate name returns error HTML
+    - _Requirements: 58.11, 58.12_
+    - _Properties: P24, P25_
+
+- [x] 22. One-click local LLM setup (scripts, Web UI) — Issue #22
+  - [x] 22.1 Create `scripts/setup-local-llm.sh`
+    - Detect OS via `uname` (macOS/Linux; print error for unsupported OS)
+    - Check if `ollama` is installed (`command -v ollama`)
+    - Install if missing (macOS: `brew install ollama` or curl installer; Linux: curl installer)
+    - Check if Ollama server is running (`curl -s http://localhost:11434/api/tags`)
+    - Start if not running (`ollama serve &`, wait up to 30s for ready)
+    - Pull recommended model (`ollama pull mistral`)
+    - Verify model responds (quick test prompt via OpenAI-compatible endpoint)
+    - Write `~/.vocabgen/config.yaml` with `local` profile in multi-profile format, set `default_profile: local`
+    - Print success message with next steps
+    - Make script executable (`chmod +x`)
+    - _Requirements: 59.1–59.7_
+    - _Design: One-Click Local LLM Setup — Shell Script_
+
+  - [x] 22.2 Create `internal/web/handlers_setup.go` with SSE setup handler
+    - Implement `handleSetupLocalLLM` — SSE endpoint that runs setup steps via `os/exec`
+    - Stream progress events: detecting OS, checking Ollama, installing, pulling model, verifying, writing config
+    - Reuse `config.SaveFileConfig()` for writing the config file
+    - Update in-memory `s.cfg` after successful setup
+    - Register route: `GET /api/setup/local-llm` in `server.go`
+    - _Requirements: 59.8, 59.9, 59.10_
+
+  - [x] 22.3 Create `internal/web/templates/partials/setup_local_llm.html`
+    - Progress log area with SSE-driven updates
+    - Status indicator (in progress / success / error)
+    - "Setup Local LLM" button triggers `hx-get="/api/setup/local-llm"` with SSE swap
+    - Register partial in `templates.go`
+    - _Requirements: 59.8_
+
+  - [x] 22.4 Update `config_form.html` with "Setup Local LLM" section
+    - Add divider and "Setup Local LLM" button below existing form
+    - Button triggers the setup partial load
+    - Show setup UI inline on the config page
+    - _Requirements: 59.8_
+
+  - [x] 22.5 Update `validateProviderEnv` for Ollama detection
+    - In `handlers_config.go`: when provider is `openai` and `base_url` contains `localhost:11434`, check Ollama reachability instead of requiring `OPENAI_API_KEY`
+    - _Requirements: 59.11_
+
+  - [x] 22.6 Write tests for local LLM setup
+    - Table-driven unit tests for OS detection logic, config generation
+    - Integration test for SSE endpoint with mocked `os/exec` (verify event sequence)
+    - Test that setup writes correct config values (provider: openai, base_url, model_id)
+    - Test `validateProviderEnv` skips API key check when Ollama base URL is configured
+    - Property test P23: setup always produces valid config (provider + base_url + model_id all non-empty)
+    - _Requirements: 59.1–59.11_
+    - _Properties: P23_
+
+  - [x] 22.7 Add E2E test section for local LLM setup
+    - Add section 13 to `scripts/e2e-test.sh`: Local LLM Setup
+    - Test `scripts/setup-local-llm.sh` syntax check (`bash -n`)
+    - Test Web UI setup endpoint is registered (`GET /api/setup/local-llm`)
+    - Test `validateProviderEnv` accepts Ollama base URL without API key
+    - _Requirements: 59.1–59.11_
+
+  - [x] 22.8 Update CHANGELOG.md for v1.2.0 and add comment to GitHub issue #22 (close will happen after testing)
+    - Add entry under `## [1.2.0]` for one-click local LLM setup via Ollama
+    - Run `gh issue close 22` only!!! after implementation is verified
+    - _Requirements: 59.1–59.11_
+
+- [x] 23. E2E tests default to local LLM — Issue #24
+  - [x] 23.1 Update `scripts/e2e-test.sh` with `-p PROFILE` flag and Ollama pre-flight check
+    - Change `-p` flag from provider mode to config profile name (default: `local` via `E2E_PROFILE` env var)
+    - Pre-flight: verify profile exists via `$BINARY lookup --profile $PROFILE --dry-run`; if fails, print actionable error and exit 1
+    - Pre-flight: if profile is `local`, check Ollama reachability at `http://localhost:11434/api/tags`; if unreachable, print error pointing to `scripts/setup-local-llm.sh` and exit 1
+    - Replace `--model-id "$MODEL_ID" $PROVIDER_FLAGS` with `--profile "$PROFILE"` in all LLM-dependent sections (3-10, 13)
+    - Sections 1-2 (Version/Help, Error Cases) and 11 (Update Checker) unchanged — no LLM calls
+    - Section 12 (Config Profiles) and 14 (Local LLM Setup) unchanged — test config mechanics, not LLM
+    - Non-interactive: no prompts, just clear error + guidance on failure
+    - _Requirements: 60.1–60.5_
+    - _Design: E2E Tests Default to Local LLM — Script Changes_
+
+  - [x] 23.2 Update Makefile `e2e` target
+    - Pass through `E2E_PROFILE`: `E2E_PROFILE=$(E2E_PROFILE) ./scripts/e2e-test.sh`
+    - _Requirements: 60.6_
+
+  - [x] 23.3 Verify E2E tests pass with local profile
+    - Run `./scripts/e2e-test.sh -p local` with Ollama running — all sections pass
+    - Run `./scripts/e2e-test.sh -p local` with Ollama stopped — clear error, exit 1
+    - Run `E2E_PROFILE=bedrock ./scripts/e2e-test.sh` — uses cloud provider (backward compat)
+    - _Requirements: 60.1–60.6_
+
+  - [x] 23.4 Update CHANGELOG.md for v1.2.0 and comment to GitHub issue #24 (close will happen after testing)
+    - Add entry under `## [1.2.0]` for E2E tests defaulting to local LLM
+    - _Requirements: 60.1–60.6_
+
+- [x] 24. Documentation updates for issues #22, #23, #24
+  - [x] 24.1 Update `docs/user-guide.md`
+    - Add "Config Profiles" section: multi-profile YAML format, `--profile` flag, `default_profile`, Web UI dropdown
+    - Add "Local LLM Setup" section: `scripts/setup-local-llm.sh` usage, Web UI setup button, Ollama requirements
+    - Add "E2E Testing" section: `./scripts/e2e-test.sh -p local`, `E2E_PROFILE` env var
+    - _Requirements: 58.1–58.9, 59.1–59.11, 60.1–60.6_
+
+  - [x] 24.2 Update `README.md`
+    - Add config profiles to Configuration section (brief example)
+    - Add "Local LLM (Ollama)" quick start: `./scripts/setup-local-llm.sh` then `vocabgen lookup "fiets" -l nl`
+    - Update provider configuration table with `--profile` flag
+    - _Requirements: 58.3, 59.7_
+
+  - [x] 24.3 Update `docs/architecture.md`
+    - Add config profiles to the Config Manager description
+    - Note the `ProfileConfig` / `FileConfig` data model
+    - _Requirements: 58.1_
+
+- [ ] 25. Checkpoint — Verify all new features and existing tests pass
+  - Run `make quality` — all tests pass, no lint issues
+  - Verify `--profile local` works end-to-end with Ollama
+  - Verify `--profile` flag works on `lookup`, `batch`, `serve` subcommands
+  - Verify Web UI config page shows profile selector
+  - Verify `scripts/setup-local-llm.sh` completes successfully on macOS
+  - Verify `./scripts/e2e-test.sh -p local` passes all sections
+  - Ensure all existing tests still pass (regression)
+  - Ask the user if questions arise.
+
+- [ ] 26. Dedicated sentence lookup prompt, validation, and service integration (Issue #26)
+  - [ ] 26.1 Add `SentenceTemplate` constant and update `BuildPrompt` in `internal/language/templates.go`
+    - Define `SentenceTemplate` as a Go string constant with `{source_language}`, `{sentence}`, `{context}`, `{target_language_name}` placeholders
+    - Template instructs the LLM to return JSON with: `sentence` (string), `translation` (string — full sentence translation into target language), `grammar_check` (object with `has_errors` bool, `corrected_sentence` string, `errors` array of `{original, corrected, explanation}`), `vocabulary` (array of `{word, type, definition, english}`)
+    - Template instructs the LLM to check for grammatical errors: word order, verb conjugation, spelling, case/gender agreement, preposition usage
+    - Template instructs the LLM to provide a corrected sentence and explain each error when errors are found
+    - Template instructs the LLM to extract key vocabulary items with POS in source language terminology
+    - Add `"sentence"` case to `BuildPrompt` switch statement, using `{sentence}` placeholder for the token
+    - _Requirements: 61.1–61.7_
+    - _Design: Section 2 — templates.go SentenceTemplate_
+
+  - [ ] 26.2 Add sentence validation types and `ValidateSentenceResponse` in `internal/language/validation.go`
+    - Define `SentenceEntry` struct: `Sentence string`, `Translation string`, `GrammarCheck GrammarCheck`, `Vocabulary []VocabItem`
+    - Define `GrammarCheck` struct: `HasErrors bool`, `CorrectedSentence string`, `Errors []GrammarError`
+    - Define `GrammarError` struct: `Original string`, `Corrected string`, `Explanation string`
+    - Define `VocabItem` struct: `Word string`, `Type string`, `Definition string`, `English string`
+    - Implement `ValidateSentenceResponse(rawJSON string) (*SentenceEntry, error)` — parses JSON, validates required fields (`sentence`, `translation`, `grammar_check`, `vocabulary`), validates `grammar_check` structure, validates each vocabulary item has required fields
+    - Return `ValidationError` for missing or malformed fields
+    - _Requirements: 61.8–61.9, 3.10_
+    - _Design: Section 2 — validation.go SentenceEntry, ValidateSentenceResponse_
+
+  - [ ] 26.3 Fix `mode()` function and update sentence lookup path in `internal/service/service.go`
+    - Change `mode()` to return `"sentence"` when `lookupType == "sentence"` (instead of `"expressions"`)
+    - Update the sentence lookup branch in `Lookup()` to call `language.BuildPrompt` with mode `"sentence"`, then `language.ValidateSentenceResponse` (instead of `ValidateResponse` + `MapFields`)
+    - Populate `LookupResult.SentenceResult` field (new field on `LookupResult`) instead of `Entry`
+    - Ensure sentence lookups remain ephemeral: no DB read, no DB write
+    - Skip hallucination check and non-word check for sentence lookups
+    - _Requirements: 61.10, 62.1–62.3, 20.10_
+    - _Design: Section 4 — service.go mode(), Data Flow: Single Lookup_
+
+  - [ ] 26.4 Add `SentenceResult` field to `LookupResult` in `internal/service/service.go`
+    - Add `SentenceResult *language.SentenceEntry` field to `LookupResult` struct
+    - CLI and web handlers check `SentenceResult != nil` to determine sentence vs word/expression output
+    - _Requirements: 62.2, 62.5_
+    - _Design: Section 4 — service.go LookupResult_
+
+  - [ ] 26.5 Write property test P26: Sentence template formatting
+    - **Property 26: Sentence template formatting produces valid prompts for any source language**
+    - Generate random source language strings, random sentence strings, random target language codes
+    - Assert output contains: resolved source language name, sentence text, target language name, grammar check instructions, no unresolved `{...}` placeholders
+    - Assert output is distinct from words and expressions template output for the same language
+    - **Validates: Requirements 61.1, 61.6, 61.7**
+
+  - [ ] 26.6 Write property test P27: Sentence validation
+    - **Property 27: Sentence validation accepts valid sentence JSON and rejects missing required fields**
+    - Generate valid sentence JSON with random strings, random grammar errors, random vocabulary items
+    - Assert `ValidateSentenceResponse` succeeds for valid input
+    - Generate JSON with random subsets of required fields removed; assert `ValidateSentenceResponse` returns `ValidationError`
+    - **Validates: Requirements 61.8, 61.9**
+
+  - [ ] 26.7 Write property test P28: Sentence lookup ephemeral
+    - **Property 28: Sentence lookup ephemeral — never writes to DB, never reads cache**
+    - Use mock provider and in-memory SQLite store
+    - Perform sentence lookup, assert: mock provider was invoked, store has zero entries after lookup, `LookupResult.SentenceResult` is non-nil, `LookupResult.Entry` is nil
+    - **Validates: Requirements 62.1, 62.3**
+
+  - [ ] 26.8 Write table-driven tests for sentence template, validation, and service
+    - Test `BuildPrompt("nl", "sentence", "Ik ga morgen naar de markt", "", "hu")` returns prompt containing "Dutch", the sentence, grammar check instructions
+    - Test `BuildPrompt` with mode "sentence" does NOT contain `{expression}` or `{word}` placeholders in output
+    - Test `ValidateSentenceResponse` with valid JSON returns correct `SentenceEntry`
+    - Test `ValidateSentenceResponse` with missing `grammar_check` returns error
+    - Test `ValidateSentenceResponse` with missing `vocabulary` returns error
+    - Test `ValidateSentenceResponse` with grammar error missing `explanation` returns error
+    - Test `mode("sentence")` returns `"sentence"` (not `"expressions"`)
+    - Test `mode("word")` still returns `"words"` (regression)
+    - Test `mode("expression")` still returns `"expressions"` (regression)
+    - _Requirements: 61.1–61.10, 62.1–62.5_
+
+- [ ] 27. Checkpoint — Verify sentence lookup works end-to-end
+  - Run `make quality` — all tests pass, no lint issues
+  - Verify `vocabgen lookup "Ik ga morgen naar de markt" -l nl --type sentence` uses the sentence template (not expressions)
+  - Verify sentence lookup result contains grammar_check and vocabulary sections
+  - Verify no database entry is created for sentence lookups
+  - Verify existing word and expression lookups are unaffected (regression)
+  - Ask the user if questions arise.
+
+- [x] 28. Docker image distribution (#47)
+  - [x] 28.1 Create `Dockerfile` with multi-stage build
+    - Builder stage: `golang:1.22-alpine`, `CGO_ENABLED=0`, `VERSION` build arg, ldflags
+    - Runtime stage: `gcr.io/distroless/static:nonroot`, port 8080, volume `/home/nonroot/.vocabgen`
+    - Default CMD: `vocabgen serve --port 8080`
+    - _Requirements: 65.1–65.5_
+    - _Design: Docker Image Distribution — Dockerfile section_
+
+  - [x] 28.2 Create `.dockerignore`
+    - Exclude `.git`, `.github`, `.kiro`, `.vscode`, `reference/`, `coverage.out`, `dist/`, `vocabgen`
+    - _Requirements: 65.10_
+
+  - [x] 28.3 Add `dockers` and `docker_manifests` to `.goreleaser.yaml`
+    - Two `dockers` entries for amd64 and arm64 using buildx
+    - Two `docker_manifests` entries for `:<version>` and `:latest` multi-arch manifests
+    - Push to `ghcr.io/npozs77/vocabgen`
+    - _Requirements: 65.6, 65.7_
+    - _Design: Docker Image Distribution — goreleaser Integration section_
+
+  - [x] 28.4 Update `.github/workflows/release.yml`
+    - Add `packages: write` permission
+    - Add GHCR login via `docker/login-action@v3`
+    - Add Docker Buildx and QEMU setup steps
+    - _Requirements: 65.8, 65.9_
+    - _Design: Docker Image Distribution — CI/CD Changes section_
+
+  - [x] 28.5 Update documentation
+    - Add Docker section to `README.md` with `docker run` example
+    - Rewrite Docker section in `docs/deployment.md` with GHCR image tags, volume mount, CLI usage, local build
+    - Add Docker installation option to `docs/user-guide.md`
+    - Add Docker entry to `CHANGELOG.md` under 1.2.2
+    - _Requirements: 65.11, 65.12, 65.13_
+
+## Notes
+
+- Tasks marked with `*` are optional: fuzz tests (4.12, 5.6, 10.6), web UI (15.1–15.9), and Vertex AI provider (7.8)
+- All property tests (P1–P23), table-driven tests, and integration tests are mandatory
+- Web UI tasks (15.1–15.9) are optional — CLI is the primary interface and can ship without the web UI
+- Vertex AI provider (7.8) is optional — Bedrock, OpenAI, and Anthropic cover the primary use cases
+- Checkpoints include **Go Learning** sections that explain Go patterns and concepts used in the preceding tasks — pause to ask questions and solidify understanding before moving on
+- Each task references specific requirements and design sections for traceability
+- Property tests validate the 28 correctness properties
+- Fuzz tests complement property tests by discovering crashes on adversarial input
+- Checkpoints ensure incremental validation at natural boundaries
+- All tests are co-located with source (`*_test.go` alongside implementation)
+- Tasks 21–23 implement issues #23, #22, #24 respectively; dependency order: 21 (profiles) → 22 (Ollama setup) → 23 (E2E local default)
+- Task 26 implements issue #26 (sentence lookup dedicated prompt); depends on existing language, validation, and service packages
+- Task 28 implements issue #47 (Docker distribution); no Go code changes, purely infra/config/docs
+
+
+- [x] 29. Database picker and live database switching (#76)
+  - [x] 29.1 Implement `GET /api/databases` endpoint — scans config directory for `*.db` files
+  - [x] 29.2 Add database picker dropdown to Config page (server-side rendered `<select>`)
+  - [x] 29.3 Add "Create new…" option with inline text input and client-side validation
+  - [x] 29.4 Server-side validation in `handlePutConfig` — reject invalid names and conflicts
+  - [x] 29.5 Create empty `.db` file on save when "Create new" is selected
+  - [x] 29.6 Implement `switchDatabase` method on Server — close old store, open new SQLiteStore
+  - [x] 29.7 Call `switchDatabase` from `handlePutConfig` and `handleSwitchProfile` when DB path changes
+  - [x] 29.8 Export `ConfigDir()` in config package for directory scanning
+  - [x] 29.9 Pass `Databases []string` to config form template data (handleConfigHTML + handleSwitchProfile)
+  - [x] 29.10 Write tests: endpoint, validation, conflict detection, fallback, profile switch with databases
+  - [x] 29.11 Update user-guide: Database Picker section (live switching, no restart)
+  - _Requirements: 66.1–66.8_
+
+- [x] 30. Multiple meanings / skip-cache lookup (#86)
+  - [x] 30.1 Add `SkipCache bool` field to `LookupParams` and `BatchParams`
+  - [x] 30.2 Implement skip-cache logic in `lookupWord` — bypass cache, require context, always insert
+  - [x] 30.3 Implement skip-cache logic in `lookupExpression` — same pattern
+  - [x] 30.4 Implement skip-cache logic in `processBatchWord` and `processBatchExpression`
+  - [x] 30.5 Add `--new-meaning` flag to CLI `lookupCmd` with `--context` validation
+  - [x] 30.6 Parse `skip_cache` form/JSON field in `parseLookupParams` web handler
+  - [x] 30.7 Add "Skip cache / Add new meaning" checkbox to lookup.html with JS context-required toggle
+  - [x] 30.8 Parse `skip_cache` in all three batch handlers (JSON, HTML, SSE stream)
+  - [x] 30.9 Create `DisambiguatedWord(word, index, total)` helper in `internal/service/disambiguation.go`
+  - [x] 30.10 Create `disambiguateWords` and `disambiguateExpressions` helpers in `internal/web/disambiguation.go`
+  - [x] 30.11 Apply disambiguation in `handleListWords`, `handleListExpressions`, `handleExport`, `handleFlashcardsHTML`
+  - [x] 30.12 Write property test P18: disambiguation suffix correctness
+  - [x] 30.13 Write table-driven tests: CLI flag validation, web disambiguation helpers
+  - [x] 30.14 Update user-guide: Multiple Meanings section
+  - [x] 30.15 Update architecture doc: DisambiguatedWord, skip-cache flow, disambiguation display
+  - _Requirements: 67.1–67.9_
+
+- [x] 31. Database detail panel toggle fix (#87)
+  - [x] 31.1 Fix HTMX `hx-swap` behavior so clicking an expanded detail row collapses it
+  - _Requirements: 68.1–68.2_
+
+- [x] 32. Documentation updates for #76, #86, #87
+  - [x] 32.1 Update `docs/architecture.md` — new routes, switchDatabase, disambiguation, database picker
+  - [x] 32.2 Update `docs/user-guide.md` — Database Picker (live switch), Multiple Meanings
+  - [x] 32.3 Update `CHANGELOG.md` under v1.4.3
+  - _Requirements: 66, 67, 68_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [1.4.3]
+
+### Added
+
+- Database picker dropdown on Config page — lists existing `.db` files in the config directory, select one or create a new database with inline name validation (#76)
+
+### Fixed
+
+- Database view detail panel now toggles on click — clicking an expanded word/expression collapses it (#87)
+
 ## [1.4.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 ### Added
 
 - Database picker dropdown on Config page — lists existing `.db` files in the config directory, select one or create a new database with inline name validation (#76)
+- Multiple meanings support — add a second (or third) meaning for the same word via "Skip cache / Add new meaning" checkbox in the Web UI or `--new-meaning` flag in the CLI; each meaning stored as a separate entry with disambiguation suffixes displayed when 2+ meanings exist (#86)
 
 ### Fixed
 

--- a/cmd/vocabgen/main.go
+++ b/cmd/vocabgen/main.go
@@ -263,6 +263,12 @@ var lookupCmd = &cobra.Command{
 		tags, _ := cmd.Flags().GetString("tags")
 		timeout, _ := cmd.Flags().GetInt("timeout")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		newMeaning, _ := cmd.Flags().GetBool("new-meaning")
+
+		// --new-meaning requires --context
+		if newMeaning && ctxSentence == "" {
+			return fmt.Errorf("--context is required when using --new-meaning")
+		}
 
 		sourceLang := appConfig.DefaultSourceLanguage
 		if sl, _ := cmd.Flags().GetString("source-language"); sl != "" {
@@ -304,6 +310,7 @@ var lookupCmd = &cobra.Command{
 			TargetLang: targetLang,
 			Tags:       tags,
 			DryRun:     dryRun,
+			SkipCache:  newMeaning,
 			Timeout:    time.Duration(timeout) * time.Second,
 			OnConflict: conflictStrategy,
 		})
@@ -373,6 +380,7 @@ func init() {
 	lookupCmd.Flags().String("context", "", "Context sentence for the lookup")
 	lookupCmd.Flags().String("on-conflict", "", "Conflict resolution strategy (replace, add, skip)")
 	lookupCmd.Flags().Bool("dry-run", false, "Preview without LLM invocation or DB writes")
+	lookupCmd.Flags().Bool("new-meaning", false, "Skip cache and add a new meaning (requires --context)")
 }
 
 // batchCmd implements the "vocabgen batch" subcommand.

--- a/cmd/vocabgen/main_test.go
+++ b/cmd/vocabgen/main_test.go
@@ -691,3 +691,35 @@ func TestCLIAWSProfileFlagExists(t *testing.T) {
 		t.Fatalf("--aws-profile default should be empty, got %q", f.DefValue)
 	}
 }
+
+// TestCLINewMeaningFlagExists tests that --new-meaning flag exists on lookup command.
+func TestCLINewMeaningFlagExists(t *testing.T) {
+	f := lookupCmd.Flags().Lookup("new-meaning")
+	if f == nil {
+		t.Fatal("flag --new-meaning not found on lookup command")
+	}
+	if f.DefValue != "false" {
+		t.Fatalf("--new-meaning default should be 'false', got %q", f.DefValue)
+	}
+}
+
+// TestCLINewMeaningRequiresContext tests that --new-meaning without --context returns an error.
+func TestCLINewMeaningRequiresContext(t *testing.T) {
+	saved := appConfig
+	tmpDir := t.TempDir()
+	appConfig = config.DefaultConfig()
+	appConfig.DBPath = tmpDir + "/test.db"
+	appConfig.DefaultSourceLanguage = "nl"
+	appConfig.Provider = "openai"
+	appConfig.BaseURL = "http://localhost:11434/v1"
+	appConfig.ModelID = "test"
+	defer func() { appConfig = saved }()
+
+	_, err := executeCommand("lookup", "beslaan", "-l", "nl", "--new-meaning")
+	if err == nil {
+		t.Error("expected error when --new-meaning is used without --context, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "--context is required") {
+		t.Errorf("error should mention '--context is required', got: %s", err.Error())
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,9 +72,9 @@ vocabgen/
 │   ├── llm/               # Provider interface, Bedrock/OpenAI/Anthropic implementations
 │   ├── output/            # Field mapping, translation flattening, Excel export
 │   ├── parsing/           # CSV reading, word/expression normalization
-│   ├── service/           # Lookup, ProcessBatch — shared business logic
+│   ├── service/           # Lookup, ProcessBatch, DisambiguatedWord — shared business logic
 │   ├── update/            # Shared update checker (semver, GitHub API, download URLs)
-│   └── web/               # HTTP handlers, routes, embedded templates
+│   └── web/               # HTTP handlers, routes, embedded templates, disambiguation helpers
 │       └── templates/     # Go html/template files (go:embed)
 ├── go.mod
 ├── go.sum
@@ -126,6 +126,10 @@ The service layer sits between the interface layers (CLI, web) and the infrastru
 
 **`ResolveConflict`**: applies conflict resolution after a cache-bypass lookup. "replace" updates the existing entry by ID. "add" inserts alongside existing entries. "skip" is a no-op.
 
+**`DisambiguatedWord`**: display helper that appends a numeric suffix `(N)` when a word has multiple entries in the database. Returns the word unchanged when only one entry exists. Applied in the web layer (database browser, flashcards, XLSX export) before rendering — never modifies stored data.
+
+**Skip-Cache / New Meaning**: When `LookupParams.SkipCache` is true and a context sentence is provided, the service bypasses the cache entirely, invokes the LLM for that specific meaning, and inserts a new row without conflict resolution. This enables storing multiple distinct meanings for the same headword. Available via `--new-meaning` CLI flag or "Skip cache / Add new meaning" checkbox in the Web UI.
+
 **Conflict Resolution Strategies**:
 
 | Strategy | Behavior | Use Case |
@@ -164,7 +168,7 @@ The config uses a two-level data model:
 - `ProfileConfig` — per-profile provider settings: `provider`, `aws_profile`, `aws_region`, `model_id`, `base_url`, `gcp_project`, `gcp_region`.
 - `Config` — flattened runtime struct combining the resolved profile's provider fields with global settings. This is what the rest of the application uses.
 
-`LoadConfig` returns defaults if the file is missing. `LoadConfigWithProfile(name)` resolves a named profile. Old flat config files (no `profiles:` key) are treated as a single implicit `default` profile for backward compatibility. `SaveFileConfig` preserves the multi-profile YAML structure. `CreateProfile(newName, sourceProfile)` copies an existing profile's values into a new named profile.
+`LoadConfig` returns defaults if the file is missing. `LoadConfigWithProfile(name)` resolves a named profile. Old flat config files (no `profiles:` key) are treated as a single implicit `default` profile for backward compatibility. `SaveFileConfig` preserves the multi-profile YAML structure. `CreateProfile(newName, sourceProfile)` copies an existing profile's values into a new named profile. `ConfigDir()` returns the resolved config directory path (used by the database picker to scan for `.db` files).
 
 API keys are deliberately excluded from the config file — they come from environment variables or `--api-key` CLI flag at runtime.
 
@@ -199,6 +203,10 @@ Server-side rendering with Go `html/template` + HTMX + Tailwind CSS (CDN). All t
 **Flashcards**: The `/flashcards` page provides a study mode for reviewing vocabulary. `handlers_flashcards.go` implements two endpoints: `GET /api/flashcards/html` assembles a filtered deck by querying `ListWords` + `ListExpressions` with difficulty/language/tag filters and returns the `flashcard_card` partial with a `data-deck` JSON attribute; `PUT /api/flashcards/rate` persists a difficulty rating (easy/hard/natural) for a word or expression. Inline JavaScript in `flashcards.html` handles card flip (CSS `rotateY` with `perspective` and `backface-visibility`), prev/next deck navigation, display mode toggle (word-first vs detail-first), and difficulty rating via `fetch`. No external JS libraries.
 
 **Conflict resolution UI**: When a lookup with context finds existing entries, the server returns a `lookup_conflict.html` partial showing existing entries side-by-side with the new result, plus resolve buttons (replace/add/skip).
+
+**Database picker**: The Config page renders a server-side `<select>` dropdown listing all `.db` files in the config directory, plus a "Create new…" option. When a new name is submitted, the handler validates it (alphanumeric + hyphens/underscores), checks for conflicts, creates the empty file, and saves the path to config. `switchDatabase` closes the current `db.Store` and opens a new `SQLiteStore` at the new path — no server restart needed.
+
+**Disambiguation display**: `disambiguateWords` and `disambiguateExpressions` helpers in the web package count occurrences of each headword in a result set and apply `service.DisambiguatedWord` suffixes in-place before passing to templates. Applied in database browser, flashcards, and XLSX export.
 
 ### `cmd/vocabgen` — CLI Entry Point
 
@@ -398,7 +406,8 @@ Forms use `hx-post`/`hx-put`/`hx-delete` to send requests. Server returns HTML f
 | Resolve conflict | POST /api/lookup/resolve/html | `lookup_result.html` |
 | Upload batch CSV | POST /api/batch/html | Starts SSE stream |
 | Batch progress | GET /api/batch/stream | SSE events (progress, complete) |
-| Save config | PUT /api/config | `config_form.html` with success message |
+| Save config | PUT /api/config | Success message (+ live DB switch if path changed) |
+| Switch profile | PUT /api/profile/switch | Re-rendered `config_form.html` (+ live DB switch) |
 | Search database | GET /api/words?search=... | `entry_table.html` |
 | Edit entry | PUT /api/words/{id} | Updated row HTML |
 | Delete entry | DELETE /api/words/{id} | Empty (row removed) |
@@ -435,6 +444,10 @@ Forms use `hx-post`/`hx-put`/`hx-delete` to send requests. Server returns HTML f
 | GET | /api/export | Excel export |
 | GET | /api/health | Health check |
 | GET | /api/languages | Supported languages list |
+| GET | /api/databases | List .db files in config directory |
+| GET | /api/profiles | List config profiles |
+| POST | /api/profiles | Create new profile |
+| PUT | /api/profile/switch | Switch active profile |
 | GET | /docs | Documentation index |
 | GET | /docs/{slug} | Documentation content page |
 | GET | /changelog | Changelog page |

--- a/docs/index.html
+++ b/docs/index.html
@@ -241,6 +241,7 @@
 
         <a class="cta" href="https://github.com/npozs77/VocabGen/releases">Download Latest Release</a>
         <a class="cta secondary" href="https://github.com/npozs77/VocabGen">View on GitHub</a>
+        <a class="cta secondary" href="look-and-feel.html">See it in Action</a>
 
         <h2>What is VocabGen?</h2>
         <p>VocabGen is a free, open-source vocabulary web app for language learners at B2–C1 level. Start the app, open

--- a/docs/look-and-feel.html
+++ b/docs/look-and-feel.html
@@ -1,0 +1,552 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VocabGen — Look &amp; Feel</title>
+    <meta name="description"
+        content="Preview VocabGen's UI — static mockups of the Lookup, Batch, Flashcards, Database, and Config pages with sample data.">
+    <link rel="canonical" href="https://npozs77.github.io/VocabGen/look-and-feel.html">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .fc-scene {
+            perspective: 800px;
+        }
+
+        .fc-card {
+            position: relative;
+            width: 100%;
+            height: 280px;
+            transition: transform 0.5s ease;
+            transform-style: preserve-3d;
+            cursor: pointer;
+        }
+
+        .fc-card.is-flipped {
+            transform: rotateY(180deg);
+        }
+
+        .fc-face {
+            position: absolute;
+            inset: 0;
+            backface-visibility: hidden;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+            border-radius: 0.75rem;
+        }
+
+        .fc-face--back {
+            transform: rotateY(180deg);
+        }
+
+        .tab-btn.active {
+            border-color: #2563eb;
+            color: #2563eb;
+        }
+    </style>
+</head>
+
+<body class="bg-gray-50 min-h-screen">
+    <!-- Nav Bar (static replica) -->
+    <nav class="bg-white shadow">
+        <div class="max-w-7xl mx-auto px-4 py-3 flex items-center gap-6">
+            <span class="font-semibold text-lg text-gray-800">VocabGen</span>
+            <span class="text-blue-600 font-medium">Lookup</span>
+            <span class="text-gray-600">Batch</span>
+            <span class="text-gray-600">Config</span>
+            <span class="text-gray-600">Database</span>
+            <span class="text-gray-600">Flashcards</span>
+            <div class="flex-1"></div>
+            <span class="text-xs text-gray-400">📂 ~/.vocabgen/vocabgen.db</span>
+            <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">default</span>
+            <span class="text-sm text-gray-500">Help ▾</span>
+        </div>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="max-w-7xl mx-auto px-4 pt-6 pb-2">
+        <h1 class="text-2xl font-bold text-gray-800 mb-1">Look &amp; Feel</h1>
+        <p class="text-gray-500 text-sm mb-4">Static mockups of VocabGen's main views with sample data. All controls are
+            visual only — nothing is interactive.</p>
+
+        <!-- Tab Navigation -->
+        <div class="flex gap-1 border-b border-gray-200 mb-6">
+            <button onclick="showTab('lookup')"
+                class="tab-btn active px-4 py-2 text-sm font-medium border-b-2 border-transparent"
+                id="tab-lookup">Lookup</button>
+            <button onclick="showTab('batch')"
+                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
+                id="tab-batch">Batch</button>
+            <button onclick="showTab('flashcards')"
+                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
+                id="tab-flashcards">Flashcards</button>
+            <button onclick="showTab('database')"
+                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
+                id="tab-database">Database</button>
+            <button onclick="showTab('config')"
+                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
+                id="tab-config">Config</button>
+        </div>
+    </div>
+
+    <main class="max-w-7xl mx-auto px-4 pb-12">
+
+        <!-- ==================== LOOKUP TAB ==================== -->
+        <div id="panel-lookup">
+            <h2 class="text-2xl font-bold mb-6">Vocabulary Lookup</h2>
+            <div class="space-y-4 max-w-lg">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Text</label>
+                    <input type="text" value="maison" disabled
+                        class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50 text-gray-800">
+                </div>
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>French</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>Hungarian</option>
+                        </select>
+                    </div>
+                </div>
+                <fieldset>
+                    <legend class="block text-sm font-medium text-gray-700 mb-1">Lookup Type</legend>
+                    <div class="flex gap-4">
+                        <label class="flex items-center gap-1"><input type="radio" checked disabled> Word</label>
+                        <label class="flex items-center gap-1"><input type="radio" disabled> Expression</label>
+                        <label class="flex items-center gap-1"><input type="radio" disabled> Sentence</label>
+                    </div>
+                </fieldset>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Context (optional)</label>
+                    <textarea rows="2" disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50"
+                        placeholder="Sentence or context where the word appears"></textarea>
+                </div>
+                <button disabled class="bg-blue-600 text-white px-4 py-2 rounded opacity-75 cursor-not-allowed">Look
+                    Up</button>
+            </div>
+
+            <!-- Sample Result -->
+            <div class="mt-8">
+                <div class="bg-white border border-gray-200 rounded shadow-sm overflow-hidden max-w-2xl">
+                    <div class="bg-blue-50 text-blue-700 text-xs px-4 py-1">From cache</div>
+                    <table class="w-full text-sm">
+                        <tbody>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Word</td>
+                                <td class="px-4 py-2 text-gray-800">maison</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Part of Speech</td>
+                                <td class="px-4 py-2 text-gray-800">nom féminin</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Article</td>
+                                <td class="px-4 py-2 text-gray-800">la</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Definition</td>
+                                <td class="px-4 py-2 text-gray-800">Bâtiment destiné à l'habitation, lieu où l'on vit
+                                </td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Example</td>
+                                <td class="px-4 py-2 text-gray-800">Nous avons acheté une maison à la campagne.</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">English</td>
+                                <td class="px-4 py-2 text-gray-800">house (home, dwelling)</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Target Translation</td>
+                                <td class="px-4 py-2 text-gray-800">ház (otthon, lakóhely)</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Connotation</td>
+                                <td class="px-4 py-2 text-gray-800">Neutral — warmth, family, stability</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Register</td>
+                                <td class="px-4 py-2 text-gray-800">courant</td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Collocations</td>
+                                <td class="px-4 py-2 text-gray-800">maison de campagne; maison individuelle; à la maison
+                                </td>
+                            </tr>
+                            <tr class="border-b border-gray-100">
+                                <td class="px-4 py-2 font-medium text-gray-600 bg-gray-50 w-1/3">Contrastive Notes</td>
+                                <td class="px-4 py-2 text-gray-800">maison (standalone building) vs appartement (flat in
+                                    a building) vs domicile (formal/legal term)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- ==================== BATCH TAB ==================== -->
+        <div id="panel-batch" class="hidden">
+            <h2 class="text-2xl font-bold mb-6">Batch Processing</h2>
+            <div class="space-y-4 max-w-lg">
+                <fieldset>
+                    <legend class="block text-sm font-medium text-gray-700 mb-2">Input Method</legend>
+                    <div class="flex gap-4 mb-3">
+                        <label class="inline-flex items-center gap-1.5 text-sm">
+                            <input type="radio" disabled> Upload CSV
+                        </label>
+                        <label class="inline-flex items-center gap-1.5 text-sm">
+                            <input type="radio" checked disabled> Paste List
+                        </label>
+                    </div>
+                    <textarea rows="6" disabled
+                        class="w-full border border-gray-300 rounded px-3 py-2 text-sm bg-gray-50 text-gray-800">eraan toe zijn
+erachter komen
+eraan gaan
+op de hoogte zijn
+het klopt</textarea>
+                </fieldset>
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>Dutch</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>Hungarian</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Mode</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>Expressions</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">On Conflict</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>Skip</option>
+                        </select>
+                    </div>
+                </div>
+                <button disabled class="bg-blue-600 text-white px-4 py-2 rounded opacity-75 cursor-not-allowed">Process
+                    Batch</button>
+            </div>
+
+            <!-- Sample Completed Summary -->
+            <div class="mt-8 max-w-lg">
+                <div class="grid grid-cols-3 gap-4 text-center">
+                    <div class="bg-green-50 border border-green-200 rounded p-3">
+                        <div class="text-2xl font-bold text-green-700">5</div>
+                        <div class="text-sm text-green-600">Processed</div>
+                    </div>
+                    <div class="bg-gray-50 border border-gray-200 rounded p-3">
+                        <div class="text-2xl font-bold text-gray-700">2</div>
+                        <div class="text-sm text-gray-600">Cached</div>
+                    </div>
+                    <div class="bg-red-50 border border-red-200 rounded p-3">
+                        <div class="text-2xl font-bold text-red-700">0</div>
+                        <div class="text-sm text-red-600">Failed</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- ==================== FLASHCARDS TAB ==================== -->
+        <div id="panel-flashcards" class="hidden">
+            <h2 class="text-2xl font-bold mb-6">Flashcards</h2>
+
+            <!-- Filter Controls -->
+            <div class="flex flex-wrap gap-4 items-end mb-6">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
+                    <select disabled class="border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>Dutch</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
+                    <select disabled class="border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>Hungarian</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Difficulty</label>
+                    <select disabled class="border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>Hard + Natural</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Display Mode</label>
+                    <select disabled class="border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>Word first</option>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Sample Flashcard -->
+            <div class="fc-scene max-w-md mx-auto">
+                <div class="fc-card bg-white border border-gray-200 rounded-xl shadow-sm">
+                    <div class="fc-face fc-face--front bg-white border border-gray-200 rounded-xl">
+                        <div class="text-3xl font-bold text-gray-800 text-center">uitzoeken</div>
+                        <div class="text-xs text-gray-400 mt-4">Click to flip</div>
+                    </div>
+                    <div class="fc-face fc-face--back bg-white border border-gray-200 rounded-xl">
+                        <div class="space-y-3 text-center">
+                            <div class="text-lg text-gray-700"><span
+                                    class="text-sm text-gray-400 block mb-1">Definition</span>Iets onderzoeken of
+                                selecteren uit meerdere opties</div>
+                            <div class="text-lg text-gray-700"><span
+                                    class="text-sm text-gray-400 block mb-1">English</span>to figure out; to sort out
+                            </div>
+                            <div class="text-lg text-gray-700"><span
+                                    class="text-sm text-gray-400 block mb-1">Translation</span>kiderít; kiválogat</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Navigation -->
+            <div class="flex items-center justify-center gap-6 mt-6">
+                <button disabled class="px-5 py-2 rounded bg-gray-200 text-gray-700 opacity-40 cursor-not-allowed">←
+                    Prev</button>
+                <span class="text-sm text-gray-600 font-medium">3 / 24</span>
+                <button disabled class="px-5 py-2 rounded bg-gray-200 text-gray-700 opacity-75 cursor-not-allowed">Next
+                    →</button>
+            </div>
+
+            <!-- Rating -->
+            <div class="flex items-center justify-center gap-3 mt-4">
+                <span class="text-sm text-gray-500 mr-1">Rate:</span>
+                <button disabled
+                    class="px-4 py-1.5 rounded text-sm border border-green-300 text-green-700 cursor-not-allowed">Easy</button>
+                <button disabled
+                    class="px-4 py-1.5 rounded text-sm border border-gray-300 text-gray-700 bg-gray-100 ring-2 ring-gray-400 cursor-not-allowed">Natural</button>
+                <button disabled
+                    class="px-4 py-1.5 rounded text-sm border border-red-300 text-red-700 cursor-not-allowed">Hard</button>
+            </div>
+        </div>
+
+        <!-- ==================== DATABASE TAB ==================== -->
+        <div id="panel-database" class="hidden">
+            <h2 class="text-2xl font-bold mb-6">Database</h2>
+
+            <!-- Filters -->
+            <div class="flex flex-wrap gap-4 items-end mb-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Source Language</label>
+                    <select disabled class="border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>Dutch</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
+                    <select disabled class="border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>All</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Type</label>
+                    <select disabled class="border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>Words</option>
+                    </select>
+                </div>
+                <div class="flex-1 min-w-[200px]">
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Search</label>
+                    <input type="text" disabled placeholder="Search entries..."
+                        class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                </div>
+            </div>
+
+            <div class="flex gap-3 mb-4">
+                <button disabled
+                    class="border border-gray-300 text-gray-700 px-4 py-2 rounded text-sm opacity-75 cursor-not-allowed">Export
+                    XLSX</button>
+                <button disabled
+                    class="border border-gray-300 text-gray-700 px-4 py-2 rounded text-sm opacity-75 cursor-not-allowed">Import
+                    CSV/XLSX</button>
+            </div>
+
+            <!-- Sample Table -->
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm border border-gray-200 rounded">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-3 py-2 text-left"><input type="checkbox" disabled></th>
+                            <th class="px-3 py-2 text-left font-medium text-gray-700">Word</th>
+                            <th class="px-3 py-2 text-left font-medium text-gray-700">Type</th>
+                            <th class="px-3 py-2 text-left font-medium text-gray-700">Definition</th>
+                            <th class="px-3 py-2 text-left font-medium text-gray-700">English</th>
+                            <th class="px-3 py-2 text-left font-medium text-gray-700">Target</th>
+                            <th class="px-3 py-2 text-left font-medium text-gray-700">Difficulty</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100">
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-3 py-2"><input type="checkbox" disabled></td>
+                            <td class="px-3 py-2 font-medium text-gray-800">stapsgewijs</td>
+                            <td class="px-3 py-2 text-gray-600">bijw.</td>
+                            <td class="px-3 py-2 text-gray-600">stap voor stap, geleidelijk aan, in fasen</td>
+                            <td class="px-3 py-2 text-gray-600">step by step; gradually; in stages</td>
+                            <td class="px-3 py-2 text-gray-600">lépésről lépésre (fokozatosan; szakaszosan)</td>
+                            <td class="px-3 py-2"><span
+                                    class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded">hard</span></td>
+                        </tr>
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-3 py-2"><input type="checkbox" disabled></td>
+                            <td class="px-3 py-2 font-medium text-gray-800">aanhanger</td>
+                            <td class="px-3 py-2 text-gray-600">zn. (de)</td>
+                            <td class="px-3 py-2 text-gray-600">persoon die een bepaalde overtuiging, ideol…</td>
+                            <td class="px-3 py-2 text-gray-600">supporter; follower; adherent</td>
+                            <td class="px-3 py-2 text-gray-600">támogató (híve; követő; pártfogó)</td>
+                            <td class="px-3 py-2"><span
+                                    class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">natural</span></td>
+                        </tr>
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-3 py-2"><input type="checkbox" disabled></td>
+                            <td class="px-3 py-2 font-medium text-gray-800">hanteren</td>
+                            <td class="px-3 py-2 text-gray-600">ww.</td>
+                            <td class="px-3 py-2 text-gray-600">gebruiken, toepassen of omgaan met iets, v…</td>
+                            <td class="px-3 py-2 text-gray-600">to handle; to wield; to manage</td>
+                            <td class="px-3 py-2 text-gray-600">kezel (forgat; alkalmaz; bánik valamivel)</td>
+                            <td class="px-3 py-2"><span
+                                    class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded">hard</span></td>
+                        </tr>
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-3 py-2"><input type="checkbox" disabled></td>
+                            <td class="px-3 py-2 font-medium text-gray-800">beschaving</td>
+                            <td class="px-3 py-2 text-gray-600">zn. (de)</td>
+                            <td class="px-3 py-2 text-gray-600">het geheel van kennis, kunst, zeden en gebr…</td>
+                            <td class="px-3 py-2 text-gray-600">civilization; culture; civilisation</td>
+                            <td class="px-3 py-2 text-gray-600">civilizáció (kultúra; műveltség)</td>
+                            <td class="px-3 py-2"><span
+                                    class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">natural</span></td>
+                        </tr>
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-3 py-2"><input type="checkbox" disabled></td>
+                            <td class="px-3 py-2 font-medium text-gray-800">misvatting</td>
+                            <td class="px-3 py-2 text-gray-600">zn. (de)</td>
+                            <td class="px-3 py-2 text-gray-600">verkeerde opvatting of begrip van iets; een…</td>
+                            <td class="px-3 py-2 text-gray-600">misconception; misunderstanding</td>
+                            <td class="px-3 py-2 text-gray-600">tévhit (téves felfogás; félreértés)</td>
+                            <td class="px-3 py-2"><span
+                                    class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded">hard</span></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="mt-3 text-sm text-gray-500">Showing 1–5 of 142 entries</div>
+        </div>
+
+        <!-- ==================== CONFIG TAB ==================== -->
+        <div id="panel-config" class="hidden">
+            <h2 class="text-2xl font-bold mb-6">Configuration</h2>
+            <div class="max-w-lg space-y-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Profile</label>
+                    <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>default</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
+                    <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>OpenAI</option>
+                    </select>
+                </div>
+                <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
+                    Set <code class="font-mono bg-blue-100 px-1 rounded">OPENAI_API_KEY</code> environment variable
+                    before starting the server.
+                    Not required when using a local server (Ollama, LM Studio) via Base URL.
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Base URL (optional)</label>
+                    <input type="text" value="http://localhost:11434/v1" disabled
+                        class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50 text-gray-800">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Model ID</label>
+                    <input type="text" value="gpt-4o" disabled
+                        class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50 text-gray-800">
+                </div>
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Default Source Language</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>Dutch</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Default Target Language</label>
+                        <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                            <option selected>Hungarian</option>
+                        </select>
+                    </div>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Database Path</label>
+                    <select disabled class="w-full border border-gray-300 rounded px-3 py-2 bg-gray-50">
+                        <option selected>~/.vocabgen/vocabgen.db</option>
+                    </select>
+                </div>
+                <div class="flex gap-3">
+                    <button disabled
+                        class="bg-blue-600 text-white px-4 py-2 rounded opacity-75 cursor-not-allowed">Save</button>
+                    <button disabled
+                        class="border border-gray-300 text-gray-700 px-4 py-2 rounded opacity-75 cursor-not-allowed">Test
+                        Connection</button>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="max-w-7xl mx-auto px-4 py-4 mt-8 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
+        <a href="index.html" class="hover:text-blue-500">← Back to Home</a>
+        <span>·</span>
+        <a href="https://github.com/npozs77/VocabGen" class="hover:text-blue-500">GitHub</a>
+        <span>·</span>
+        <a href="https://github.com/npozs77/VocabGen/releases" class="hover:text-blue-500">Download</a>
+    </footer>
+
+    <!-- Tab Switching Script -->
+    <script>
+        function showTab(name) {
+            var panels = ['lookup', 'batch', 'flashcards', 'database', 'config'];
+            for (var i = 0; i < panels.length; i++) {
+                document.getElementById('panel-' + panels[i]).classList.toggle('hidden', panels[i] !== name);
+                var btn = document.getElementById('tab-' + panels[i]);
+                if (panels[i] === name) {
+                    btn.classList.add('active');
+                    btn.classList.remove('text-gray-500');
+                } else {
+                    btn.classList.remove('active');
+                    btn.classList.add('text-gray-500');
+                }
+            }
+        }
+        // Flashcard flip on click
+        var fcCard = document.querySelector('.fc-card');
+        if (fcCard) {
+            fcCard.addEventListener('click', function () {
+                this.classList.toggle('is-flipped');
+            });
+        }
+    </script>
+</body>
+
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -27,6 +27,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://npozs77.github.io/VocabGen/look-and-feel.html</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://github.com/npozs77/VocabGen/releases</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -232,7 +232,7 @@ Open `http://localhost:8080` in your browser. This is the primary way to use Voc
 - **Lookup** (`/`): Enter a word or expression, select source/target language, optionally provide context. Results display inline. Conflict resolution UI appears when an existing entry is found with a new context. Select "Sentence" type to analyze a full sentence — the LLM checks grammar, provides corrections, translates the sentence, and extracts key vocabulary. Sentence lookups are ephemeral (not stored in the database).
 - **Batch** (`/batch`): Upload a CSV file, select mode and languages, set conflict strategy. Progress streams via SSE. Cancel a running batch at any time — partial results are preserved. Summary shows processed/cached/failed/replaced/added counts.
 - **Flashcards** (`/flashcards`): Study vocabulary with a flip-card interface. Filter by language, tags, and difficulty. Rate cards as easy/hard/natural to focus future sessions. See [Flashcards](#flashcards) below.
-- **Config** (`/config`): View and edit provider settings, test connection to the LLM provider. Credential env var hints are shown per provider; API keys are read from environment variables automatically. On first launch, the "default" profile is shown — edit the fields and click Save to configure your provider. Use "Add new profile…" in the profile dropdown to create additional setups (e.g., a "local" profile for Ollama and a "prod" profile for Bedrock).
+- **Config** (`/config`): View and edit provider settings, test connection to the LLM provider. Credential env var hints are shown per provider; API keys are read from environment variables automatically. On first launch, the "default" profile is shown — edit the fields and click Save to configure your provider. Use "Add new profile…" in the profile dropdown to create additional setups (e.g., a "local" profile for Ollama and a "prod" profile for Bedrock). A database picker dropdown lists all `.db` files in the config directory — select an existing database or choose "Create new…" to enter a name for a new one (validated inline to prevent accidental overwrites). A server restart is required to switch databases.
 - **Database** (`/database`): Browse, search, edit, delete vocabulary entries. Select individual entries or use select-all to bulk delete. Import CSV, export to Excel. Filter by language, search text, or tags.
 
 ### Help Menu
@@ -611,7 +611,17 @@ All user data is stored in `~/.vocabgen/`, independent of where the vocabgen bin
 
 The web UI displays the active database path in the navigation bar (next to the profile indicator), so you can always tell at a glance which database you're connected to.
 
-To use a custom database path:
+### Database Picker (Web UI)
+
+The Config page includes a database picker dropdown that lists all `.db` files found in the config directory (`~/.vocabgen/` or `/data/` in Docker). This makes it easy to manage multiple databases (e.g., per-course or dev/prod) without remembering file paths.
+
+- **Select an existing database**: Choose from the dropdown to set it as the active database path
+- **Create a new database**: Select "Create new…" at the bottom of the dropdown, then type a name (letters, numbers, hyphens, underscores only). The name is validated inline — if it conflicts with an existing file, an error is shown
+- **Server restart required**: The database switch takes effect on the next server restart (hot-swap is not supported)
+
+The new database file is created automatically by vocabgen on the next startup (existing behavior — `NewSQLiteStore` auto-creates missing files).
+
+To use a custom database path from the CLI:
 
 ```bash
 vocabgen serve --db-path ~/.vocabgen/my-project.db

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -692,3 +692,44 @@ Batch default is `skip`. Override with `--on-conflict`:
 ```bash
 vocabgen batch --input-file ch1.csv --mode words -l nl --on-conflict replace
 ```
+
+## Multiple Meanings
+
+Many words have multiple meanings or can function as different parts of speech. vocabgen supports storing each meaning as a separate entry with its own context, definition, and translations.
+
+### Adding a New Meaning (Web UI)
+
+1. On the Lookup page, check the **"Skip cache / Add new meaning"** checkbox
+2. The context field becomes required — enter a sentence that disambiguates the specific meaning you want
+3. Submit the lookup — the LLM returns a result for that specific sense only
+4. The new entry is stored as a separate row (no conflict resolution needed)
+
+### Adding a New Meaning (CLI)
+
+Use the `--new-meaning` flag with a `--context` sentence:
+
+```bash
+vocabgen lookup "beslaan" -l nl --new-meaning --context "De ramen van de auto beslaan door de temperatuurverschillen."
+vocabgen lookup "beslaan" -l nl --new-meaning --context "De vergadering besloeg drie uur van mijn ochtend."
+vocabgen lookup "beslaan" -l nl --new-meaning --context "De hoefsmid besloeg het paard met nieuwe ijzers."
+```
+
+The `--new-meaning` flag requires `--context` — without a context sentence, the command returns an error.
+
+### Disambiguation Display
+
+When a word has 2 or more entries in the database, all entries display a numeric suffix:
+
+- `beslaan (1)` — to fog up
+- `beslaan (2)` — to occupy (space/time)
+- `beslaan (3)` — to shoe (a horse)
+
+Single-meaning words display without any suffix. The disambiguation indicator appears in:
+
+- Database browser
+- Flashcards
+- XLSX export
+
+### Batch Processing
+
+In batch mode, use `skip_cache` (Web UI checkbox) to add new meanings for all tokens in the batch. Each token must have a context sentence (second CSV column). Tokens without context are skipped when skip-cache is active.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -615,11 +615,9 @@ The web UI displays the active database path in the navigation bar (next to the 
 
 The Config page includes a database picker dropdown that lists all `.db` files found in the config directory (`~/.vocabgen/` or `/data/` in Docker). This makes it easy to manage multiple databases (e.g., per-course or dev/prod) without remembering file paths.
 
-- **Select an existing database**: Choose from the dropdown to set it as the active database path
-- **Create a new database**: Select "Create new…" at the bottom of the dropdown, then type a name (letters, numbers, hyphens, underscores only). The name is validated inline — if it conflicts with an existing file, an error is shown
-- **Server restart required**: The database switch takes effect on the next server restart (hot-swap is not supported)
-
-The new database file is created automatically by vocabgen on the next startup (existing behavior — `NewSQLiteStore` auto-creates missing files).
+- **Select an existing database**: Choose from the dropdown and click Save — the server switches to the new database immediately (no restart needed)
+- **Create a new database**: Select "Create new…" at the bottom of the dropdown, then type a name (letters, numbers, hyphens, underscores only). The name is validated inline — if it conflicts with an existing file, an error is shown. The file is created on Save.
+- **Profile-based switching**: Each config profile can point to a different database. Switching profiles also switches the active database live.
 
 To use a custom database path from the CLI:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,14 @@ func getConfigDir() (string, error) {
 	return filepath.Join(home, ".vocabgen"), nil
 }
 
+// ConfigDir returns the resolved config directory path.
+// In Docker, it returns /data; otherwise ~/.vocabgen.
+// This is the exported version of getConfigDir for use by other packages
+// (e.g., scanning for database files).
+func ConfigDir() (string, error) {
+	return getConfigDir()
+}
+
 // FilePath returns the resolved path to the config file.
 func FilePath() string {
 	dir, err := getConfigDir()

--- a/internal/service/disambiguation.go
+++ b/internal/service/disambiguation.go
@@ -1,0 +1,14 @@
+package service
+
+import "fmt"
+
+// DisambiguatedWord returns the display form of a word/expression when
+// multiple meanings exist. If total is 1, the word is returned unchanged.
+// If total > 1, a numeric suffix is appended: "word (1)", "word (2)", etc.
+// The index parameter is 1-based.
+func DisambiguatedWord(word string, index, total int) string {
+	if total <= 1 {
+		return word
+	}
+	return fmt.Sprintf("%s (%d)", word, index)
+}

--- a/internal/service/disambiguation_test.go
+++ b/internal/service/disambiguation_test.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestDisambiguatedWord_SingleMeaning(t *testing.T) {
+	tests := []struct {
+		name  string
+		word  string
+		index int
+		total int
+		want  string
+	}{
+		{"single meaning returns word unchanged", "beslaan", 1, 1, "beslaan"},
+		{"zero total returns word unchanged", "lopen", 1, 0, "lopen"},
+		{"negative total returns word unchanged", "huis", 1, -1, "huis"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DisambiguatedWord(tt.word, tt.index, tt.total)
+			if got != tt.want {
+				t.Errorf("DisambiguatedWord(%q, %d, %d) = %q, want %q", tt.word, tt.index, tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisambiguatedWord_MultipleMeanings(t *testing.T) {
+	tests := []struct {
+		name  string
+		word  string
+		index int
+		total int
+		want  string
+	}{
+		{"two meanings, first", "beslaan", 1, 2, "beslaan (1)"},
+		{"two meanings, second", "beslaan", 2, 2, "beslaan (2)"},
+		{"three meanings, third", "run", 3, 3, "run (3)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DisambiguatedWord(tt.word, tt.index, tt.total)
+			if got != tt.want {
+				t.Errorf("DisambiguatedWord(%q, %d, %d) = %q, want %q", tt.word, tt.index, tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPropertyP18_DisambiguationSuffix verifies that for any word with N meanings (N > 1),
+// all N entries display correct disambiguation suffixes, and single-meaning words have no suffix.
+func TestPropertyP18_DisambiguationSuffix(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		word := rapid.StringMatching(`[a-z]{2,20}`).Draw(t, "word")
+		total := rapid.IntRange(1, 50).Draw(t, "total")
+
+		if total == 1 {
+			got := DisambiguatedWord(word, 1, total)
+			if got != word {
+				t.Fatalf("single meaning: DisambiguatedWord(%q, 1, 1) = %q, want %q", word, got, word)
+			}
+		} else {
+			for i := 1; i <= total; i++ {
+				got := DisambiguatedWord(word, i, total)
+				expected := fmt.Sprintf("%s (%d)", word, i)
+				if got != expected {
+					t.Fatalf("DisambiguatedWord(%q, %d, %d) = %q, want %q", word, i, total, got, expected)
+				}
+			}
+		}
+	})
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -27,6 +27,7 @@ type LookupParams struct {
 	TargetLang string
 	Tags       string
 	DryRun     bool
+	SkipCache  bool // bypass cache and add a new meaning (requires Context)
 	Timeout    time.Duration
 	OnConflict ConflictStrategy
 	ReplaceID  int64
@@ -325,6 +326,39 @@ func Lookup(ctx context.Context, store db.Store, params LookupParams) (*LookupRe
 
 // lookupWord handles the cache-check and LLM invocation flow for a single word lookup.
 func lookupWord(ctx context.Context, store db.Store, params LookupParams, m, normalized, sourceLang, targetLang string) (*LookupResult, error) {
+	// SkipCache mode: bypass cache entirely, invoke LLM, and always insert as a new row.
+	if params.SkipCache {
+		if params.Context == "" {
+			return nil, fmt.Errorf("context sentence is required when adding a new meaning (skip cache)")
+		}
+		slog.Info("skip cache (new meaning)", slog.String("word", normalized), slog.String("context", params.Context))
+		entry, err := invokeLLM(ctx, params.Provider, params.ModelID, sourceLang, m, normalized, params.Context, targetLang)
+		if err != nil {
+			return nil, err
+		}
+		entry.Tags = params.Tags
+
+		result := &LookupResult{Entry: entry}
+		if w := checkNonWord(normalized, entry); w != "" {
+			result.Warning = w
+			slog.Warn(w, slog.String("word", normalized))
+			return result, nil
+		}
+
+		row := entryToWordRow(entry, params.SourceLang, params.TargetLang, params.Tags)
+		row.Word = normalized
+		if err := store.InsertWord(ctx, row); err != nil {
+			slog.Error("database insert failed", slog.String("word", normalized), slog.String("error", err.Error()))
+			return nil, fmt.Errorf("database insert failed: %w", err)
+		}
+		slog.Info("new meaning added", slog.String("word", normalized))
+		if w := checkHallucination(normalized, entry.Example); w != "" {
+			result.Warning = w
+			slog.Warn(w, slog.String("word", normalized))
+		}
+		return result, nil
+	}
+
 	existing, err := store.FindWords(ctx, normalized, params.SourceLang)
 	if err != nil {
 		slog.Error("database lookup failed", slog.String("word", normalized), slog.String("error", err.Error()))
@@ -414,6 +448,35 @@ func lookupWord(ctx context.Context, store db.Store, params LookupParams, m, nor
 
 // lookupExpression handles the cache-check and LLM invocation flow for a single expression lookup.
 func lookupExpression(ctx context.Context, store db.Store, params LookupParams, m, normalized, sourceLang, targetLang string) (*LookupResult, error) {
+	// SkipCache mode: bypass cache entirely, invoke LLM, and always insert as a new row.
+	if params.SkipCache {
+		if params.Context == "" {
+			return nil, fmt.Errorf("context sentence is required when adding a new meaning (skip cache)")
+		}
+		slog.Info("skip cache (new meaning)", slog.String("expression", normalized), slog.String("context", params.Context))
+		entry, err := invokeLLM(ctx, params.Provider, params.ModelID, sourceLang, m, normalized, params.Context, targetLang)
+		if err != nil {
+			return nil, err
+		}
+		entry.Tags = params.Tags
+
+		result := &LookupResult{Entry: entry}
+		if w := checkNonWord(normalized, entry); w != "" {
+			result.Warning = w
+			slog.Warn(w, slog.String("expression", normalized))
+			return result, nil
+		}
+
+		row := entryToExprRow(entry, params.SourceLang, params.TargetLang, params.Tags)
+		row.Expression = normalized
+		if err := store.InsertExpression(ctx, row); err != nil {
+			slog.Error("database insert failed", slog.String("expression", normalized), slog.String("error", err.Error()))
+			return nil, fmt.Errorf("database insert failed: %w", err)
+		}
+		slog.Info("new meaning added", slog.String("expression", normalized))
+		return result, nil
+	}
+
 	existing, err := store.FindExpressions(ctx, normalized, params.SourceLang)
 	if err != nil {
 		slog.Error("database lookup failed", slog.String("expression", normalized), slog.String("error", err.Error()))
@@ -533,6 +596,7 @@ type BatchParams struct {
 	Tags       string
 	Limit      int
 	DryRun     bool
+	SkipCache  bool // bypass cache for all tokens (requires context per token)
 	Timeout    time.Duration
 	OnConflict ConflictStrategy // default: "skip"
 	OnProgress ProgressFunc     // optional progress callback
@@ -651,6 +715,38 @@ func processBatchWord(ctx context.Context, store db.Store, params BatchParams, s
 		return
 	}
 
+	// SkipCache mode: always invoke LLM and insert as new row.
+	if params.SkipCache {
+		if ctxSentence == "" {
+			slog.Warn("batch: skip_cache requires context, skipping", slog.String("word", normalized))
+			result.Skipped++
+			return
+		}
+		if params.Limit > 0 && *newCount >= params.Limit {
+			return
+		}
+		entry, err := invokeLLM(ctx, params.Provider, params.ModelID, sourceLang, params.Mode, normalized, ctxSentence, targetLang)
+		if err != nil {
+			slog.Error("batch: LLM failed", slog.String("word", normalized), slog.String("error", err.Error()))
+			result.Errors = append(result.Errors, BatchError{Token: normalized, Message: err.Error()})
+			result.Failed++
+			*newCount++
+			return
+		}
+		entry.Tags = params.Tags
+		row := entryToWordRow(entry, params.SourceLang, params.TargetLang, params.Tags)
+		row.Word = normalized
+		if err := store.InsertWord(ctx, row); err != nil {
+			result.Errors = append(result.Errors, BatchError{Token: normalized, Message: err.Error()})
+			result.Failed++
+		} else {
+			result.Added++
+			result.Results = append(result.Results, *entry)
+		}
+		*newCount++
+		return
+	}
+
 	existing, err := store.FindWords(ctx, normalized, params.SourceLang)
 	if err != nil {
 		slog.Error("batch: database lookup failed", slog.String("word", normalized), slog.String("error", err.Error()))
@@ -728,6 +824,38 @@ func processBatchWord(ctx context.Context, store db.Store, params BatchParams, s
 // invokes the LLM on miss, and applies the configured conflict strategy.
 func processBatchExpression(ctx context.Context, store db.Store, params BatchParams, sourceLang, targetLang, normalized, ctxSentence string, result *BatchResult, newCount *int) {
 	if ctx.Err() != nil {
+		return
+	}
+
+	// SkipCache mode: always invoke LLM and insert as new row.
+	if params.SkipCache {
+		if ctxSentence == "" {
+			slog.Warn("batch: skip_cache requires context, skipping", slog.String("expression", normalized))
+			result.Skipped++
+			return
+		}
+		if params.Limit > 0 && *newCount >= params.Limit {
+			return
+		}
+		entry, err := invokeLLM(ctx, params.Provider, params.ModelID, sourceLang, params.Mode, normalized, ctxSentence, targetLang)
+		if err != nil {
+			slog.Error("batch: LLM failed", slog.String("expression", normalized), slog.String("error", err.Error()))
+			result.Errors = append(result.Errors, BatchError{Token: normalized, Message: err.Error()})
+			result.Failed++
+			*newCount++
+			return
+		}
+		entry.Tags = params.Tags
+		row := entryToExprRow(entry, params.SourceLang, params.TargetLang, params.Tags)
+		row.Expression = normalized
+		if err := store.InsertExpression(ctx, row); err != nil {
+			result.Errors = append(result.Errors, BatchError{Token: normalized, Message: err.Error()})
+			result.Failed++
+		} else {
+			result.Added++
+			result.Results = append(result.Results, *entry)
+		}
+		*newCount++
 		return
 	}
 

--- a/internal/web/disambiguation.go
+++ b/internal/web/disambiguation.go
@@ -1,0 +1,60 @@
+package web
+
+import (
+	"strings"
+
+	"github.com/user/vocabgen/internal/db"
+	"github.com/user/vocabgen/internal/service"
+)
+
+// disambiguateWords modifies the Word field in-place to add numeric suffixes
+// when multiple entries share the same headword (case-insensitive).
+// Single-meaning words are left unchanged.
+func disambiguateWords(words []db.WordRow) {
+	if len(words) == 0 {
+		return
+	}
+
+	// Count occurrences per normalized word.
+	counts := make(map[string]int)
+	for i := range words {
+		key := strings.ToLower(words[i].Word)
+		counts[key]++
+	}
+
+	// Assign indices for words with multiple meanings.
+	indices := make(map[string]int)
+	for i := range words {
+		key := strings.ToLower(words[i].Word)
+		total := counts[key]
+		if total > 1 {
+			indices[key]++
+			words[i].Word = service.DisambiguatedWord(words[i].Word, indices[key], total)
+		}
+	}
+}
+
+// disambiguateExpressions modifies the Expression field in-place to add numeric
+// suffixes when multiple entries share the same headword (case-insensitive).
+// Single-meaning expressions are left unchanged.
+func disambiguateExpressions(expressions []db.ExpressionRow) {
+	if len(expressions) == 0 {
+		return
+	}
+
+	counts := make(map[string]int)
+	for i := range expressions {
+		key := strings.ToLower(expressions[i].Expression)
+		counts[key]++
+	}
+
+	indices := make(map[string]int)
+	for i := range expressions {
+		key := strings.ToLower(expressions[i].Expression)
+		total := counts[key]
+		if total > 1 {
+			indices[key]++
+			expressions[i].Expression = service.DisambiguatedWord(expressions[i].Expression, indices[key], total)
+		}
+	}
+}

--- a/internal/web/disambiguation_test.go
+++ b/internal/web/disambiguation_test.go
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"testing"
+
+	"github.com/user/vocabgen/internal/db"
+)
+
+func TestDisambiguateWords_SingleMeaning(t *testing.T) {
+	words := []db.WordRow{
+		{ID: 1, Word: "huis"},
+		{ID: 2, Word: "werk"},
+		{ID: 3, Word: "fiets"},
+	}
+	disambiguateWords(words)
+
+	// No suffixes for single-meaning words.
+	for _, w := range words {
+		switch w.ID {
+		case 1:
+			if w.Word != "huis" {
+				t.Errorf("word ID 1: got %q, want %q", w.Word, "huis")
+			}
+		case 2:
+			if w.Word != "werk" {
+				t.Errorf("word ID 2: got %q, want %q", w.Word, "werk")
+			}
+		case 3:
+			if w.Word != "fiets" {
+				t.Errorf("word ID 3: got %q, want %q", w.Word, "fiets")
+			}
+		}
+	}
+}
+
+func TestDisambiguateWords_MultipleMeanings(t *testing.T) {
+	words := []db.WordRow{
+		{ID: 1, Word: "beslaan"},
+		{ID: 2, Word: "huis"},
+		{ID: 3, Word: "beslaan"},
+		{ID: 4, Word: "beslaan"},
+	}
+	disambiguateWords(words)
+
+	expected := map[int64]string{
+		1: "beslaan (1)",
+		2: "huis",
+		3: "beslaan (2)",
+		4: "beslaan (3)",
+	}
+	for _, w := range words {
+		want := expected[w.ID]
+		if w.Word != want {
+			t.Errorf("word ID %d: got %q, want %q", w.ID, w.Word, want)
+		}
+	}
+}
+
+func TestDisambiguateWords_CaseInsensitive(t *testing.T) {
+	words := []db.WordRow{
+		{ID: 1, Word: "Beslaan"},
+		{ID: 2, Word: "beslaan"},
+	}
+	disambiguateWords(words)
+
+	// Both should get suffixes since they match case-insensitively.
+	if words[0].Word != "Beslaan (1)" {
+		t.Errorf("word ID 1: got %q, want %q", words[0].Word, "Beslaan (1)")
+	}
+	if words[1].Word != "beslaan (2)" {
+		t.Errorf("word ID 2: got %q, want %q", words[1].Word, "beslaan (2)")
+	}
+}
+
+func TestDisambiguateWords_Empty(t *testing.T) {
+	var words []db.WordRow
+	disambiguateWords(words) // should not panic
+}
+
+func TestDisambiguateExpressions_MultipleMeanings(t *testing.T) {
+	exprs := []db.ExpressionRow{
+		{ID: 1, Expression: "op de hoogte"},
+		{ID: 2, Expression: "op de hoogte"},
+		{ID: 3, Expression: "in de war"},
+	}
+	disambiguateExpressions(exprs)
+
+	expected := map[int64]string{
+		1: "op de hoogte (1)",
+		2: "op de hoogte (2)",
+		3: "in de war",
+	}
+	for _, e := range exprs {
+		want := expected[e.ID]
+		if e.Expression != want {
+			t.Errorf("expression ID %d: got %q, want %q", e.ID, e.Expression, want)
+		}
+	}
+}

--- a/internal/web/handlers_batch.go
+++ b/internal/web/handlers_batch.go
@@ -145,6 +145,7 @@ func (s *Server) handleBatchJSON(w http.ResponseWriter, r *http.Request) {
 		ModelID:    s.cfg.ModelID,
 		TargetLang: targetLang,
 		Tags:       tags,
+		SkipCache:  r.FormValue("skip_cache") == "on" || r.FormValue("skip_cache") == "true",
 		OnConflict: onConflict,
 	})
 	if err != nil {
@@ -210,6 +211,7 @@ func (s *Server) handleBatchHTML(w http.ResponseWriter, r *http.Request) {
 		ModelID:    s.cfg.ModelID,
 		TargetLang: targetLang,
 		Tags:       tags,
+		SkipCache:  r.FormValue("skip_cache") == "on" || r.FormValue("skip_cache") == "true",
 		OnConflict: onConflict,
 	})
 	if err != nil {
@@ -319,6 +321,7 @@ func (s *Server) handleBatchStream(w http.ResponseWriter, r *http.Request) {
 		ModelID:    s.cfg.ModelID,
 		TargetLang: targetLang,
 		Tags:       tags,
+		SkipCache:  r.FormValue("skip_cache") == "on" || r.FormValue("skip_cache") == "true",
 		OnConflict: onConflict,
 		OnProgress: progressFn,
 	})

--- a/internal/web/handlers_config.go
+++ b/internal/web/handlers_config.go
@@ -104,6 +104,13 @@ func (s *Server) handleSwitchProfile(w http.ResponseWriter, r *http.Request) {
 	s.activeProfile = req.Profile
 	s.logger.Info("switched config profile", "profile", req.Profile)
 
+	// Hot-swap database if the new profile has a different DB path.
+	if cfg.DBPath != "" && cfg.DBPath != s.dbPath {
+		if err := s.switchDatabase(cfg.DBPath); err != nil {
+			s.logger.Error("failed to switch database on profile change", "path", cfg.DBPath, "error", err)
+		}
+	}
+
 	// Determine if the new profile uses a local model (for warning banner).
 	isLocal := strings.Contains(cfg.BaseURL, "localhost:11434")
 
@@ -132,17 +139,32 @@ func (s *Server) handleSwitchProfile(w http.ResponseWriter, r *http.Request) {
 	// This replaces the two-step approach (PUT then GET) that was prone to
 	// stale form values leaking into the re-render request (#28).
 	profiles, _, _ := config.ListProfiles()
+
+	// Scan config directory for existing .db files.
+	var databases []string
+	if dir, dirErr := config.ConfigDir(); dirErr == nil {
+		if entries, readErr := os.ReadDir(dir); readErr == nil {
+			for _, entry := range entries {
+				if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".db") {
+					databases = append(databases, dir+"/"+entry.Name())
+				}
+			}
+		}
+	}
+
 	data := struct {
 		Config        *config.Config
 		Languages     []service.LanguageInfo
 		Profiles      []string
 		ActiveProfile string
+		Databases     []string
 		StatusMessage template.HTML
 	}{
 		Config:        &cfg,
 		Languages:     service.GetSupportedLanguages(),
 		Profiles:      profiles,
 		ActiveProfile: s.activeProfile,
+		Databases:     databases,
 		StatusMessage: template.HTML(`<p class="text-green-600 text-sm mt-1">Switched to profile "` + req.Profile + `".</p>`),
 	}
 	// Signal the page to update the local model warning banner.
@@ -233,7 +255,7 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	if updated.Provider == "" {
 		updated.Provider = "bedrock"
 	}
-	if updated.DBPath == "" {
+	if updated.DBPath == "" || updated.DBPath == "__new__" {
 		updated.DBPath = s.cfg.DBPath
 	}
 
@@ -267,6 +289,14 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		// Set the db_path to the new file in the config directory.
 		if dir != "" {
 			updated.DBPath = filepath.Join(dir, newDBName)
+			// Create the empty database file so it appears in the picker immediately.
+			f, createErr := os.Create(updated.DBPath)
+			if createErr != nil {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte(`<p class="text-red-600 text-sm mt-1">Failed to create database file: ` + createErr.Error() + `</p>`))
+				return
+			}
+			_ = f.Close()
 		}
 	}
 
@@ -286,6 +316,15 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 
 	// Update in-memory config
 	*s.cfg = updated
+
+	// Hot-swap database if path changed.
+	if updated.DBPath != s.dbPath {
+		if err := s.switchDatabase(updated.DBPath); err != nil {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(`<p class="text-red-600 text-sm mt-1">Config saved but failed to switch database: ` + err.Error() + `</p>`))
+			return
+		}
+	}
 
 	s.logger.Info("config saved", "profile", s.activeProfile, "provider", updated.Provider)
 
@@ -319,17 +358,31 @@ func (s *Server) handleConfigHTML(w http.ResponseWriter, r *http.Request) {
 
 	profiles, _, _ := config.ListProfiles()
 
+	// Scan config directory for existing .db files.
+	var databases []string
+	if dir, err := config.ConfigDir(); err == nil {
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, entry := range entries {
+				if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".db") {
+					databases = append(databases, dir+"/"+entry.Name())
+				}
+			}
+		}
+	}
+
 	data := struct {
 		Config        *config.Config
 		Languages     []service.LanguageInfo
 		Profiles      []string
 		ActiveProfile string
+		Databases     []string
 		StatusMessage template.HTML
 	}{
 		Config:        &cfg,
 		Languages:     service.GetSupportedLanguages(),
 		Profiles:      profiles,
 		ActiveProfile: s.activeProfile,
+		Databases:     databases,
 	}
 	// Signal the page to update the local model warning banner based on
 	// the previewed provider. Non-openai providers never use a local URL.

--- a/internal/web/handlers_config.go
+++ b/internal/web/handlers_config.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,6 +16,42 @@ import (
 // handleGetConfig handles GET /api/config — return current config as JSON.
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.cfg)
+}
+
+// handleListDatabases handles GET /api/databases — scans the config directory
+// for *.db files and returns them as a JSON array of filenames.
+func (s *Server) handleListDatabases(w http.ResponseWriter, r *http.Request) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to resolve config directory: "+err.Error())
+		return
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// If the directory doesn't exist yet, return an empty list.
+		if os.IsNotExist(err) {
+			writeJSON(w, http.StatusOK, []string{})
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "failed to read config directory: "+err.Error())
+		return
+	}
+
+	var databases []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".db") {
+			databases = append(databases, entry.Name())
+		}
+	}
+	if databases == nil {
+		databases = []string{}
+	}
+
+	writeJSON(w, http.StatusOK, databases)
 }
 
 // handleGetProfiles handles GET /api/profiles — return available profiles and active profile.
@@ -188,7 +225,7 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 			GCPRegion:             r.FormValue("gcp_region"),
 			DefaultSourceLanguage: r.FormValue("default_source_language"),
 			DefaultTargetLanguage: r.FormValue("default_target_language"),
-			DBPath:                s.cfg.DBPath, // preserve DB path
+			DBPath:                r.FormValue("db_path"),
 		}
 	}
 
@@ -198,6 +235,39 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	if updated.DBPath == "" {
 		updated.DBPath = s.cfg.DBPath
+	}
+
+	// Validate db_path when "create new" intent is signaled.
+	// The form sends db_path_new_name when the user typed a new DB name.
+	newDBName := ""
+	if ct != "application/json" {
+		newDBName = r.FormValue("db_path_new_name")
+	}
+	if newDBName != "" {
+		// Sanitize: only allow alphanumeric, hyphens, underscores, and dots.
+		if !isValidDBName(newDBName) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(`<p class="text-red-600 text-sm mt-1">Invalid database name. Use only letters, numbers, hyphens, and underscores.</p>`))
+			return
+		}
+		// Ensure it ends with .db
+		if !strings.HasSuffix(newDBName, ".db") {
+			newDBName += ".db"
+		}
+		// Check for conflict with existing files.
+		dir, err := config.ConfigDir()
+		if err == nil {
+			existingPath := filepath.Join(dir, newDBName)
+			if _, statErr := os.Stat(existingPath); statErr == nil {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte(`<p class="text-red-600 text-sm mt-1">A database named "` + newDBName + `" already exists. Choose a different name.</p>`))
+				return
+			}
+		}
+		// Set the db_path to the new file in the config directory.
+		if dir != "" {
+			updated.DBPath = filepath.Join(dir, newDBName)
+		}
 	}
 
 	// Validate provider credentials are available via environment.
@@ -360,4 +430,27 @@ func (s *Server) handleProfileSwitcherPartial(w http.ResponseWriter, _ *http.Req
 		Profiles:      profiles,
 	}
 	_ = renderPartial(w, "profile_switcher", data)
+}
+
+// isValidDBName checks that a database filename contains only safe characters:
+// letters, digits, hyphens, underscores, and dots. The .db extension is optional
+// (it will be appended if missing).
+func isValidDBName(name string) bool {
+	if name == "" {
+		return false
+	}
+	// Strip .db suffix for validation of the base name.
+	base := strings.TrimSuffix(name, ".db")
+	if base == "" {
+		return false
+	}
+	for _, r := range base {
+		isLower := r >= 'a' && r <= 'z'
+		isUpper := r >= 'A' && r <= 'Z'
+		isDigit := r >= '0' && r <= '9'
+		if !isLower && !isUpper && !isDigit && r != '-' && r != '_' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/web/handlers_config_test.go
+++ b/internal/web/handlers_config_test.go
@@ -693,3 +693,255 @@ func TestProfileSwitch_StaleProviderParamIgnored(t *testing.T) {
 		t.Fatal("expected provider query param to still work for provider selector preview")
 	}
 }
+
+// TestListDatabases_ReturnsDBFiles tests GET /api/databases returns .db files.
+func TestListDatabases_ReturnsDBFiles(t *testing.T) {
+	// Create a temp dir with some .db files and non-.db files.
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	// Create test files.
+	for _, name := range []string{"vocabgen.db", "vocabgen-dev.db", "config.yaml", "notes.txt"} {
+		if err := os.WriteFile(dir+"/"+name, []byte("test"), 0o644); err != nil {
+			t.Fatalf("create test file %s: %v", name, err)
+		}
+	}
+
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/databases", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	var databases []string
+	if err := json.NewDecoder(w.Body).Decode(&databases); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+
+	// Should only contain .db files.
+	if len(databases) != 2 {
+		t.Fatalf("expected 2 databases, got %d: %v", len(databases), databases)
+	}
+	hasVocabgen := false
+	hasVocabgenDev := false
+	for _, db := range databases {
+		if db == "vocabgen.db" {
+			hasVocabgen = true
+		}
+		if db == "vocabgen-dev.db" {
+			hasVocabgenDev = true
+		}
+	}
+	if !hasVocabgen || !hasVocabgenDev {
+		t.Fatalf("expected vocabgen.db and vocabgen-dev.db, got %v", databases)
+	}
+}
+
+// TestListDatabases_EmptyDir tests GET /api/databases with no .db files.
+func TestListDatabases_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/databases", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	var databases []string
+	if err := json.NewDecoder(w.Body).Decode(&databases); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+
+	if len(databases) != 0 {
+		t.Fatalf("expected empty list, got %v", databases)
+	}
+}
+
+// TestListDatabases_SkipsDirectories tests that directories ending in .db are not listed.
+func TestListDatabases_SkipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	// Create a directory named "fake.db" and a real file "real.db".
+	if err := os.Mkdir(dir+"/fake.db", 0o755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+	if err := os.WriteFile(dir+"/real.db", []byte("test"), 0o644); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/databases", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var databases []string
+	if err := json.NewDecoder(w.Body).Decode(&databases); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+
+	if len(databases) != 1 || databases[0] != "real.db" {
+		t.Fatalf("expected [real.db], got %v", databases)
+	}
+}
+
+// TestPutConfig_NewDBName_Valid tests that a valid new DB name is accepted.
+func TestPutConfig_NewDBName_Valid(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	t.Setenv("AWS_PROFILE", "test")
+
+	srv := newTestServer()
+	form := "provider=bedrock&aws_region=us-east-1&default_source_language=nl&default_target_language=hu&db_path=&db_path_new_name=my-new-course"
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Configuration saved") {
+		t.Fatalf("expected success message, got: %s", w.Body.String())
+	}
+	// Verify the db_path was set to the new file path.
+	if !strings.Contains(srv.cfg.DBPath, "my-new-course.db") {
+		t.Fatalf("expected db_path to contain 'my-new-course.db', got %q", srv.cfg.DBPath)
+	}
+}
+
+// TestPutConfig_NewDBName_Conflict tests that a conflicting new DB name is rejected.
+func TestPutConfig_NewDBName_Conflict(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	// Create an existing database file.
+	if err := os.WriteFile(dir+"/existing.db", []byte("data"), 0o644); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+
+	t.Setenv("AWS_PROFILE", "test")
+
+	srv := newTestServer()
+	form := "provider=bedrock&aws_region=us-east-1&default_source_language=nl&default_target_language=hu&db_path=&db_path_new_name=existing"
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "already exists") {
+		t.Fatalf("expected conflict error, got: %s", w.Body.String())
+	}
+}
+
+// TestPutConfig_NewDBName_Invalid tests that an invalid new DB name is rejected.
+func TestPutConfig_NewDBName_Invalid(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	t.Setenv("AWS_PROFILE", "test")
+
+	tests := []struct {
+		name    string
+		dbName  string
+		wantErr string
+	}{
+		{"spaces", "my course", "Invalid database name"},
+		{"special chars", "db@home!", "Invalid database name"},
+		{"path traversal", "../evil", "Invalid database name"},
+		{"slash", "path/to/db", "Invalid database name"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServer()
+			form := "provider=bedrock&aws_region=us-east-1&default_source_language=nl&default_target_language=hu&db_path=&db_path_new_name=" + tc.dbName
+			req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(form))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if !strings.Contains(w.Body.String(), tc.wantErr) {
+				t.Fatalf("expected %q in response, got: %s", tc.wantErr, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestPutConfig_SelectExistingDB tests that selecting an existing DB from the dropdown works.
+func TestPutConfig_SelectExistingDB(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	t.Setenv("AWS_PROFILE", "test")
+
+	srv := newTestServer()
+	form := "provider=bedrock&aws_region=us-east-1&default_source_language=nl&default_target_language=hu&db_path=" + dir + "/vocabgen-dev.db"
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Configuration saved") {
+		t.Fatalf("expected success message, got: %s", w.Body.String())
+	}
+	if srv.cfg.DBPath != dir+"/vocabgen-dev.db" {
+		t.Fatalf("expected db_path %q, got %q", dir+"/vocabgen-dev.db", srv.cfg.DBPath)
+	}
+}
+
+// TestIsValidDBName tests the isValidDBName helper function.
+func TestIsValidDBName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple name", "vocabgen", true},
+		{"with hyphen", "my-course", true},
+		{"with underscore", "my_course", true},
+		{"with digits", "course2024", true},
+		{"with .db suffix", "vocabgen.db", true},
+		{"empty", "", false},
+		{"just .db", ".db", false},
+		{"spaces", "my course", false},
+		{"special chars", "db@home", false},
+		{"path separator", "path/db", false},
+		{"dots in name", "my.course", false},
+		{"backslash", "path\\db", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isValidDBName(tc.input)
+			if got != tc.want {
+				t.Fatalf("isValidDBName(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/web/handlers_config_test.go
+++ b/internal/web/handlers_config_test.go
@@ -824,6 +824,10 @@ func TestPutConfig_NewDBName_Valid(t *testing.T) {
 	if !strings.Contains(srv.cfg.DBPath, "my-new-course.db") {
 		t.Fatalf("expected db_path to contain 'my-new-course.db', got %q", srv.cfg.DBPath)
 	}
+	// Verify the .db file was actually created on disk.
+	if _, err := os.Stat(srv.cfg.DBPath); os.IsNotExist(err) {
+		t.Fatalf("expected database file to be created at %q, but it does not exist", srv.cfg.DBPath)
+	}
 }
 
 // TestPutConfig_NewDBName_Conflict tests that a conflicting new DB name is rejected.
@@ -943,5 +947,79 @@ func TestIsValidDBName(t *testing.T) {
 				t.Fatalf("isValidDBName(%q) = %v, want %v", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestPutConfig_NewDBPath_FallbackWhenNew tests that db_path="__new__" without a name falls back to current.
+func TestPutConfig_NewDBPath_FallbackWhenNew(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	t.Setenv("AWS_PROFILE", "test")
+
+	srv := newTestServer()
+	originalDBPath := srv.cfg.DBPath
+
+	// Send __new__ as db_path but no db_path_new_name — should fall back to current.
+	form := "provider=bedrock&aws_region=us-east-1&default_source_language=nl&default_target_language=hu&db_path=__new__&db_path_new_name="
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	if srv.cfg.DBPath != originalDBPath {
+		t.Fatalf("expected db_path to remain %q, got %q", originalDBPath, srv.cfg.DBPath)
+	}
+}
+
+// TestSwitchProfile_IncludesDatabases tests that profile switch re-renders with database picker.
+func TestSwitchProfile_IncludesDatabases(t *testing.T) {
+	dir := t.TempDir()
+	config.SetConfigDirForTest(dir)
+	t.Cleanup(func() { config.SetConfigDirForTest(os.TempDir()) })
+
+	// Create a .db file so it shows in the picker.
+	if err := os.WriteFile(dir+"/vocabgen.db", []byte{}, 0o644); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+
+	// Write a multi-profile config.
+	fc := config.FileConfig{
+		DefaultProfile: "default",
+		Profiles: map[string]config.ProfileConfig{
+			"default": {Provider: "bedrock", AWSRegion: "us-east-1"},
+			"local":   {Provider: "openai", BaseURL: "http://localhost:11434/v1", ModelID: "test"},
+		},
+		DefaultSourceLanguage: "nl",
+		DefaultTargetLanguage: "hu",
+		DBPath:                dir + "/vocabgen.db",
+	}
+	if err := config.SaveFileConfig(fc); err != nil {
+		t.Fatalf("SaveFileConfig: %v", err)
+	}
+
+	srv := newTestServer()
+	srv.cfg.DBPath = dir + "/vocabgen.db"
+
+	form := "profile=local"
+	req := httptest.NewRequest(http.MethodPut, "/api/profile/switch", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	// The response should contain the database picker with "Create new" option.
+	body := w.Body.String()
+	if !strings.Contains(body, "Create new") {
+		t.Fatalf("expected 'Create new' in profile switch response, got: %s", body)
+	}
+	if !strings.Contains(body, "Save") {
+		t.Fatalf("expected 'Save' button in profile switch response, got: %s", body)
 	}
 }

--- a/internal/web/handlers_db.go
+++ b/internal/web/handlers_db.go
@@ -75,6 +75,9 @@ func (s *Server) handleListWords(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Apply disambiguation suffixes for words with multiple meanings.
+	disambiguateWords(words)
+
 	// Check if HTMX request — return partial
 	if r.Header.Get("HX-Request") == "true" {
 		totalPages := (total + filter.PageSize - 1) / filter.PageSize
@@ -121,6 +124,9 @@ func (s *Server) handleListExpressions(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// Apply disambiguation suffixes for expressions with multiple meanings.
+	disambiguateExpressions(expressions)
 
 	if r.Header.Get("HX-Request") == "true" {
 		totalPages := (total + filter.PageSize - 1) / filter.PageSize
@@ -764,6 +770,10 @@ func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// Apply disambiguation for words with multiple meanings.
+	disambiguateWords(words)
+
 	for _, wr := range words {
 		wordEntries = append(wordEntries, output.Entry{
 			Word: wr.Word, Type: wr.PartOfSpeech, Article: wr.Article,
@@ -782,6 +792,10 @@ func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// Apply disambiguation for expressions with multiple meanings.
+	disambiguateExpressions(exprs)
+
 	for _, er := range exprs {
 		exprEntries = append(exprEntries, output.Entry{
 			Expression: er.Expression, Definition: er.Definition,

--- a/internal/web/handlers_flashcards.go
+++ b/internal/web/handlers_flashcards.go
@@ -64,6 +64,11 @@ func (s *Server) handleFlashcardsHTML(w http.ResponseWriter, r *http.Request) {
 
 	// Convert to FlashcardItem slice.
 	deck := make([]db.FlashcardItem, 0, len(words)+len(expressions))
+
+	// Apply disambiguation for words with multiple meanings.
+	disambiguateWords(words)
+	disambiguateExpressions(expressions)
+
 	for _, w := range words {
 		deck = append(deck, db.FlashcardItem{
 			ID:                w.ID,

--- a/internal/web/handlers_lookup.go
+++ b/internal/web/handlers_lookup.go
@@ -17,6 +17,7 @@ type lookupRequest struct {
 	Context        string `json:"context"`
 	TargetLanguage string `json:"target_language"`
 	Tags           string `json:"tags"`
+	SkipCache      bool   `json:"skip_cache"`
 }
 
 // resolveRequest is the JSON body for POST /api/lookup/resolve.
@@ -51,6 +52,7 @@ func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, error
 			Context:        r.FormValue("context"),
 			TargetLanguage: r.FormValue("target_language"),
 			Tags:           r.FormValue("tags"),
+			SkipCache:      r.FormValue("skip_cache") == "on" || r.FormValue("skip_cache") == "true",
 		}
 	}
 
@@ -81,6 +83,7 @@ func (s *Server) parseLookupParams(r *http.Request) (service.LookupParams, error
 		Context:    req.Context,
 		TargetLang: req.TargetLanguage,
 		Tags:       req.Tags,
+		SkipCache:  req.SkipCache,
 	}, nil
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -140,6 +140,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /api/profiles", s.handleCreateProfile)
 	s.mux.HandleFunc("PUT /api/profile/switch", s.handleSwitchProfile)
 	s.mux.HandleFunc("GET /api/profile/switcher", s.handleProfileSwitcherPartial)
+	s.mux.HandleFunc("GET /api/databases", s.handleListDatabases)
 
 	// Database API
 	s.mux.HandleFunc("GET /api/tags", s.handleListTags)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -200,6 +200,25 @@ func (s *Server) newPageData(activePage string) pageData {
 	return pd
 }
 
+// switchDatabase closes the current store and opens a new one at the given path.
+// Updates s.store and s.dbPath on success. Returns an error if the new store
+// cannot be opened (the old store remains closed in that case).
+func (s *Server) switchDatabase(newPath string) error {
+	if newPath == s.dbPath {
+		return nil
+	}
+	_ = s.store.Close()
+	newStore, err := db.NewSQLiteStore(newPath)
+	if err != nil {
+		s.logger.Error("failed to open new database", "path", newPath, "error", err)
+		return err
+	}
+	s.store = newStore
+	s.dbPath = newPath
+	s.logger.Info("switched database", "path", newPath)
+	return nil
+}
+
 // handleHealth returns a simple health check response.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -244,6 +244,7 @@ func TestAPIRoutesRegistered(t *testing.T) {
 		{"get-profiles", http.MethodGet, "/api/profiles", http.StatusOK},
 		{"switch-profile", http.MethodPut, "/api/profile/switch", http.StatusBadRequest},
 		{"profile-switcher", http.MethodGet, "/api/profile/switcher", http.StatusOK},
+		{"databases", http.MethodGet, "/api/databases", http.StatusOK},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/web/templates/database.html
+++ b/internal/web/templates/database.html
@@ -99,6 +99,15 @@
 </div>
 
 <script>
+  function toggleDetail(id, url, el) {
+    var existing = document.getElementById('edit-row-' + id);
+    if (existing) {
+      existing.remove();
+      return;
+    }
+    htmx.ajax('GET', url, { target: el.closest('tr'), swap: 'afterend' });
+  }
+
   function toggleSelectAll(el) {
     var cbs = document.querySelectorAll('.entry-cb');
     for (var i = 0; i < cbs.length; i++) {

--- a/internal/web/templates/lookup.html
+++ b/internal/web/templates/lookup.html
@@ -54,6 +54,26 @@
       placeholder="Sentence or context where the word appears"></textarea>
   </div>
 
+  <div class="flex items-center gap-2">
+    <input type="checkbox" id="skip_cache" name="skip_cache"
+      class="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" onchange="toggleContextRequired(this)">
+    <label for="skip_cache" class="text-sm font-medium text-gray-700">Skip cache / Add new meaning</label>
+    <span class="text-xs text-gray-500">(context becomes required)</span>
+  </div>
+
+  <script>
+    function toggleContextRequired(cb) {
+      var ctx = document.getElementById('context');
+      if (cb.checked) {
+        ctx.setAttribute('required', 'required');
+        ctx.placeholder = 'Context sentence is required when adding a new meaning';
+      } else {
+        ctx.removeAttribute('required');
+        ctx.placeholder = 'Sentence or context where the word appears';
+      }
+    }
+  </script>
+
   {{template "tag_picker_input" .}}
 
   <div class="flex items-center gap-3">

--- a/internal/web/templates/partials/config_form.html
+++ b/internal/web/templates/partials/config_form.html
@@ -138,9 +138,88 @@
 
   <div>
     <label class="block text-sm font-medium text-gray-700 mb-1">Database Path</label>
-    <input type="text" value="{{.Config.DBPath}}" readonly
-      class="w-full border border-gray-200 rounded px-3 py-2 bg-gray-100 text-gray-500">
+    <div id="db-picker-container">
+      <select id="db_path_selector" name="db_path"
+        onchange="if(this.value==='__new__'){document.getElementById('db-new-name-container').style.display='block'}else{document.getElementById('db-new-name-container').style.display='none';document.getElementById('db_path_new_name').value=''}"
+        hx-get="/api/databases" hx-trigger="load" hx-target="#db-picker-options" hx-swap="innerHTML"
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <option value="{{.Config.DBPath}}" selected>{{.Config.DBPath}}</option>
+      </select>
+      <template id="db-picker-options-template">
+        <!-- Populated by HTMX from /api/databases -->
+      </template>
+    </div>
+    <div id="db-new-name-container" style="display:none" class="mt-2">
+      <input type="text" id="db_path_new_name" name="db_path_new_name" placeholder="e.g. my-course"
+        class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      <p class="text-gray-500 text-xs mt-1">Enter a name for the new database (without .db extension). It will be
+        created in the config directory on next restart.</p>
+      <p id="db-name-error" class="text-red-600 text-sm mt-1" style="display:none"></p>
+    </div>
+    <p class="text-gray-500 text-xs mt-1">Server restart required to switch databases.</p>
   </div>
+
+  <script>
+    // Populate the database picker dropdown from /api/databases response.
+    document.addEventListener('htmx:afterRequest', function (evt) {
+      if (evt.detail.pathInfo && evt.detail.pathInfo.requestPath === '/api/databases') {
+        try {
+          var databases = JSON.parse(evt.detail.xhr.responseText);
+          var select = document.getElementById('db_path_selector');
+          var currentDBPath = '{{.Config.DBPath}}';
+          // Clear existing options
+          select.innerHTML = '';
+          // Add options for each existing database
+          var configDir = currentDBPath.substring(0, currentDBPath.lastIndexOf('/'));
+          var found = false;
+          databases.forEach(function (db) {
+            var fullPath = configDir + '/' + db;
+            var opt = document.createElement('option');
+            opt.value = fullPath;
+            opt.textContent = db;
+            if (fullPath === currentDBPath) {
+              opt.selected = true;
+              found = true;
+            }
+            select.appendChild(opt);
+          });
+          // If current DB path wasn't in the list, add it at the top
+          if (!found) {
+            var opt = document.createElement('option');
+            opt.value = currentDBPath;
+            opt.textContent = currentDBPath.split('/').pop() + ' (current)';
+            opt.selected = true;
+            select.insertBefore(opt, select.firstChild);
+          }
+          // Add "Create new…" option
+          var newOpt = document.createElement('option');
+          newOpt.value = '__new__';
+          newOpt.textContent = 'Create new\u2026';
+          select.appendChild(newOpt);
+        } catch (e) {
+          // If parsing fails, keep the current option
+        }
+      }
+    });
+    // Client-side validation for new DB name
+    (function () {
+      var input = document.getElementById('db_path_new_name');
+      if (input) {
+        input.addEventListener('input', function () {
+          var val = this.value.trim();
+          var errEl = document.getElementById('db-name-error');
+          if (!val) { errEl.style.display = 'none'; return; }
+          var pattern = /^[a-zA-Z0-9_-]+(\\.db)?$/;
+          if (!pattern.test(val)) {
+            errEl.textContent = 'Use only letters, numbers, hyphens, and underscores.';
+            errEl.style.display = 'block';
+          } else {
+            errEl.style.display = 'none';
+          }
+        });
+      }
+    })();
+  </script>
 
   <div id="save-status">{{if .StatusMessage}}{{.StatusMessage}}{{end}}</div>
 

--- a/internal/web/templates/partials/config_form.html
+++ b/internal/web/templates/partials/config_form.html
@@ -141,13 +141,16 @@
     <div id="db-picker-container">
       <select id="db_path_selector" name="db_path"
         onchange="if(this.value==='__new__'){document.getElementById('db-new-name-container').style.display='block'}else{document.getElementById('db-new-name-container').style.display='none';document.getElementById('db_path_new_name').value=''}"
-        hx-get="/api/databases" hx-trigger="load" hx-target="#db-picker-options" hx-swap="innerHTML"
         class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        {{$currentDB := .Config.DBPath}}
+        {{range .Databases}}
+        <option value="{{.}}" {{if eq . $currentDB}}selected{{end}}>{{.}}</option>
+        {{end}}
+        {{if not .Databases}}
         <option value="{{.Config.DBPath}}" selected>{{.Config.DBPath}}</option>
+        {{end}}
+        <option value="__new__">Create new…</option>
       </select>
-      <template id="db-picker-options-template">
-        <!-- Populated by HTMX from /api/databases -->
-      </template>
     </div>
     <div id="db-new-name-container" style="display:none" class="mt-2">
       <input type="text" id="db_path_new_name" name="db_path_new_name" placeholder="e.g. my-course"
@@ -156,51 +159,10 @@
         created in the config directory on next restart.</p>
       <p id="db-name-error" class="text-red-600 text-sm mt-1" style="display:none"></p>
     </div>
-    <p class="text-gray-500 text-xs mt-1">Server restart required to switch databases.</p>
+    <p class="text-gray-500 text-xs mt-1">Database switches take effect immediately.</p>
   </div>
 
   <script>
-    // Populate the database picker dropdown from /api/databases response.
-    document.addEventListener('htmx:afterRequest', function (evt) {
-      if (evt.detail.pathInfo && evt.detail.pathInfo.requestPath === '/api/databases') {
-        try {
-          var databases = JSON.parse(evt.detail.xhr.responseText);
-          var select = document.getElementById('db_path_selector');
-          var currentDBPath = '{{.Config.DBPath}}';
-          // Clear existing options
-          select.innerHTML = '';
-          // Add options for each existing database
-          var configDir = currentDBPath.substring(0, currentDBPath.lastIndexOf('/'));
-          var found = false;
-          databases.forEach(function (db) {
-            var fullPath = configDir + '/' + db;
-            var opt = document.createElement('option');
-            opt.value = fullPath;
-            opt.textContent = db;
-            if (fullPath === currentDBPath) {
-              opt.selected = true;
-              found = true;
-            }
-            select.appendChild(opt);
-          });
-          // If current DB path wasn't in the list, add it at the top
-          if (!found) {
-            var opt = document.createElement('option');
-            opt.value = currentDBPath;
-            opt.textContent = currentDBPath.split('/').pop() + ' (current)';
-            opt.selected = true;
-            select.insertBefore(opt, select.firstChild);
-          }
-          // Add "Create new…" option
-          var newOpt = document.createElement('option');
-          newOpt.value = '__new__';
-          newOpt.textContent = 'Create new\u2026';
-          select.appendChild(newOpt);
-        } catch (e) {
-          // If parsing fails, keep the current option
-        }
-      }
-    });
     // Client-side validation for new DB name
     (function () {
       var input = document.getElementById('db_path_new_name');
@@ -209,7 +171,7 @@
           var val = this.value.trim();
           var errEl = document.getElementById('db-name-error');
           if (!val) { errEl.style.display = 'none'; return; }
-          var pattern = /^[a-zA-Z0-9_-]+(\\.db)?$/;
+          var pattern = /^[a-zA-Z0-9_-]+(\.db)?$/;
           if (!pattern.test(val)) {
             errEl.textContent = 'Use only letters, numbers, hyphens, and underscores.';
             errEl.style.display = 'block';

--- a/internal/web/templates/partials/entry_table.html
+++ b/internal/web/templates/partials/entry_table.html
@@ -32,8 +32,8 @@
       <td class="px-2 py-2" onclick="event.stopPropagation()">
         <input type="checkbox" class="entry-cb rounded" value="{{.ID}}" onchange="updateBulkActions()">
       </td>
-      <td class="px-3 py-2 font-medium text-gray-800 cursor-pointer" hx-get="/api/words/{{.ID}}/edit"
-        hx-target="closest tr" hx-swap="afterend">{{.Word}}</td>
+      <td class="px-3 py-2 font-medium text-gray-800 cursor-pointer"
+        onclick="toggleDetail({{.ID}}, '/api/words/{{.ID}}/edit', this)">{{.Word}}</td>
       <td class="px-3 py-2"><span class="text-xs bg-gray-100 text-gray-600 px-1 rounded">{{.PartOfSpeech}}</span></td>
       <td class="px-3 py-2 text-gray-600">{{.Article}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.Definition}}</td>
@@ -68,8 +68,8 @@
       <td class="px-2 py-2" onclick="event.stopPropagation()">
         <input type="checkbox" class="entry-cb rounded" value="{{.ID}}" onchange="updateBulkActions()">
       </td>
-      <td class="px-3 py-2 font-medium text-gray-800 cursor-pointer" hx-get="/api/expressions/{{.ID}}/edit"
-        hx-target="closest tr" hx-swap="afterend">{{.Expression}}</td>
+      <td class="px-3 py-2 font-medium text-gray-800 cursor-pointer"
+        onclick="toggleDetail({{.ID}}, '/api/expressions/{{.ID}}/edit', this)">{{.Expression}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.Definition}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.English}}</td>
       <td class="px-3 py-2 text-gray-600 max-w-xs truncate">{{.TargetTranslation}}</td>


### PR DESCRIPTION
## Summary

Database picker, multiple meanings support, and UI polish. Adds a database picker dropdown on the Config page for switching between `.db` files, supports storing multiple meanings per word via skip-cache/new-meaning mode with disambiguation suffixes, fixes the database detail panel toggle, and adds a Look & Feel mockup page to GitHub Pages.

## Related Issue

Fixes #76, Fixes #86, Fixes #87, Fixes #88

## Changes

- Database picker dropdown on Config page — list existing `.db` files, create new databases, live DB switching without server restart
- Multiple meanings support — skip-cache / add-new-meaning mode stores separate entries per meaning with disambiguation suffixes
- Database detail panel now collapses on re-click
- Look & Feel static mockup subpage added to GitHub Pages site
- Architecture and user-guide documentation updated
- Spec documents updated with requirements 66–68, design, and tasks 29–32

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
