### PR TITLE
feat: add Google Gemini and Vertex AI providers

### DIFF
--- a/.github/ISSUE_TEMPLATE/analysis_comment.md
+++ b/.github/ISSUE_TEMPLATE/analysis_comment.md
@@ -12,6 +12,24 @@ What is affected and how significant is this?
 
 What is causing the issue?
 
+### End-User Impact & Design Concerns
+
+_(For Medium/Large scope issues — skip for Small)_
+
+**User Experience**:
+- How does this change what the user sees or does?
+- Are there new workflows, screens, or CLI flags?
+- Can this be made optional/modular (enable/disable)?
+
+**Data & Configuration**:
+- Does this affect the database schema or data model?
+- Are there migration concerns for existing users?
+- Does config.yaml need new sections or breaking changes?
+
+**Open Questions** (decisions needed before implementation):
+1. Question that needs user input
+2. Question that needs user input
+
 ### Proposed Plan
 
 1. Step one

--- a/.kiro/specs/go-vocabulary-generator/design.md
+++ b/.kiro/specs/go-vocabulary-generator/design.md
@@ -21,7 +21,7 @@ The Go Vocabulary Generator (`vocabgen`) is a single-binary CLI and embedded web
 | CLI framework | Cobra | Subcommands (`lookup`, `batch`, `serve`), auto-generated help, flag parsing |
 | Web framework | stdlib `net/http` + `html/template` + HTMX | No JS build step, embedded in binary, sufficient for local tool |
 | Database | SQLite via `modernc.org/sqlite` | Pure-Go, cross-compiles, embedded, zero-config |
-| LLM abstraction | Go interface + provider registry | 4 real implementations (Bedrock, OpenAI, Anthropic, Vertex AI), testable with manual mocks |
+| LLM abstraction | Go interface + provider registry | 5 real implementations (Bedrock, OpenAI, Anthropic, Vertex AI, Gemini), testable with manual mocks |
 | Config format | YAML at `~/.vocabgen/config.yaml` | Human-readable, simple, `gopkg.in/yaml.v3` |
 | PBT library | `pgregory.net/rapid` | Go-native, integrates with `testing`, no external runner |
 | Excel export | `github.com/xuri/excelize/v2` | Well-maintained, pure-Go xlsx writer |
@@ -56,6 +56,7 @@ graph TB
     LLM --> OPENAI["OpenAI API<br/>(+ Azure, Ollama, LM Studio)"]
     LLM --> ANTHROPIC["Anthropic API"]
     LLM --> VERTEXAI["Google Vertex AI"]
+    LLM --> GEMINI["Google Gemini API"]
     CLI --> CFG
     WEB --> CFG
     DB --> SQLITE["~/.vocabgen/vocabgen.db"]
@@ -256,6 +257,7 @@ var Registry = map[string]NewProviderFunc{
     "openai":    NewOpenAIProvider,
     "anthropic": NewAnthropicProvider,
     "vertexai":  NewVertexAIProvider,
+    "gemini":    NewGeminiProvider,
 }
 ```
 
@@ -321,6 +323,25 @@ type VertexAIProvider struct {
 func NewVertexAIProvider(opts ProviderOptions) (Provider, error)
 func (p *VertexAIProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error)
 func (p *VertexAIProvider) Name() string { return "vertexai" }
+```
+
+```go
+// gemini.go
+
+// GeminiProvider implements Provider for the Google Gemini API (direct, via API key).
+// Uses the generativelanguage.googleapis.com REST endpoint.
+// Distinct from VertexAIProvider which uses GCP infrastructure and ADC.
+type GeminiProvider struct {
+    apiKey   string
+    maxRetry int
+    client   *http.Client
+}
+
+// NewGeminiProvider creates a GeminiProvider using a Gemini API key.
+// Returns error if API key is empty.
+func NewGeminiProvider(opts ProviderOptions) (Provider, error)
+func (p *GeminiProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error)
+func (p *GeminiProvider) Name() string { return "gemini" }
 ```
 
 ### 2. `internal/language` — Templates, Validation, Registry

--- a/.kiro/specs/go-vocabulary-generator/requirements.md
+++ b/.kiro/specs/go-vocabulary-generator/requirements.md
@@ -19,6 +19,7 @@ Key technical direction: Go with Cobra CLI, embedded web UI via `go:embed` + `ne
 - **OpenAI_Provider**: Provider implementation for the OpenAI API, also compatible with OpenAI-compatible local servers (Ollama, LM Studio) via custom base URL
 - **Anthropic_Provider**: Provider implementation for the Anthropic Claude direct API
 - **Vertex_AI_Provider**: Provider implementation for Google Vertex AI (Gemini, PaLM, Claude on Vertex)
+- **Gemini_Provider**: Provider implementation for the Google Gemini API (direct), authenticating via API key against `generativelanguage.googleapis.com`
 - **Provider_Registry**: A map from provider name strings to provider constructor functions
 - **Database**: SQLite file-based database stored at a configurable path (default: `~/.vocabgen/vocabgen.db`)
 - **Word_Entry**: A row in the words table containing vocabulary data plus metadata (source_language, target_language, created_at, updated_at)
@@ -232,7 +233,7 @@ Key technical direction: Go with Cobra CLI, embedded web UI via `go:embed` + `ne
 
 #### Acceptance Criteria
 
-1. WHEN the CLI is invoked, THE CLI SHALL accept a `--provider` flag with valid values including "bedrock", "openai", "anthropic", and "vertexai"
+1. WHEN the CLI is invoked, THE CLI SHALL accept a `--provider` flag with valid values including "bedrock", "openai", "anthropic", "vertexai", and "gemini"
 2. WHEN no `--provider` flag is specified, THE CLI SHALL default to "bedrock"
 3. WHEN an unsupported provider name is specified, THE CLI SHALL display an error listing valid provider names and exit with a non-zero code
 4. WHEN the Provider_Registry is queried, THE Provider_Registry SHALL map string identifiers to their corresponding provider constructor functions
@@ -251,6 +252,7 @@ Key technical direction: Go with Cobra CLI, embedded web UI via `go:embed` + `ne
 5. WHEN the "bedrock" provider is selected, THE App SHALL ignore the `--api-key` flag
 6. WHEN the "openai" or "anthropic" provider is selected, THE App SHALL ignore the `--profile` flag
 7. WHEN the "vertexai" provider is selected, THE App SHALL use Google Application Default Credentials and accept a project ID via `--gcp-project` or `GCP_PROJECT` environment variable
+8. WHEN the "gemini" provider is selected, THE App SHALL accept an API key via the `--api-key` flag or the `GEMINI_API_KEY` environment variable
 
 ### Requirement 13: Error Handling Across Providers
 
@@ -1210,3 +1212,22 @@ The Go Vocabulary Generator is successfully implemented when:
 
 1. WHEN the user clicks an expanded detail panel in the database view, THE panel SHALL collapse (toggle behavior)
 2. WHEN the user clicks a collapsed entry, THE detail panel SHALL expand as before
+
+### Requirement 69: Gemini API Provider Implementation (Direct)
+
+**User Story:** As a user who wants to use Google Gemini models without GCP infrastructure, I want a direct Gemini API provider that authenticates with a simple API key, so that I can access Gemini models with minimal setup (similar to OpenAI/Anthropic).
+
+#### Acceptance Criteria
+
+1. WHEN the Gemini_Provider is used, THE Gemini_Provider SHALL implement the Provider_Interface
+2. WHEN the Gemini_Provider authenticates, THE Gemini_Provider SHALL use an API key sourced from the `GEMINI_API_KEY` environment variable or the `--api-key` CLI flag
+3. WHEN no API key is available, THE Gemini_Provider SHALL return a descriptive authentication error before attempting invocation
+4. WHEN a model is specified, THE Gemini_Provider SHALL support specifying a Gemini model name (e.g., "gemini-2.0-flash", "gemini-2.5-pro") via the `--model-id` flag
+5. WHEN the Gemini_Provider encounters rate-limit errors, THE Gemini_Provider SHALL retry once with a 1-second delay
+6. WHEN the Gemini_Provider is selected via `--provider gemini`, THE Provider_Registry SHALL resolve it to the Gemini API provider (distinct from `--provider vertexai` which uses GCP Vertex AI)
+7. WHEN the Gemini_Provider invokes the API, THE Gemini_Provider SHALL send requests to the `generativelanguage.googleapis.com` endpoint using the REST API
+
+#### Properties
+
+- P69.1: Gemini provider requires API key — construction without API key returns descriptive error (Req 69, AC 2–3)
+- P69.2: Gemini provider implements Provider interface — Invoke returns (string, nil) or ("", error), Name returns "gemini" (Req 69, AC 1)

--- a/.kiro/specs/go-vocabulary-generator/tasks.md
+++ b/.kiro/specs/go-vocabulary-generator/tasks.md
@@ -235,13 +235,24 @@ Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary 
     - Test OpenAI provider rejects nil API key when no base URL
     - Test Anthropic provider rejects nil API key
     - _Requirements: 11.3, 13.1, 13.2_
-  - [x]* 7.8 Implement VertexAIProvider (optional — can be deferred)
+  - [x] 7.8 Implement VertexAIProvider (optional — can be deferred)
     - `NewVertexAIProvider(opts)` creates HTTP client using Google ADC; validates GCP project ID present
     - `Invoke` sends request to Vertex AI Gemini API, extracts text content
     - Retry once on rate-limit errors (1 second delay)
     - Return `ProviderError` on auth failure, empty response, or exhausted retries
     - _Requirements: 51.1–51.7, 12.7_
     - _Design: Section 1 — vertexai.go_
+
+  - [x] 7.9 Implement GeminiProvider (direct Gemini API via API key)
+    - `NewGeminiProvider(opts)` creates HTTP client; validates API key present (from `GEMINI_API_KEY` env var or `--api-key` flag)
+    - `Invoke` sends request to `generativelanguage.googleapis.com` REST API, extracts text content from response
+    - Retry once on HTTP 429 rate-limit (1 second delay)
+    - Return `ProviderError` on auth failure, empty response, or exhausted retries
+    - Add `"gemini"` entry to the provider Registry
+    - Write table-driven tests: construction without API key returns error, Name() returns "gemini"
+    - Update documentation, Changelog and Readme md files.
+    - _Requirements: 69.1–69.7_
+    - _Design: Section 1 — gemini.go_
 
 - [x] 8. Database package (`internal/db/`)
   - [x] 8.1 Implement SQLiteStore, schema migration, and models

--- a/.kiro/specs/go-vocabulary-generator/tasks.md
+++ b/.kiro/specs/go-vocabulary-generator/tasks.md
@@ -235,7 +235,7 @@ Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary 
     - Test OpenAI provider rejects nil API key when no base URL
     - Test Anthropic provider rejects nil API key
     - _Requirements: 11.3, 13.1, 13.2_
-  - [ ]* 7.8 Implement VertexAIProvider (optional — can be deferred)
+  - [x]* 7.8 Implement VertexAIProvider (optional — can be deferred)
     - `NewVertexAIProvider(opts)` creates HTTP client using Google ADC; validates GCP project ID present
     - `Invoke` sends request to Vertex AI Gemini API, extracts text content
     - Retry once on rate-limit errors (1 second delay)
@@ -885,8 +885,8 @@ Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary 
   - Ensure all existing tests still pass (regression)
   - Ask the user if questions arise.
 
-- [ ] 26. Dedicated sentence lookup prompt, validation, and service integration (Issue #26)
-  - [ ] 26.1 Add `SentenceTemplate` constant and update `BuildPrompt` in `internal/language/templates.go`
+- [x] 26. Dedicated sentence lookup prompt, validation, and service integration (Issue #26)
+  - [x] 26.1 Add `SentenceTemplate` constant and update `BuildPrompt` in `internal/language/templates.go`
     - Define `SentenceTemplate` as a Go string constant with `{source_language}`, `{sentence}`, `{context}`, `{target_language_name}` placeholders
     - Template instructs the LLM to return JSON with: `sentence` (string), `translation` (string — full sentence translation into target language), `grammar_check` (object with `has_errors` bool, `corrected_sentence` string, `errors` array of `{original, corrected, explanation}`), `vocabulary` (array of `{word, type, definition, english}`)
     - Template instructs the LLM to check for grammatical errors: word order, verb conjugation, spelling, case/gender agreement, preposition usage
@@ -896,7 +896,7 @@ Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary 
     - _Requirements: 61.1–61.7_
     - _Design: Section 2 — templates.go SentenceTemplate_
 
-  - [ ] 26.2 Add sentence validation types and `ValidateSentenceResponse` in `internal/language/validation.go`
+  - [x] 26.2 Add sentence validation types and `ValidateSentenceResponse` in `internal/language/validation.go`
     - Define `SentenceEntry` struct: `Sentence string`, `Translation string`, `GrammarCheck GrammarCheck`, `Vocabulary []VocabItem`
     - Define `GrammarCheck` struct: `HasErrors bool`, `CorrectedSentence string`, `Errors []GrammarError`
     - Define `GrammarError` struct: `Original string`, `Corrected string`, `Explanation string`
@@ -906,7 +906,7 @@ Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary 
     - _Requirements: 61.8–61.9, 3.10_
     - _Design: Section 2 — validation.go SentenceEntry, ValidateSentenceResponse_
 
-  - [ ] 26.3 Fix `mode()` function and update sentence lookup path in `internal/service/service.go`
+  - [x] 26.3 Fix `mode()` function and update sentence lookup path in `internal/service/service.go`
     - Change `mode()` to return `"sentence"` when `lookupType == "sentence"` (instead of `"expressions"`)
     - Update the sentence lookup branch in `Lookup()` to call `language.BuildPrompt` with mode `"sentence"`, then `language.ValidateSentenceResponse` (instead of `ValidateResponse` + `MapFields`)
     - Populate `LookupResult.SentenceResult` field (new field on `LookupResult`) instead of `Entry`
@@ -915,33 +915,33 @@ Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary 
     - _Requirements: 61.10, 62.1–62.3, 20.10_
     - _Design: Section 4 — service.go mode(), Data Flow: Single Lookup_
 
-  - [ ] 26.4 Add `SentenceResult` field to `LookupResult` in `internal/service/service.go`
+  - [x] 26.4 Add `SentenceResult` field to `LookupResult` in `internal/service/service.go`
     - Add `SentenceResult *language.SentenceEntry` field to `LookupResult` struct
     - CLI and web handlers check `SentenceResult != nil` to determine sentence vs word/expression output
     - _Requirements: 62.2, 62.5_
     - _Design: Section 4 — service.go LookupResult_
 
-  - [ ] 26.5 Write property test P26: Sentence template formatting
+  - [x] 26.5 Write property test P26: Sentence template formatting
     - **Property 26: Sentence template formatting produces valid prompts for any source language**
     - Generate random source language strings, random sentence strings, random target language codes
     - Assert output contains: resolved source language name, sentence text, target language name, grammar check instructions, no unresolved `{...}` placeholders
     - Assert output is distinct from words and expressions template output for the same language
     - **Validates: Requirements 61.1, 61.6, 61.7**
 
-  - [ ] 26.6 Write property test P27: Sentence validation
+  - [x] 26.6 Write property test P27: Sentence validation
     - **Property 27: Sentence validation accepts valid sentence JSON and rejects missing required fields**
     - Generate valid sentence JSON with random strings, random grammar errors, random vocabulary items
     - Assert `ValidateSentenceResponse` succeeds for valid input
     - Generate JSON with random subsets of required fields removed; assert `ValidateSentenceResponse` returns `ValidationError`
     - **Validates: Requirements 61.8, 61.9**
 
-  - [ ] 26.7 Write property test P28: Sentence lookup ephemeral
+  - [x] 26.7 Write property test P28: Sentence lookup ephemeral
     - **Property 28: Sentence lookup ephemeral — never writes to DB, never reads cache**
     - Use mock provider and in-memory SQLite store
     - Perform sentence lookup, assert: mock provider was invoked, store has zero entries after lookup, `LookupResult.SentenceResult` is non-nil, `LookupResult.Entry` is nil
     - **Validates: Requirements 62.1, 62.3**
 
-  - [ ] 26.8 Write table-driven tests for sentence template, validation, and service
+  - [x] 26.8 Write table-driven tests for sentence template, validation, and service
     - Test `BuildPrompt("nl", "sentence", "Ik ga morgen naar de markt", "", "hu")` returns prompt containing "Dutch", the sentence, grammar check instructions
     - Test `BuildPrompt` with mode "sentence" does NOT contain `{expression}` or `{word}` placeholders in output
     - Test `ValidateSentenceResponse` with valid JSON returns correct `SentenceEntry`
@@ -953,7 +953,7 @@ Build `vocabgen` — a single-binary Go CLI and embedded web app for vocabulary 
     - Test `mode("expression")` still returns `"expressions"` (regression)
     - _Requirements: 61.1–61.10, 62.1–62.5_
 
-- [ ] 27. Checkpoint — Verify sentence lookup works end-to-end
+- [x] 27. Checkpoint — Verify sentence lookup works end-to-end
   - Run `make quality` — all tests pass, no lint issues
   - Verify `vocabgen lookup "Ik ga morgen naar de markt" -l nl --type sentence` uses the sentence template (not expressions)
   - Verify sentence lookup result contains grammar_check and vocabulary sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 
 ### Added
 
+- Google Vertex AI provider — use Gemini models via `--provider vertexai --gcp-project <project-id>`, authenticates with Application Default Credentials
 - Database picker dropdown on Config page — lists existing `.db` files in the config directory, select one or create a new database with inline name validation (#76)
 - Multiple meanings support — add a second (or third) meaning for the same word via "Skip cache / Add new meaning" checkbox in the Web UI or `--new-meaning` flag in the CLI; each meaning stored as a separate entry with disambiguation suffixes displayed when 2+ meanings exist (#86)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/).
 
-## [1.4.3]
+## [1.5.0]
 
 ### Added
 
+- Google Gemini API provider — use Gemini models directly via `--provider gemini`, authenticates with API key from `GEMINI_API_KEY` env var or `--api-key` flag
 - Google Vertex AI provider — use Gemini models via `--provider vertexai --gcp-project <project-id>`, authenticates with Application Default Credentials
 - Database picker dropdown on Config page — lists existing `.db` files in the config directory, select one or create a new database with inline name validation (#76)
 - Multiple meanings support — add a second (or third) meaning for the same word via "Skip cache / Add new meaning" checkbox in the Web UI or `--new-meaning` flag in the CLI; each meaning stored as a separate entry with disambiguation suffixes displayed when 2+ meanings exist (#86)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![License](https://img.shields.io/badge/license-MIT-blue)
 ![GitHub Release](https://img.shields.io/github/v/release/npozs77/VocabGen)
 
-**VocabGen** is an open-source vocabulary web app and flashcard tool for language learners. Look up words, batch-process CSV word lists, and study with flashcards — all in your browser. Powered by LLM providers (OpenAI, Anthropic, AWS Bedrock, Ollama), it ships as a single binary with zero setup friction.
+**VocabGen** is an open-source vocabulary web app and flashcard tool for language learners. Look up words, batch-process CSV word lists, and study with flashcards — all in your browser. Powered by LLM providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex AI, Ollama), it ships as a single binary with zero setup friction.
 
 ## Features
 
@@ -31,6 +31,7 @@ This app calls LLM APIs to generate vocabulary data. It does not include a built
 | AWS Bedrock | AWS account with Bedrock model access enabled | Pay-per-token |
 | OpenAI API | API key from [platform.openai.com](https://platform.openai.com) | Pay-per-token |
 | Anthropic API | API key from [console.anthropic.com](https://console.anthropic.com) | Pay-per-token |
+| Google Vertex AI | GCP project with Vertex AI enabled + [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) | Pay-per-token |
 | Ollama (local) | [Ollama](https://ollama.com) installed with a model pulled | Free (runs on your hardware) |
 | LM Studio / vLLM | Any OpenAI-compatible local server | Free (runs on your hardware) |
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![License](https://img.shields.io/badge/license-MIT-blue)
 ![GitHub Release](https://img.shields.io/github/v/release/npozs77/VocabGen)
 
-**VocabGen** is an open-source vocabulary web app and flashcard tool for language learners. Look up words, batch-process CSV word lists, and study with flashcards — all in your browser. Powered by LLM providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex AI, Ollama), it ships as a single binary with zero setup friction.
+**VocabGen** is an open-source vocabulary web app and flashcard tool for language learners. Look up words, batch-process CSV word lists, and study with flashcards — all in your browser. Powered by LLM providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex AI, Google Gemini, Ollama), it ships as a single binary with zero setup friction.
 
 ## Features
 
@@ -16,7 +16,7 @@
 - 🔤 **LLM-powered vocabulary lookup** — get definitions, translations, connotation, and register for any word or expression
 - 📄 **CSV batch processing** — upload word lists via the web UI or process them from the command line
 - 🌍 **Multi-language support** — Dutch, German, French, Spanish, Italian, Russian, Portuguese, Polish, Turkish, Hungarian, English, and any custom language
-- 🤖 **Multiple LLM providers** — OpenAI, Anthropic, AWS Bedrock, Google Vertex AI, Ollama (free local), Azure OpenAI, LM Studio
+- 🤖 **Multiple LLM providers** — OpenAI, Anthropic, AWS Bedrock, Google Vertex AI, Google Gemini, Ollama (free local), Azure OpenAI, LM Studio
 - 💾 **SQLite cache** — never pay twice for the same lookup
 - 📦 **Single binary** — zero dependencies, cross-platform (macOS, Linux, Windows), Docker support
 - 🔒 **Privacy-first** — runs locally, no telemetry, API keys stay in env vars
@@ -32,6 +32,7 @@ This app calls LLM APIs to generate vocabulary data. It does not include a built
 | OpenAI API | API key from [platform.openai.com](https://platform.openai.com) | Pay-per-token |
 | Anthropic API | API key from [console.anthropic.com](https://console.anthropic.com) | Pay-per-token |
 | Google Vertex AI | GCP project with Vertex AI enabled + [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) | Pay-per-token |
+| Google Gemini API | API key from [aistudio.google.com](https://aistudio.google.com) | Free tier + pay-per-token |
 | Ollama (local) | [Ollama](https://ollama.com) installed with a model pulled | Free (runs on your hardware) |
 | LM Studio / vLLM | Any OpenAI-compatible local server | Free (runs on your hardware) |
 
@@ -77,7 +78,7 @@ vocabgen batch --input-file ch1.csv --mode words -l nl --tags "chapter-1"
 |------|-------|---------|-------------|
 | `--source-language` | `-l` | (from config) | Source language code or name |
 | `--target-language` | | `hu` | Target language for translations |
-| `--provider` | | `bedrock` | LLM provider (`bedrock`, `openai`, `anthropic`, `vertexai`) |
+| `--provider` | | `bedrock` | LLM provider (`bedrock`, `openai`, `anthropic`, `vertexai`, `gemini`) |
 | `--model-id` | | | LLM model identifier |
 | `--api-key` | | | API key (OpenAI/Anthropic) |
 | `--base-url` | | | Custom API base URL (Ollama, Azure, LM Studio) |
@@ -137,6 +138,7 @@ For first-time setup, the Web UI config page is the easiest way to configure you
 | OpenAI | API key | `vocabgen lookup "word" -l nl --provider openai --api-key sk-...` |
 | Anthropic | API key | `vocabgen lookup "word" -l nl --provider anthropic --api-key sk-ant-...` |
 | Vertex AI | Google ADC | `vocabgen lookup "word" -l nl --provider vertexai --gcp-project my-proj` |
+| Gemini | API key | `vocabgen lookup "word" -l nl --provider gemini --api-key AIza...` |
 | Ollama (local) | None | `vocabgen lookup "word" -l nl --provider openai --base-url http://localhost:11434/v1` |
 | Azure OpenAI | API key + URL | `vocabgen lookup "word" -l nl --provider openai --base-url https://my-resource.openai.azure.com --api-key ...` |
 
@@ -157,6 +159,7 @@ The script installs Ollama (if needed), pulls a model, and creates a `local` con
 |----------|----------|-------------|
 | `OPENAI_API_KEY` | OpenAI | API key (overridden by `--api-key`) |
 | `ANTHROPIC_API_KEY` | Anthropic | API key (overridden by `--api-key`) |
+| `GEMINI_API_KEY` | Gemini | API key (overridden by `--api-key`) |
 | `GCP_PROJECT` | Vertex AI | GCP project ID (overridden by `--gcp-project`) |
 | `AWS_PROFILE` | Bedrock | AWS profile (overridden by `--aws-profile`) |
 | `AWS_REGION` | Bedrock | AWS region (overridden by `--region`) |

--- a/cmd/vocabgen/main.go
+++ b/cmd/vocabgen/main.go
@@ -128,7 +128,7 @@ func init() {
 	// Persistent flags available to all subcommands
 	pf := rootCmd.PersistentFlags()
 	pf.BoolP("verbose", "v", false, "Enable debug logging")
-	pf.String("provider", "bedrock", "LLM provider (bedrock, openai, anthropic, vertexai)")
+	pf.String("provider", "bedrock", "LLM provider (bedrock, openai, anthropic, vertexai, gemini)")
 	pf.StringP("region", "r", "us-east-1", "AWS region for Bedrock provider")
 	pf.Int("timeout", 60, "Per-request timeout in seconds")
 	pf.String("tags", "", "Comma-separated tags for entries")

--- a/cmd/vocabgen/main_test.go
+++ b/cmd/vocabgen/main_test.go
@@ -226,7 +226,8 @@ func TestCLIProviderValidation(t *testing.T) {
 		{"openai valid", "openai", false},
 		{"anthropic valid", "anthropic", false},
 		{"vertexai valid", "vertexai", false},
-		{"invalid provider", "gemini", true},
+		{"gemini valid", "gemini", false},
+		{"invalid provider", "invalidprovider", true},
 		{"empty provider", "", true},
 	}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ A `Registry` map connects provider name strings to constructor functions. Adding
 | Bedrock | `bedrock.go` | AWS credential chain (profile or default) | Once on throttling/timeout |
 | OpenAI | `openai.go` | API key (or none with custom base URL) | Once on HTTP 429 |
 | Anthropic | `anthropic.go` | API key | Once on HTTP 429 |
-| Vertex AI | `vertexai.go` | Google ADC (stub, not yet implemented) | Once on rate-limit |
+| Vertex AI | `vertexai.go` | Google ADC (Application Default Credentials) | Once on HTTP 429 |
 
 All providers return `ProviderError` on failure, which wraps the provider name and underlying error. Callers use `errors.As(&ProviderError{})` for unified error handling regardless of which provider failed.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,7 @@ graph TB
     LLM --> OPENAI["OpenAI API<br/>(+ Azure, Ollama, LM Studio)"]
     LLM --> ANTHROPIC["Anthropic API"]
     LLM --> VERTEXAI["Google Vertex AI"]
+    LLM --> GEMINI["Google Gemini API"]
     CLI --> CFG
     WEB --> CFG
     WEB --> DOCS
@@ -69,7 +70,7 @@ vocabgen/
 │   ├── config/            # YAML config manager (LoadConfig, SaveConfig)
 │   ├── db/                # SQLite schema, migrations, CRUD, cache layer
 │   ├── language/          # Prompt templates, schemas, validation, language registry
-│   ├── llm/               # Provider interface, Bedrock/OpenAI/Anthropic implementations
+│   ├── llm/               # Provider interface, Bedrock/OpenAI/Anthropic/VertexAI/Gemini implementations
 │   ├── output/            # Field mapping, translation flattening, Excel export
 │   ├── parsing/           # CSV reading, word/expression normalization
 │   ├── service/           # Lookup, ProcessBatch, DisambiguatedWord — shared business logic
@@ -95,6 +96,7 @@ A `Registry` map connects provider name strings to constructor functions. Adding
 | OpenAI | `openai.go` | API key (or none with custom base URL) | Once on HTTP 429 |
 | Anthropic | `anthropic.go` | API key | Once on HTTP 429 |
 | Vertex AI | `vertexai.go` | Google ADC (Application Default Credentials) | Once on HTTP 429 |
+| Gemini | `gemini.go` | API key (via `GEMINI_API_KEY` or `--api-key`) | Once on HTTP 429 |
 
 All providers return `ProviderError` on failure, which wraps the provider name and underlying error. Callers use `errors.As(&ProviderError{})` for unified error handling regardless of which provider failed.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VocabGen — Vocabulary Web App & Flashcard Tool for Language Learners</title>
     <meta name="description"
-        content="Open-source vocabulary web app and flashcard tool for language learners. Look up words, analyze sentences for grammar errors, batch-process CSV lists, and study with flashcards in your browser. Powered by LLM (OpenAI, Anthropic, Bedrock, Ollama). Single binary, zero setup.">
+        content="Open-source vocabulary web app and flashcard tool for language learners. Look up words, analyze sentences for grammar errors, batch-process CSV lists, and study with flashcards in your browser. Powered by LLM (OpenAI, Anthropic, Bedrock, Gemini, Ollama). Single binary, zero setup.">
     <meta name="keywords"
-        content="vocabulary web app, flashcard app, language learning tool, vocabulary generator, CSV to vocabulary, LLM vocabulary, OpenAI, Anthropic, AWS Bedrock, Ollama, flashcards, language learner, study tool, open source">
+        content="vocabulary web app, flashcard app, language learning tool, vocabulary generator, CSV to vocabulary, LLM vocabulary, OpenAI, Anthropic, AWS Bedrock, Google Gemini, Ollama, flashcards, language learner, study tool, open source">
     <meta name="author" content="npozs77">
     <meta name="robots" content="index, follow">
     <meta name="google-site-verification" content="bQNvbLYfpPRmNyhHt3VhixzcgNgJzhRxQSD6Cv43fow" />
@@ -51,7 +51,7 @@
       "Sentence analysis with grammar checking and vocabulary extraction",
       "CSV batch processing via web UI or CLI",
       "Multi-language support (11+ languages, any custom language)",
-      "LLM providers: OpenAI, Anthropic, AWS Bedrock, Ollama (free local)",
+      "LLM providers: OpenAI, Anthropic, AWS Bedrock, Google Gemini, Ollama (free local)",
       "SQLite cache for cost efficiency",
       "Single binary, zero dependencies, runs locally",
       "CLI for scripting and automation",
@@ -246,7 +246,8 @@
         <h2>What is VocabGen?</h2>
         <p>VocabGen is a free, open-source vocabulary web app for language learners at B2–C1 level. Start the app, open
             your browser, and you can look up words, upload CSV word lists for batch processing, study with flashcards,
-            and manage your vocabulary database. It uses LLM providers (OpenAI, Anthropic, AWS Bedrock, Ollama) to
+            and manage your vocabulary database. It uses LLM providers (OpenAI, Anthropic, AWS Bedrock, Google Gemini,
+            Ollama) to
             generate structured vocabulary entries with definitions, translations, connotation, and register. Everything
             runs locally on your machine — your data stays private.</p>
 
@@ -286,6 +287,7 @@
             <div class="provider">OpenAI</div>
             <div class="provider">Anthropic</div>
             <div class="provider">AWS Bedrock</div>
+            <div class="provider">Google Gemini</div>
             <div class="provider">Google Vertex AI</div>
             <div class="provider">Ollama (free)</div>
             <div class="provider">Azure OpenAI</div>

--- a/docs/ui-preview.html
+++ b/docs/ui-preview.html
@@ -54,7 +54,8 @@
     <!-- Mockup Nav Bar (replica of the real app nav — items switch tabs) -->
     <nav class="bg-white shadow">
         <div class="max-w-7xl mx-auto px-4 py-3 flex items-center gap-6">
-            <span class="font-semibold text-lg text-gray-800">VocabGen</span>
+            <a href="index.html"
+                class="font-semibold text-lg text-gray-800 hover:text-blue-600 no-underline">VocabGen</a>
             <a href="#" onclick="showTab('lookup'); return false;" id="nav-lookup"
                 class="text-blue-600 font-medium">Lookup</a>
             <a href="#" onclick="showTab('batch'); return false;" id="nav-batch"
@@ -597,8 +598,13 @@ het klopt</textarea>
                 </div>
                 <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
                     Set <code class="font-mono bg-blue-100 px-1 rounded">OPENAI_API_KEY</code> environment variable
-                    before starting the server.
+                    or use <code class="font-mono bg-blue-100 px-1 rounded">--api-key</code> flag.
                     Not required when using a local server (Ollama, LM Studio) via Base URL.
+                    <br>Examples — Ollama: <code
+                        class="font-mono bg-blue-100 px-1 rounded">http://localhost:11434/v1</code> · Model:
+                    <code class="font-mono bg-blue-100 px-1 rounded">translategemma</code>
+                    · OpenAI: <code class="font-mono bg-blue-100 px-1 rounded">https://api.openai.com/v1</code> · Model:
+                    <code class="font-mono bg-blue-100 px-1 rounded">gpt-4o</code>
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-1">Base URL (optional)</label>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -89,7 +89,7 @@ vocabgen serve --port 8080
 
 Open `http://localhost:8080/config` in your browser. From there you can:
 
-- Select your LLM provider (Bedrock, OpenAI, Anthropic, Vertex AI)
+- Select your LLM provider (Bedrock, OpenAI, Anthropic, Vertex AI, Gemini)
 - Set your default source and target languages
 - Choose a model ID
 - Test the connection (uses the API key from your environment variables automatically)
@@ -125,6 +125,7 @@ Each provider authenticates differently:
 | OpenAI | `OPENAI_API_KEY` env var or `--api-key` flag |
 | Anthropic | `ANTHROPIC_API_KEY` env var or `--api-key` flag |
 | Vertex AI | Google Application Default Credentials + `--gcp-project` or `GCP_PROJECT` env var |
+| Gemini | `GEMINI_API_KEY` env var or `--api-key` flag |
 | Ollama | None (local server) |
 
 API keys are never stored in `config.yaml`. Use environment variables or CLI flags.
@@ -554,6 +555,15 @@ vocabgen lookup "werk" -l nl --provider openai --base-url http://localhost:11434
 ```
 
 No API key needed for local servers.
+
+### Google Gemini (direct API)
+
+```bash
+export GEMINI_API_KEY=AIza...
+vocabgen lookup "werk" -l nl --provider gemini --model-id gemini-2.0-flash
+```
+
+Get an API key from [Google AI Studio](https://aistudio.google.com). The Gemini API has a free tier with rate limits — suitable for light usage without a payment method.
 
 ### Azure OpenAI
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,11 @@ require (
 	pgregory.net/rapid v1.3.0
 )
 
-require github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
+)
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
@@ -81,6 +83,8 @@ golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -1,0 +1,221 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GeminiProvider implements Provider for the Google Gemini API (direct, via API key).
+// Uses the generativelanguage.googleapis.com REST endpoint.
+// Distinct from VertexAIProvider which uses GCP infrastructure and ADC.
+type GeminiProvider struct {
+	apiKey string
+	client *http.Client
+}
+
+// NewGeminiProvider creates a GeminiProvider using a Gemini API key.
+// Returns error if API key is empty.
+func NewGeminiProvider(opts ProviderOptions) (Provider, error) {
+	if opts.APIKey == "" {
+		return nil, &ProviderError{
+			Provider: "gemini",
+			Message:  "API key is required: set GEMINI_API_KEY environment variable or use --api-key flag",
+		}
+	}
+
+	return &GeminiProvider{
+		apiKey: opts.APIKey,
+		client: &http.Client{Timeout: 120 * time.Second},
+	}, nil
+}
+
+// Name returns the provider identifier.
+func (p *GeminiProvider) Name() string { return "gemini" }
+
+// geminiRequest is the JSON body for the Gemini generateContent endpoint.
+type geminiRequest struct {
+	Contents []geminiContent `json:"contents"`
+}
+
+// geminiContent represents a content entry in the request.
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+// geminiPart represents a part within a content entry.
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+// geminiResponse is the JSON body returned by the generateContent endpoint.
+type geminiResponse struct {
+	Candidates []geminiCandidate `json:"candidates"`
+}
+
+// geminiCandidate represents a single candidate in the response.
+type geminiCandidate struct {
+	Content geminiContent `json:"content"`
+}
+
+// Invoke sends a generateContent request to the Gemini API and returns the text response.
+// It retries once on HTTP 429 (rate limit) with a 1-second delay.
+func (p *GeminiProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error) {
+	reqBody := geminiRequest{
+		Contents: []geminiContent{
+			{
+				Role:  "user",
+				Parts: []geminiPart{{Text: prompt}},
+			},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", &ProviderError{
+			Provider: "gemini",
+			Message:  "failed to marshal request: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	// Gemini REST API endpoint with API key as query parameter.
+	url := fmt.Sprintf(
+		"https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s",
+		modelID, p.apiKey,
+	)
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			slog.Debug("gemini: retrying after error", slog.Int("attempt", attempt+1), slog.String("error", lastErr.Error()))
+			select {
+			case <-ctx.Done():
+				return "", &ProviderError{
+					Provider: "gemini",
+					Message:  "context cancelled during retry",
+					Err:      ctx.Err(),
+				}
+			case <-time.After(1 * time.Second):
+			}
+		}
+
+		text, retryable, err := p.doRequest(ctx, url, bodyBytes)
+		if err != nil {
+			lastErr = err
+			if retryable && attempt == 0 {
+				continue
+			}
+			return "", err
+		}
+		return text, nil
+	}
+
+	return "", lastErr
+}
+
+// doRequest performs a single HTTP request and returns the extracted text,
+// whether the error is retryable, and any error.
+func (p *GeminiProvider) doRequest(ctx context.Context, url string, body []byte) (string, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", false, &ProviderError{
+			Provider: "gemini",
+			Message:  "failed to create request: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", false, &ProviderError{
+			Provider: "gemini",
+			Message:  "request failed: " + err.Error(),
+			Err:      err,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false, &ProviderError{
+			Provider: "gemini",
+			Message:  "failed to read response body: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	// Rate limit — retryable.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return "", true, &ProviderError{
+			Provider: "gemini",
+			Message:  "rate limited (HTTP 429): retries exhausted",
+		}
+	}
+
+	// Auth failure.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200]
+		}
+		return "", false, &ProviderError{
+			Provider: "gemini",
+			Message:  fmt.Sprintf("authentication failed (HTTP %d): %s", resp.StatusCode, snippet),
+		}
+	}
+
+	// Non-2xx status.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200]
+		}
+		return "", false, &ProviderError{
+			Provider: "gemini",
+			Message:  fmt.Sprintf("HTTP %d: %s", resp.StatusCode, snippet),
+		}
+	}
+
+	// Parse response JSON.
+	var result geminiResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", false, &ProviderError{
+			Provider: "gemini",
+			Message:  "failed to parse response JSON: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	// Extract text from the first candidate's parts.
+	text := p.extractText(result)
+	if text == "" {
+		return "", false, &ProviderError{
+			Provider: "gemini",
+			Message:  "empty response from model",
+		}
+	}
+
+	return text, false, nil
+}
+
+// extractText concatenates all text parts from the first candidate.
+func (p *GeminiProvider) extractText(resp geminiResponse) string {
+	if len(resp.Candidates) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range resp.Candidates[0].Content.Parts {
+		sb.WriteString(part.Text)
+	}
+	return strings.TrimSpace(sb.String())
+}

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -1,0 +1,96 @@
+package llm
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestGeminiProviderRejectsEmptyAPIKey validates that NewGeminiProvider
+// returns a *ProviderError when APIKey is empty.
+//
+// Validates: Requirements 69.1, 12.8
+func TestGeminiProviderRejectsEmptyAPIKey(t *testing.T) {
+	tests := []struct {
+		name string
+		opts ProviderOptions
+	}{
+		{
+			name: "empty api key",
+			opts: ProviderOptions{APIKey: ""},
+		},
+		{
+			name: "all fields empty",
+			opts: ProviderOptions{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewGeminiProvider(tc.opts)
+			if err == nil {
+				t.Fatal("NewGeminiProvider() returned nil error, want *ProviderError")
+			}
+			var provErr *ProviderError
+			if !errors.As(err, &provErr) {
+				t.Fatalf("error is not *ProviderError: %v", err)
+			}
+			if provErr.Provider != "gemini" {
+				t.Errorf("ProviderError.Provider = %q, want %q", provErr.Provider, "gemini")
+			}
+		})
+	}
+}
+
+// TestGeminiProviderConstructionWithAPIKey validates that NewGeminiProvider
+// succeeds when a valid API key is provided.
+//
+// Validates: Requirements 69.1
+func TestGeminiProviderConstructionWithAPIKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiKey string
+	}{
+		{name: "valid api key", apiKey: "AIzaSyTest1234567890"},
+		{name: "short api key", apiKey: "key123"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewGeminiProvider(ProviderOptions{APIKey: tc.apiKey})
+			if err != nil {
+				t.Fatalf("NewGeminiProvider() returned error: %v", err)
+			}
+			if p == nil {
+				t.Fatal("NewGeminiProvider() returned nil provider")
+			}
+		})
+	}
+}
+
+// TestGeminiProviderName validates that Name() returns "gemini".
+//
+// Validates: Requirements 69.2
+func TestGeminiProviderName(t *testing.T) {
+	p, err := NewGeminiProvider(ProviderOptions{APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("NewGeminiProvider() returned error: %v", err)
+	}
+
+	got := p.Name()
+	if got != "gemini" {
+		t.Errorf("Name() = %q, want %q", got, "gemini")
+	}
+}
+
+// TestGeminiRegistryEntry validates that the Registry contains a "gemini" entry.
+//
+// Validates: Requirements 11.4
+func TestGeminiRegistryEntry(t *testing.T) {
+	fn, ok := Registry["gemini"]
+	if !ok {
+		t.Fatal("Registry missing entry for \"gemini\"")
+	}
+	if fn == nil {
+		t.Fatal("Registry entry for \"gemini\" is nil")
+	}
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -51,4 +51,5 @@ var Registry = map[string]NewProviderFunc{
 	"openai":    NewOpenAIProvider,
 	"anthropic": NewAnthropicProvider,
 	"vertexai":  NewVertexAIProvider,
+	"gemini":    NewGeminiProvider,
 }

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -80,6 +80,7 @@ func TestRegistryContainsAllProviders(t *testing.T) {
 		{name: "openai", provider: "openai"},
 		{name: "anthropic", provider: "anthropic"},
 		{name: "vertexai", provider: "vertexai"},
+		{name: "gemini", provider: "gemini"},
 	}
 
 	for _, tc := range tests {

--- a/internal/llm/vertexai.go
+++ b/internal/llm/vertexai.go
@@ -1,26 +1,255 @@
 package llm
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
-// VertexAIProvider implements Provider for Google Vertex AI.
-// Stub — full implementation in task 7.8.
-type VertexAIProvider struct{}
-
-// NewVertexAIProvider creates a VertexAIProvider. Stub — returns error until implemented.
-func NewVertexAIProvider(opts ProviderOptions) (Provider, error) {
-	return nil, &ProviderError{
-		Provider: "vertexai",
-		Message:  "Vertex AI provider not yet implemented",
-	}
+// VertexAIProvider implements Provider for Google Vertex AI (Gemini API).
+// It uses Application Default Credentials (ADC) for authentication and
+// calls the generateContent REST endpoint.
+type VertexAIProvider struct {
+	project     string
+	region      string
+	client      *http.Client
+	tokenSource oauth2.TokenSource
 }
 
-// Invoke is a stub that returns an error until the Vertex AI provider is fully implemented.
-func (p *VertexAIProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error) {
-	return "", fmt.Errorf("vertexai: not yet implemented")
+// NewVertexAIProvider creates a VertexAIProvider using Google ADC.
+// Requires a GCP project ID (via opts.GCPProject). Region defaults to "us-central1".
+func NewVertexAIProvider(opts ProviderOptions) (Provider, error) {
+	if opts.GCPProject == "" {
+		return nil, &ProviderError{
+			Provider: "vertexai",
+			Message:  "GCP project ID is required: set GCP_PROJECT environment variable or use --gcp-project flag",
+		}
+	}
+
+	region := opts.Region
+	if region == "" {
+		region = "us-central1"
+	}
+
+	// Use ADC to get credentials scoped to Vertex AI.
+	ctx := context.Background()
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, &ProviderError{
+			Provider: "vertexai",
+			Message:  "failed to find Google Application Default Credentials: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	return &VertexAIProvider{
+		project:     opts.GCPProject,
+		region:      region,
+		client:      &http.Client{Timeout: 120 * time.Second},
+		tokenSource: creds.TokenSource,
+	}, nil
 }
 
 // Name returns the provider identifier.
 func (p *VertexAIProvider) Name() string { return "vertexai" }
+
+// vertexaiRequest is the JSON body for the Vertex AI generateContent endpoint.
+type vertexaiRequest struct {
+	Contents []vertexaiContent `json:"contents"`
+}
+
+// vertexaiContent represents a content entry in the request/response.
+type vertexaiContent struct {
+	Role  string         `json:"role,omitempty"`
+	Parts []vertexaiPart `json:"parts"`
+}
+
+// vertexaiPart represents a part within a content entry.
+type vertexaiPart struct {
+	Text string `json:"text"`
+}
+
+// vertexaiResponse is the JSON body returned by the generateContent endpoint.
+type vertexaiResponse struct {
+	Candidates []vertexaiCandidate `json:"candidates"`
+}
+
+// vertexaiCandidate represents a single candidate in the response.
+type vertexaiCandidate struct {
+	Content vertexaiContent `json:"content"`
+}
+
+// Invoke sends a generateContent request to Vertex AI and returns the text response.
+// It retries once on HTTP 429 (rate limit) with a 1-second delay.
+func (p *VertexAIProvider) Invoke(ctx context.Context, prompt, modelID string) (string, error) {
+	reqBody := vertexaiRequest{
+		Contents: []vertexaiContent{
+			{
+				Role:  "user",
+				Parts: []vertexaiPart{{Text: prompt}},
+			},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", &ProviderError{
+			Provider: "vertexai",
+			Message:  "failed to marshal request: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	// Vertex AI generateContent endpoint.
+	url := fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent",
+		p.region, p.project, p.region, modelID,
+	)
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			slog.Debug("vertexai: retrying after error", slog.Int("attempt", attempt+1), slog.String("error", lastErr.Error()))
+			select {
+			case <-ctx.Done():
+				return "", &ProviderError{
+					Provider: "vertexai",
+					Message:  "context cancelled during retry",
+					Err:      ctx.Err(),
+				}
+			case <-time.After(1 * time.Second):
+			}
+		}
+
+		text, retryable, err := p.doRequest(ctx, url, bodyBytes)
+		if err != nil {
+			lastErr = err
+			if retryable && attempt == 0 {
+				continue
+			}
+			return "", err
+		}
+		return text, nil
+	}
+
+	return "", lastErr
+}
+
+// doRequest performs a single HTTP request and returns the extracted text,
+// whether the error is retryable, and any error.
+func (p *VertexAIProvider) doRequest(ctx context.Context, url string, body []byte) (string, bool, error) {
+	// Get a fresh OAuth2 token.
+	token, err := p.tokenSource.Token()
+	if err != nil {
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  "failed to obtain access token: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  "failed to create request: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  "request failed: " + err.Error(),
+			Err:      err,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  "failed to read response body: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	// Rate limit — retryable.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return "", true, &ProviderError{
+			Provider: "vertexai",
+			Message:  "rate limited (HTTP 429): retries exhausted",
+		}
+	}
+
+	// Auth failure.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200]
+		}
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  fmt.Sprintf("authentication failed (HTTP %d): %s", resp.StatusCode, snippet),
+		}
+	}
+
+	// Non-2xx status.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200]
+		}
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  fmt.Sprintf("HTTP %d: %s", resp.StatusCode, snippet),
+		}
+	}
+
+	// Parse response JSON.
+	var result vertexaiResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  "failed to parse response JSON: " + err.Error(),
+			Err:      err,
+		}
+	}
+
+	// Extract text from the first candidate's parts.
+	text := p.extractText(result)
+	if text == "" {
+		return "", false, &ProviderError{
+			Provider: "vertexai",
+			Message:  "empty response from model",
+		}
+	}
+
+	return text, false, nil
+}
+
+// extractText concatenates all text parts from the first candidate.
+func (p *VertexAIProvider) extractText(resp vertexaiResponse) string {
+	if len(resp.Candidates) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range resp.Candidates[0].Content.Parts {
+		sb.WriteString(part.Text)
+	}
+	return strings.TrimSpace(sb.String())
+}

--- a/internal/llm/vertexai_test.go
+++ b/internal/llm/vertexai_test.go
@@ -1,0 +1,356 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+// staticTokenSource returns a fixed token for testing.
+type staticTokenSource struct {
+	token *oauth2.Token
+}
+
+func (s *staticTokenSource) Token() (*oauth2.Token, error) {
+	return s.token, nil
+}
+
+// failingTokenSource always returns an error.
+type failingTokenSource struct{}
+
+func (f *failingTokenSource) Token() (*oauth2.Token, error) {
+	return nil, errors.New("ADC not configured")
+}
+
+// TestNewVertexAIProviderValidation validates constructor validation logic.
+//
+// Validates: Requirements 51.1, 51.2
+func TestNewVertexAIProviderValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       ProviderOptions
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:       "missing GCP project",
+			opts:       ProviderOptions{GCPProject: ""},
+			wantErr:    true,
+			wantSubstr: "GCP project ID is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewVertexAIProvider(tc.opts)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("NewVertexAIProvider() returned nil error, want error")
+				}
+				var provErr *ProviderError
+				if !errors.As(err, &provErr) {
+					t.Fatalf("error is not *ProviderError: %v", err)
+				}
+				if !strings.Contains(err.Error(), tc.wantSubstr) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tc.wantSubstr)
+				}
+			}
+		})
+	}
+}
+
+// TestVertexAIProviderName validates the Name() method.
+//
+// Validates: Requirements 51.1
+func TestVertexAIProviderName(t *testing.T) {
+	p := &VertexAIProvider{}
+	if got := p.Name(); got != "vertexai" {
+		t.Errorf("Name() = %q, want %q", got, "vertexai")
+	}
+}
+
+// TestVertexAIProviderInvoke validates Invoke with a mock HTTP server.
+//
+// Validates: Requirements 51.3, 51.4, 51.5, 51.6, 51.7
+func TestVertexAIProviderInvoke(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		tokenSrc   oauth2.TokenSource
+		wantErr    bool
+		wantSubstr string
+		wantText   string
+	}{
+		{
+			name: "successful response",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				resp := vertexaiResponse{
+					Candidates: []vertexaiCandidate{
+						{
+							Content: vertexaiContent{
+								Parts: []vertexaiPart{{Text: "Hello world"}},
+							},
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			tokenSrc: &staticTokenSource{token: &oauth2.Token{AccessToken: "test-token"}},
+			wantText: "Hello world",
+		},
+		{
+			name: "multi-part response concatenated",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				resp := vertexaiResponse{
+					Candidates: []vertexaiCandidate{
+						{
+							Content: vertexaiContent{
+								Parts: []vertexaiPart{
+									{Text: "Part 1 "},
+									{Text: "Part 2"},
+								},
+							},
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			tokenSrc: &staticTokenSource{token: &oauth2.Token{AccessToken: "test-token"}},
+			wantText: "Part 1 Part 2",
+		},
+		{
+			name: "empty response returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				resp := vertexaiResponse{Candidates: []vertexaiCandidate{}}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			tokenSrc:   &staticTokenSource{token: &oauth2.Token{AccessToken: "test-token"}},
+			wantErr:    true,
+			wantSubstr: "empty response",
+		},
+		{
+			name: "auth failure returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error": "permission denied"}`))
+			},
+			tokenSrc:   &staticTokenSource{token: &oauth2.Token{AccessToken: "bad-token"}},
+			wantErr:    true,
+			wantSubstr: "authentication failed",
+		},
+		{
+			name: "rate limit retries once then fails",
+			handler: func() http.HandlerFunc {
+				calls := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					calls++
+					w.WriteHeader(http.StatusTooManyRequests)
+					_, _ = w.Write([]byte(`{"error": "rate limited"}`))
+				}
+			}(),
+			tokenSrc:   &staticTokenSource{token: &oauth2.Token{AccessToken: "test-token"}},
+			wantErr:    true,
+			wantSubstr: "rate limited",
+		},
+		{
+			name: "rate limit retries once then succeeds",
+			handler: func() http.HandlerFunc {
+				calls := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					calls++
+					if calls == 1 {
+						w.WriteHeader(http.StatusTooManyRequests)
+						_, _ = w.Write([]byte(`{"error": "rate limited"}`))
+						return
+					}
+					resp := vertexaiResponse{
+						Candidates: []vertexaiCandidate{
+							{Content: vertexaiContent{Parts: []vertexaiPart{{Text: "success after retry"}}}},
+						},
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(resp)
+				}
+			}(),
+			tokenSrc: &staticTokenSource{token: &oauth2.Token{AccessToken: "test-token"}},
+			wantText: "success after retry",
+		},
+		{
+			name:       "token source failure returns error",
+			handler:    func(w http.ResponseWriter, r *http.Request) {},
+			tokenSrc:   &failingTokenSource{},
+			wantErr:    true,
+			wantSubstr: "failed to obtain access token",
+		},
+		{
+			name: "server error (500) returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error": "internal"}`))
+			},
+			tokenSrc:   &staticTokenSource{token: &oauth2.Token{AccessToken: "test-token"}},
+			wantErr:    true,
+			wantSubstr: "HTTP 500",
+		},
+		{
+			name: "invalid JSON response returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`not json`))
+			},
+			tokenSrc:   &staticTokenSource{token: &oauth2.Token{AccessToken: "test-token"}},
+			wantErr:    true,
+			wantSubstr: "failed to parse response JSON",
+		},
+		{
+			name: "authorization header is set",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				auth := r.Header.Get("Authorization")
+				if auth != "Bearer my-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte(`{"error": "bad auth"}`))
+					return
+				}
+				resp := vertexaiResponse{
+					Candidates: []vertexaiCandidate{
+						{Content: vertexaiContent{Parts: []vertexaiPart{{Text: "authed"}}}},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			tokenSrc: &staticTokenSource{token: &oauth2.Token{AccessToken: "my-token"}},
+			wantText: "authed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			p := &VertexAIProvider{
+				project:     "test-project",
+				region:      "us-central1",
+				client:      server.Client(),
+				tokenSource: tc.tokenSrc,
+			}
+
+			// Override the URL by calling doRequest directly via Invoke.
+			// We need to override the URL construction, so we'll call the internal method.
+			ctx := context.Background()
+
+			// Build the request body the same way Invoke does.
+			reqBody := vertexaiRequest{
+				Contents: []vertexaiContent{
+					{Role: "user", Parts: []vertexaiPart{{Text: "test prompt"}}},
+				},
+			}
+			bodyBytes, err := json.Marshal(reqBody)
+			if err != nil {
+				t.Fatalf("failed to marshal request: %v", err)
+			}
+
+			// Use the test server URL instead of the real Vertex AI endpoint.
+			url := server.URL + "/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.0-flash:generateContent"
+
+			var result string
+			var lastErr error
+			for attempt := 0; attempt < 2; attempt++ {
+				text, retryable, reqErr := p.doRequest(ctx, url, bodyBytes)
+				if reqErr != nil {
+					lastErr = reqErr
+					if retryable && attempt == 0 {
+						continue
+					}
+					break
+				}
+				result = text
+				lastErr = nil
+				break
+			}
+
+			if tc.wantErr {
+				if lastErr == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(lastErr.Error(), tc.wantSubstr) {
+					t.Errorf("error = %q, want it to contain %q", lastErr.Error(), tc.wantSubstr)
+				}
+				var provErr *ProviderError
+				if !errors.As(lastErr, &provErr) {
+					t.Errorf("error is not *ProviderError: %v", lastErr)
+				}
+			} else {
+				if lastErr != nil {
+					t.Fatalf("unexpected error: %v", lastErr)
+				}
+				if result != tc.wantText {
+					t.Errorf("result = %q, want %q", result, tc.wantText)
+				}
+			}
+		})
+	}
+}
+
+// TestVertexAIProviderRequestFormat validates the request body format sent to the API.
+//
+// Validates: Requirements 51.3
+func TestVertexAIProviderRequestFormat(t *testing.T) {
+	var receivedBody vertexaiRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		resp := vertexaiResponse{
+			Candidates: []vertexaiCandidate{
+				{Content: vertexaiContent{Parts: []vertexaiPart{{Text: "ok"}}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := &VertexAIProvider{
+		project:     "my-project",
+		region:      "europe-west1",
+		client:      server.Client(),
+		tokenSource: &staticTokenSource{token: &oauth2.Token{AccessToken: "tok"}},
+	}
+
+	body, _ := json.Marshal(vertexaiRequest{
+		Contents: []vertexaiContent{
+			{Role: "user", Parts: []vertexaiPart{{Text: "translate this"}}},
+		},
+	})
+
+	url := server.URL + "/v1/projects/my-project/locations/europe-west1/publishers/google/models/gemini-2.0-flash:generateContent"
+	_, _, err := p.doRequest(context.Background(), url, body)
+	if err != nil {
+		t.Fatalf("doRequest failed: %v", err)
+	}
+
+	if len(receivedBody.Contents) != 1 {
+		t.Fatalf("expected 1 content entry, got %d", len(receivedBody.Contents))
+	}
+	if receivedBody.Contents[0].Role != "user" {
+		t.Errorf("role = %q, want %q", receivedBody.Contents[0].Role, "user")
+	}
+	if len(receivedBody.Contents[0].Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(receivedBody.Contents[0].Parts))
+	}
+	if receivedBody.Contents[0].Parts[0].Text != "translate this" {
+		t.Errorf("text = %q, want %q", receivedBody.Contents[0].Parts[0].Text, "translate this")
+	}
+}

--- a/internal/web/handlers_config.go
+++ b/internal/web/handlers_config.go
@@ -454,6 +454,10 @@ func validateProviderEnv(provider, baseURL, gcpProject string) string {
 		if gcpProject == "" && os.Getenv("GCP_PROJECT") == "" {
 			return "GCP project ID is required for Vertex AI. Set the GCP_PROJECT environment variable or fill in the GCP Project field."
 		}
+	case "gemini":
+		if os.Getenv("GEMINI_API_KEY") == "" {
+			return "GEMINI_API_KEY environment variable is not set. Set it before starting the server: export GEMINI_API_KEY=..."
+		}
 	}
 	return ""
 }

--- a/internal/web/templates/partials/config_form.html
+++ b/internal/web/templates/partials/config_form.html
@@ -41,6 +41,7 @@
       <option value="openai" {{if eq .Config.Provider "openai" }} selected{{end}}>OpenAI</option>
       <option value="anthropic" {{if eq .Config.Provider "anthropic" }} selected{{end}}>Anthropic</option>
       <option value="vertexai" {{if eq .Config.Provider "vertexai" }} selected{{end}}>Vertex AI</option>
+      <option value="gemini" {{if eq .Config.Provider "gemini" }} selected{{end}}>Google Gemini</option>
     </select>
   </div>
 
@@ -63,8 +64,8 @@
 
   {{if eq .Config.Provider "openai"}}
   <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
-    Set <code class="font-mono bg-blue-100 px-1 rounded">OPENAI_API_KEY</code> environment variable before starting the
-    server.
+    Set <code class="font-mono bg-blue-100 px-1 rounded">OPENAI_API_KEY</code> environment variable or use
+    <code class="font-mono bg-blue-100 px-1 rounded">--api-key</code> flag.
     Not required when using a local server (Ollama, LM Studio) via Base URL.
     <br>Examples — Ollama: <code class="font-mono bg-blue-100 px-1 rounded">http://localhost:11434/v1</code> · Model:
     <code class="font-mono bg-blue-100 px-1 rounded">translategemma</code>
@@ -82,7 +83,14 @@
   {{if eq .Config.Provider "anthropic"}}
   <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
     Set <code class="font-mono bg-blue-100 px-1 rounded">ANTHROPIC_API_KEY</code> environment variable before starting
-    the server.
+    the server, or use <code class="font-mono bg-blue-100 px-1 rounded">--api-key</code> flag.
+  </div>
+  {{end}}
+
+  {{if eq .Config.Provider "gemini"}}
+  <div class="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
+    Set <code class="font-mono bg-blue-100 px-1 rounded">GEMINI_API_KEY</code> environment variable before starting the
+    server, or use <code class="font-mono bg-blue-100 px-1 rounded">--api-key</code> flag.
   </div>
   {{end}}
 
@@ -109,8 +117,8 @@
       class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
       placeholder="{{if eq .Config.Provider " bedrock"}}e.g. us.anthropic.claude-sonnet-4-20250514-v1:0{{else if eq
       .Config.Provider "openai" }}e.g. gpt-4o, or translategemma for Ollama{{else if eq .Config.Provider "anthropic"
-      }}e.g. claude-sonnet-4-6{{else if eq .Config.Provider "vertexai" }}e.g. gemini-2.0-flash{{else}}Enter model
-      ID{{end}}">
+      }}e.g. claude-sonnet-4-6{{else if eq .Config.Provider "vertexai" }}e.g. gemini-2.0-flash{{else if eq
+      .Config.Provider "gemini" }}e.g. gemini-2.0-flash{{else}}Enter model ID{{end}}">
   </div>
 
   <div class="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary

Add Google Gemini and Vertex AI as LLM providers, expanding provider support beyond Bedrock, OpenAI, and Anthropic. Gemini authenticates via API key (`GEMINI_API_KEY`), Vertex AI uses Application Default Credentials with a GCP project ID.

## Related Issue

None

## Changes

- Add Google Vertex AI provider (`--provider vertexai --gcp-project <id>`) with ADC authentication
- Add Google Gemini API provider (`--provider gemini`) with API key authentication
- Fix frontend issues for Gemini provider config hints and credential display
- Update GitHub issue analysis template with improved structure
- Update CHANGELOG, README, docs (architecture, user-guide, ui-preview), and spec files

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
