### PR TITLE
docs: rename look-and-feel to ui-preview, clean up duplicate nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -241,7 +241,7 @@
 
         <a class="cta" href="https://github.com/npozs77/VocabGen/releases">Download Latest Release</a>
         <a class="cta secondary" href="https://github.com/npozs77/VocabGen">View on GitHub</a>
-        <a class="cta secondary" href="look-and-feel.html">See it in Action</a>
+        <a class="cta secondary" href="ui-preview.html" target="_blank" rel="noopener">See it in Action</a>
 
         <h2>What is VocabGen?</h2>
         <p>VocabGen is a free, open-source vocabulary web app for language learners at B2–C1 level. Start the app, open

--- a/docs/ui-preview.html
+++ b/docs/ui-preview.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>VocabGen — Look &amp; Feel</title>
+    <title>VocabGen — UI Preview</title>
     <meta name="description"
         content="Preview VocabGen's UI — static mockups of the Lookup, Batch, Flashcards, Database, and Config pages with sample data.">
-    <link rel="canonical" href="https://npozs77.github.io/VocabGen/look-and-feel.html">
+    <link rel="canonical" href="https://npozs77.github.io/VocabGen/ui-preview.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         .fc-scene {
@@ -51,45 +51,46 @@
 </head>
 
 <body class="bg-gray-50 min-h-screen">
-    <!-- Nav Bar (static replica) -->
+    <!-- Mockup Nav Bar (replica of the real app nav — items switch tabs) -->
     <nav class="bg-white shadow">
         <div class="max-w-7xl mx-auto px-4 py-3 flex items-center gap-6">
             <span class="font-semibold text-lg text-gray-800">VocabGen</span>
-            <span class="text-blue-600 font-medium">Lookup</span>
-            <span class="text-gray-600">Batch</span>
-            <span class="text-gray-600">Config</span>
-            <span class="text-gray-600">Database</span>
-            <span class="text-gray-600">Flashcards</span>
+            <a href="#" onclick="showTab('lookup'); return false;" id="nav-lookup"
+                class="text-blue-600 font-medium">Lookup</a>
+            <a href="#" onclick="showTab('batch'); return false;" id="nav-batch"
+                class="text-gray-600 hover:text-blue-600">Batch</a>
+            <a href="#" onclick="showTab('config'); return false;" id="nav-config"
+                class="text-gray-600 hover:text-blue-600">Config</a>
+            <a href="#" onclick="showTab('database'); return false;" id="nav-database"
+                class="text-gray-600 hover:text-blue-600">Database</a>
+            <a href="#" onclick="showTab('flashcards'); return false;" id="nav-flashcards"
+                class="text-gray-600 hover:text-blue-600">Flashcards</a>
             <div class="flex-1"></div>
             <span class="text-xs text-gray-400">📂 ~/.vocabgen/vocabgen.db</span>
+            <!-- Profile switcher -->
             <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">default</span>
-            <span class="text-sm text-gray-500">Help ▾</span>
+            <!-- Help menu -->
+            <div class="relative">
+                <button onclick="document.getElementById('help-dropdown').classList.toggle('hidden')"
+                    class="text-sm text-gray-500 hover:text-blue-600">Help ▾</button>
+                <div id="help-dropdown"
+                    class="hidden absolute right-0 mt-1 w-48 bg-white rounded shadow-lg border z-50">
+                    <span class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">About</span>
+                    <span class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Report an Issue ↗</span>
+                    <span class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Documentation</span>
+                    <span class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Changelog</span>
+                    <span class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Check for Update</span>
+                </div>
+            </div>
         </div>
     </nav>
 
-    <!-- Page Header -->
-    <div class="max-w-7xl mx-auto px-4 pt-6 pb-2">
-        <h1 class="text-2xl font-bold text-gray-800 mb-1">Look &amp; Feel</h1>
-        <p class="text-gray-500 text-sm mb-4">Static mockups of VocabGen's main views with sample data. All controls are
-            visual only — nothing is interactive.</p>
-
-        <!-- Tab Navigation -->
-        <div class="flex gap-1 border-b border-gray-200 mb-6">
-            <button onclick="showTab('lookup')"
-                class="tab-btn active px-4 py-2 text-sm font-medium border-b-2 border-transparent"
-                id="tab-lookup">Lookup</button>
-            <button onclick="showTab('batch')"
-                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
-                id="tab-batch">Batch</button>
-            <button onclick="showTab('flashcards')"
-                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
-                id="tab-flashcards">Flashcards</button>
-            <button onclick="showTab('database')"
-                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
-                id="tab-database">Database</button>
-            <button onclick="showTab('config')"
-                class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-500"
-                id="tab-config">Config</button>
+    <!-- UI Preview info box -->
+    <div class="max-w-7xl mx-auto px-4 pt-4 pb-2">
+        <div class="bg-white border border-gray-200 rounded-lg px-4 py-3 mb-6 shadow-sm">
+            <h1 class="text-lg font-semibold text-gray-800 inline">UI Preview</h1>
+            <span class="text-gray-500 text-sm ml-2">— Static mockups of VocabGen's main views with sample data. All
+                controls are visual only.</span>
         </div>
     </div>
 
@@ -529,13 +530,11 @@ het klopt</textarea>
             var panels = ['lookup', 'batch', 'flashcards', 'database', 'config'];
             for (var i = 0; i < panels.length; i++) {
                 document.getElementById('panel-' + panels[i]).classList.toggle('hidden', panels[i] !== name);
-                var btn = document.getElementById('tab-' + panels[i]);
+                var nav = document.getElementById('nav-' + panels[i]);
                 if (panels[i] === name) {
-                    btn.classList.add('active');
-                    btn.classList.remove('text-gray-500');
+                    nav.className = 'text-blue-600 font-medium';
                 } else {
-                    btn.classList.remove('active');
-                    btn.classList.add('text-gray-500');
+                    nav.className = 'text-gray-600 hover:text-blue-600';
                 }
             }
         }

--- a/docs/ui-preview.html
+++ b/docs/ui-preview.html
@@ -427,7 +427,7 @@ het klopt</textarea>
                             <td class="px-3 py-2"><span
                                     class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded">hard</span></td>
                         </tr>
-                        <tr class="hover:bg-gray-50">
+                        <tr class="bg-blue-50">
                             <td class="px-3 py-2"><input type="checkbox" disabled></td>
                             <td class="px-3 py-2 font-medium text-gray-800">beschaving</td>
                             <td class="px-3 py-2 text-gray-600">zn. (de)</td>
@@ -436,6 +436,132 @@ het klopt</textarea>
                             <td class="px-3 py-2 text-gray-600">civilizáció (kultúra; műveltség)</td>
                             <td class="px-3 py-2"><span
                                     class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">natural</span></td>
+                        </tr>
+                        <!-- Expanded detail panel for beschaving -->
+                        <tr>
+                            <td colspan="7" class="px-0 py-0">
+                                <div class="bg-blue-50 border-t border-b border-blue-200 px-6 py-4">
+                                    <div class="grid grid-cols-4 gap-4 mb-3">
+                                        <div>
+                                            <label class="block text-xs text-blue-600 font-medium mb-0.5">Word</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">
+                                                beschaving</div>
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-blue-600 font-medium mb-0.5">Part of
+                                                Speech</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">zn.
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <label
+                                                class="block text-xs text-blue-600 font-medium mb-0.5">Article</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">de
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <label
+                                                class="block text-xs text-blue-600 font-medium mb-0.5">Register</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">
+                                                formeel</div>
+                                        </div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="block text-xs text-blue-600 font-medium mb-0.5">Definition</label>
+                                        <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">het
+                                            geheel van kennis, kunst, zeden en gebruiken van een volk of tijdperk;
+                                            cultuur in brede zin</div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="block text-xs text-blue-600 font-medium mb-0.5">English
+                                            Definition</label>
+                                        <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">the
+                                            collective knowledge, arts, customs, and practices of a people or era;
+                                            culture in its broadest sense</div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="block text-xs text-blue-600 font-medium mb-0.5">Example</label>
+                                        <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">De
+                                            Griekse beschaving heeft een grote invloed gehad op de Westerse wereld.
+                                        </div>
+                                    </div>
+                                    <div class="grid grid-cols-2 gap-4 mb-3">
+                                        <div>
+                                            <label
+                                                class="block text-xs text-blue-600 font-medium mb-0.5">English</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">
+                                                civilization (culture; civilisation)</div>
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-blue-600 font-medium mb-0.5">Target
+                                                Translation</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">
+                                                civilizáció (kultúra; műveltség)</div>
+                                        </div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="block text-xs text-blue-600 font-medium mb-0.5">Notes</label>
+                                        <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">formeel
+                                            register; vaak gebruikt in historische en culturele contexten</div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label
+                                            class="block text-xs text-blue-600 font-medium mb-0.5">Connotation</label>
+                                        <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">neutraal
+                                            tot positief; suggereert ontwikkeling en verfijning</div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="block text-xs text-blue-600 font-medium mb-0.5">Contrastive
+                                            Notes</label>
+                                        <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">cultuur –
+                                            meer specifiek gericht op kunst en intellectuele aspecten; maatschappij –
+                                            benadrukt sociale structuren zonder culturele waardeoordelen</div>
+                                    </div>
+                                    <div class="grid grid-cols-2 gap-4 mb-3">
+                                        <div>
+                                            <label
+                                                class="block text-xs text-blue-600 font-medium mb-0.5">Collocations</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">
+                                                westerse beschaving; antieke beschaving; moderne beschaving; beschaving
+                                                en barbarij</div>
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-blue-600 font-medium mb-0.5">Secondary
+                                                Meanings</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">het
+                                                proces van civiliseren of beschaafd worden; verfijning van gedrag en
+                                                manieren</div>
+                                        </div>
+                                    </div>
+                                    <div class="grid grid-cols-3 gap-4 mb-4">
+                                        <div>
+                                            <label class="block text-xs text-blue-600 font-medium mb-0.5">Tags</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">HS3.2
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-blue-600 font-medium mb-0.5">Source
+                                                Language</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">nl
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-blue-600 font-medium mb-0.5">Target
+                                                Language</label>
+                                            <div class="bg-white border border-gray-200 rounded px-2 py-1 text-sm">hu
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="flex gap-2">
+                                        <button disabled
+                                            class="bg-blue-600 text-white px-3 py-1.5 rounded text-sm opacity-75 cursor-not-allowed">Save</button>
+                                        <button disabled
+                                            class="bg-red-600 text-white px-3 py-1.5 rounded text-sm opacity-75 cursor-not-allowed">Delete</button>
+                                        <button disabled
+                                            class="border border-gray-300 text-gray-700 px-3 py-1.5 rounded text-sm opacity-75 cursor-not-allowed">Cancel</button>
+                                    </div>
+                                </div>
+                            </td>
                         </tr>
                         <tr class="hover:bg-gray-50">
                             <td class="px-3 py-2"><input type="checkbox" disabled></td>


### PR DESCRIPTION
## Summary

Rename look-and-feel.html to ui-preview.html, remove duplicate tab row (nav bar items now switch panels directly), and open the link from index.html in a new tab.

## Related Issue

Follow-up to #88

## Changes

- Renamed `docs/look-and-feel.html` → `docs/ui-preview.html`
- Removed duplicate tab navigation row — nav bar items now act as tab switchers
- "See it in Action" link on index.html opens in a new tab (`target="_blank"`)
- Added "UI Preview" info box below nav bar
- Updated canonical URL

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [ ] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
