### PR TITLE
feat: add API-key authentication for service-accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This pr
 
 ### Added
 
+- API-key authentication for service-accounts — protect `/api/*` endpoints with Bearer tokens for headless automation (MCP server, containers); backward compatible (no `users.yaml` = fully open access); includes `vocabgen auth init` CLI for key generation and auto-provisioning via `VOCABGEN_API_KEY` env var in Docker
 - Google Gemini API provider — use Gemini models directly via `--provider gemini`, authenticates with API key from `GEMINI_API_KEY` env var or `--api-key` flag
 - Google Vertex AI provider — use Gemini models via `--provider vertexai --gcp-project <project-id>`, authenticates with Application Default Credentials
 - Database picker dropdown on Config page — lists existing `.db` files in the config directory, select one or create a new database with inline name validation (#76)

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ RUN chmod +x /entrypoint.sh
 VOLUME /data
 ENV HOME=/home/vocabgen
 
+# API-key authentication (optional, zero-config):
+# Set VOCABGEN_API_KEY to enable auth automatically on first start.
+# The serve command will auto-create /data/users.yaml with a bcrypt hash.
+# Optional: VOCABGEN_API_KEY_NAME (default: "service-account")
+# Optional: VOCABGEN_API_KEY_SCOPE (default: "read-only")
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \

--- a/cmd/vocabgen/main.go
+++ b/cmd/vocabgen/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/user/vocabgen/internal/auth"
 	"github.com/user/vocabgen/internal/config"
 	"github.com/user/vocabgen/internal/db"
 	"github.com/user/vocabgen/internal/llm"
@@ -46,8 +47,8 @@ var rootCmd = &cobra.Command{
 	Long:    "A CLI and embedded web app for generating structured vocabulary lists using LLM providers.",
 	Version: version,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Skip config loading for version and update subcommands
-		if cmd.Name() == "version" || cmd.Name() == "update" {
+		// Skip config loading for version, update, and auth subcommands
+		if cmd.Name() == "version" || cmd.Name() == "update" || cmd.Name() == "init" || cmd.Parent().Name() == "auth" {
 			return nil
 		}
 
@@ -151,6 +152,7 @@ func init() {
 	rootCmd.AddCommand(restoreCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(authCmd)
 }
 
 // createProvider builds a Provider from the current config and CLI flags.
@@ -530,17 +532,125 @@ var serveCmd = &cobra.Command{
 		addr := fmt.Sprintf(":%d", port)
 		slog.Info("starting web server", "addr", addr)
 
+		// Load users.yaml for API-key authentication.
+		cfgDir, err := config.ConfigDir()
+		if err != nil {
+			return fmt.Errorf("resolve config directory: %w", err)
+		}
+		usersPath := filepath.Join(cfgDir, "users.yaml")
+
+		// Auto-provision: if VOCABGEN_API_KEY is set and users.yaml doesn't exist,
+		// create users.yaml automatically. This enables zero-config auth in Docker
+		// by simply setting the env var in docker-compose.
+		if apiKey := os.Getenv("VOCABGEN_API_KEY"); apiKey != "" {
+			if _, statErr := os.Stat(usersPath); os.IsNotExist(statErr) {
+				hash, hashErr := auth.HashAPIKey(apiKey)
+				if hashErr != nil {
+					return fmt.Errorf("auto-provision auth: %w", hashErr)
+				}
+				svcName := os.Getenv("VOCABGEN_API_KEY_NAME")
+				if svcName == "" {
+					svcName = "service-account"
+				}
+				svcScope := os.Getenv("VOCABGEN_API_KEY_SCOPE")
+				if svcScope == "" {
+					svcScope = "read-only"
+				}
+				if provErr := auth.ProvisionUsersConfig(usersPath, svcName, hash, svcScope); provErr != nil {
+					return fmt.Errorf("auto-provision auth: %w", provErr)
+				}
+				slog.Info("auth: auto-provisioned users.yaml from VOCABGEN_API_KEY", "name", svcName, "scope", svcScope)
+			}
+		}
+
+		usersConfig, err := auth.LoadUsersConfig(usersPath)
+		if err != nil {
+			return fmt.Errorf("load users config: %w", err)
+		}
+		if usersConfig != nil {
+			slog.Info("auth: enabled", "service_accounts", len(usersConfig.ServiceAccounts))
+		} else {
+			slog.Info("auth: disabled (no users.yaml)")
+		}
+
 		// Graceful shutdown via signal handling
 		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 		defer stop()
 
-		srv := web.NewServer(store, &appConfig, slog.Default(), version, buildDate, runtime.Version(), resolvedDBPath)
+		srv := web.NewServer(store, &appConfig, slog.Default(), version, buildDate, runtime.Version(), resolvedDBPath, usersConfig)
 		return srv.ListenAndServe(ctx, addr)
 	},
 }
 
 func init() {
 	serveCmd.Flags().Int("port", 8080, "Port to listen on")
+}
+
+// authCmd implements the "vocabgen auth" subcommand group.
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage API-key authentication",
+}
+
+// authInitCmd implements "vocabgen auth init".
+var authInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Generate an API key and create users.yaml",
+	Long: `Generate a random API key for service-account access and write it to users.yaml.
+
+If users.yaml already exists, this command exits with an error (use --force to overwrite).
+The generated plaintext key is printed to stdout — save it securely, it cannot be recovered.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, _ := cmd.Flags().GetString("name")
+		scope, _ := cmd.Flags().GetString("scope")
+		force, _ := cmd.Flags().GetBool("force")
+
+		cfgDir, err := config.ConfigDir()
+		if err != nil {
+			return fmt.Errorf("resolve config directory: %w", err)
+		}
+		usersPath := filepath.Join(cfgDir, "users.yaml")
+
+		// Check if file exists (unless --force).
+		if !force {
+			if _, statErr := os.Stat(usersPath); statErr == nil {
+				return fmt.Errorf("users.yaml already exists at %s (use --force to overwrite)", usersPath)
+			}
+		} else {
+			// Remove existing file so ProvisionUsersConfig can create it.
+			_ = os.Remove(usersPath)
+		}
+
+		// Generate key and hash.
+		key, err := auth.GenerateAPIKey()
+		if err != nil {
+			return err
+		}
+		hash, err := auth.HashAPIKey(key)
+		if err != nil {
+			return err
+		}
+
+		// Write users.yaml.
+		if err := auth.ProvisionUsersConfig(usersPath, name, hash, scope); err != nil {
+			return err
+		}
+
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "API key generated for service-account %q (scope: %s)\n", name, scope)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Key: %s\n", key)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Written to: %s\n", usersPath)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nSave this key securely — it cannot be recovered.\n")
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Use it as: Authorization: Bearer %s\n", key)
+
+		return nil
+	},
+}
+
+func init() {
+	authInitCmd.Flags().String("name", "service-account", "Service account name")
+	authInitCmd.Flags().String("scope", "read-only", "Access scope (read-only, read-write)")
+	authInitCmd.Flags().Bool("force", false, "Overwrite existing users.yaml")
+	authCmd.AddCommand(authInitCmd)
 }
 
 // backupCmd implements the "vocabgen backup" subcommand.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,7 @@ vocabgen/
 │   ├── deployment.md
 │   └── user-guide.md
 ├── internal/
+│   ├── auth/              # API-key authentication (service-accounts, middleware, users.yaml)
 │   ├── config/            # YAML config manager (LoadConfig, SaveConfig)
 │   ├── db/                # SQLite schema, migrations, CRUD, cache layer
 │   ├── language/          # Prompt templates, schemas, validation, language registry
@@ -83,6 +84,18 @@ vocabgen/
 ```
 
 ## Package Details
+
+### `internal/auth` — API-Key Authentication
+
+Stateless Bearer-token authentication for service-accounts. Loads `users.yaml` from the config directory (`~/.vocabgen/` or `/data/` in Docker). Each entry defines a bcrypt-hashed API key and a scope (`read-only` or `read-write`).
+
+**Middleware**: Wraps the HTTP handler. Protects `/api/*` routes (except `/api/health`). Non-API routes (HTML pages) pass through unauthenticated in Phase 1. Returns 401 JSON for missing/invalid keys, 403 JSON for scope violations.
+
+**Open-access fallback**: When `users.yaml` is absent, the middleware is a no-op — identical behavior to pre-auth releases.
+
+**CLI**: `vocabgen auth init` generates a random key, bcrypt-hashes it, and writes `users.yaml`. Supports `--name`, `--scope`, `--force` flags.
+
+**Auto-provisioning**: The `serve` command checks `VOCABGEN_API_KEY` env var at startup. If set and `users.yaml` doesn't exist, it auto-creates the file with the hashed key. Optional env vars: `VOCABGEN_API_KEY_NAME`, `VOCABGEN_API_KEY_SCOPE`.
 
 ### `internal/llm` — Provider Interface
 
@@ -212,7 +225,7 @@ Server-side rendering with Go `html/template` + HTMX + Tailwind CSS (CDN). All t
 
 ### `cmd/vocabgen` — CLI Entry Point
 
-Cobra CLI with subcommands: `lookup`, `batch`, `serve`, `backup`, `restore`, `version`, `update`.
+Cobra CLI with subcommands: `lookup`, `batch`, `serve`, `backup`, `restore`, `version`, `update`, `auth`.
 
 `PersistentPreRunE` on the root command loads config, applies CLI flag overrides, and configures `slog`. Provider is created from config + flags via the registry. SQLite store is opened from the configured path. Config loading is skipped for `version` and `update` subcommands.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -445,6 +445,98 @@ Via the web UI database page: upload a CSV file with vocabulary entries to bulk-
 
 Via the web UI database page: export filtered entries as an `.xlsx` file. The download filename follows the pattern `vocabgen-{lang}-{type}-{date}.xlsx`.
 
+## API Authentication (Service Accounts)
+
+VocabGen supports optional API-key authentication for service-accounts (e.g., an MCP server or automation container) that call `/api/*` endpoints programmatically.
+
+### How It Works
+
+- **No `users.yaml`** → fully open access (current default, backward compatible)
+- **`users.yaml` present** → all `/api/*` endpoints (except `/api/health`) require a valid `Authorization: Bearer <key>` header
+
+Browser page routes (`/`, `/batch`, `/config`, etc.) remain open regardless of auth configuration.
+
+### Setup
+
+#### Option A: CLI (recommended for local development)
+
+```bash
+vocabgen auth init --name mcp-server
+```
+
+This generates a random API key, writes `~/.vocabgen/users.yaml` with the bcrypt hash, and prints the key to stdout. Save it securely — it cannot be recovered.
+
+Flags:
+- `--name` — service account name (default: `service-account`)
+- `--scope` — access scope: `read-only` or `read-write` (default: `read-only`)
+- `--force` — overwrite existing `users.yaml`
+
+#### Option B: Docker / Compose (zero-config via env var)
+
+Set `VOCABGEN_API_KEY` to any secret string in your compose file — the server auto-creates `users.yaml` on first start:
+
+```yaml
+environment:
+  VOCABGEN_API_KEY: "any-secret-string-you-choose"  # callers send this as Bearer token
+  VOCABGEN_API_KEY_NAME: "mcp-server"               # optional, default: service-account
+  VOCABGEN_API_KEY_SCOPE: "read-only"               # optional, default: read-only
+```
+
+No key generation step needed — pick any string you like (longer is more secure). The server bcrypt-hashes it at startup and writes `/data/users.yaml`. On subsequent restarts, the existing file is used (not regenerated). Callers authenticate with: `Authorization: Bearer any-secret-string-you-choose`.
+
+#### Option C: Manual
+
+1. Generate a bcrypt hash of your desired API key:
+
+```bash
+# Using htpasswd (Apache utils)
+htpasswd -bnBC 10 "" "your-secret-api-key" | tr -d ':\n'
+
+# Or using Python
+python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-secret-api-key', bcrypt.gensalt()).decode())"
+```
+
+2. Create `~/.vocabgen/users.yaml` (or `/data/users.yaml` in Docker):
+
+```yaml
+service_accounts:
+  - name: mcp-server
+    key_hash: "$2a$10$..."   # bcrypt hash from step 1
+    scope: read-only          # only GET /api/* allowed
+```
+
+3. Restart the server. You'll see a log line confirming auth is enabled:
+
+```
+level=INFO msg="auth: enabled" service_accounts=1
+```
+
+### Usage
+
+Include the API key in requests:
+
+```bash
+curl -H "Authorization: Bearer your-secret-api-key" http://localhost:8080/api/words
+```
+
+### Scope
+
+| Scope | Allowed Methods | Description |
+|-------|----------------|-------------|
+| `read-only` | GET | Default. Read access to all API endpoints |
+| `read-write` | GET, POST, PUT, DELETE | Full API access |
+
+### Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 401 | Missing, malformed, or invalid Bearer token |
+| 403 | Valid token but insufficient scope (e.g., POST with `read-only`) |
+
+### Health Endpoint
+
+`GET /api/health` is always exempt from authentication — Docker HEALTHCHECK and monitoring tools can reach it without credentials.
+
 ## Provider Switching
 
 ### AWS Bedrock (default)

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/xuri/efp v0.0.1 // indirect
 	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect
 	github.com/yuin/goldmark v1.8.2
-	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/crypto/bcrypt"
+	"gopkg.in/yaml.v3"
+)
+
+// ServiceAccount represents a single API-key-authenticated service account.
+type ServiceAccount struct {
+	Name    string `yaml:"name"`
+	KeyHash string `yaml:"key_hash"`
+	Scope   string `yaml:"scope"`
+}
+
+// UsersConfig holds all service accounts loaded from users.yaml.
+type UsersConfig struct {
+	ServiceAccounts []ServiceAccount `yaml:"service_accounts"`
+}
+
+// LoadUsersConfig reads and parses a users.yaml file at path.
+// Returns nil (no error) if the file does not exist — this signals
+// that auth is disabled (open access mode).
+func LoadUsersConfig(path string) (*UsersConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("auth: read users config: %w", err)
+	}
+
+	var cfg UsersConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("auth: parse users config: %w", err)
+	}
+
+	// Validate entries
+	for i, sa := range cfg.ServiceAccounts {
+		if sa.Name == "" {
+			return nil, fmt.Errorf("auth: service_accounts[%d]: name is required", i)
+		}
+		if sa.KeyHash == "" {
+			return nil, fmt.Errorf("auth: service_accounts[%d] (%s): key_hash is required", i, sa.Name)
+		}
+		if sa.Scope == "" {
+			cfg.ServiceAccounts[i].Scope = "read-only"
+		}
+	}
+
+	return &cfg, nil
+}
+
+// ValidateAPIKey checks whether the provided plaintext key matches any
+// service-account's bcrypt hash. Returns the matching ServiceAccount if
+// found, or nil if no match.
+func ValidateAPIKey(cfg *UsersConfig, key string) *ServiceAccount {
+	if cfg == nil || len(cfg.ServiceAccounts) == 0 {
+		return nil
+	}
+	for i := range cfg.ServiceAccounts {
+		if bcrypt.CompareHashAndPassword([]byte(cfg.ServiceAccounts[i].KeyHash), []byte(key)) == nil {
+			return &cfg.ServiceAccounts[i]
+		}
+	}
+	return nil
+}
+
+// GenerateAPIKey generates a cryptographically random 32-byte hex-encoded API key.
+func GenerateAPIKey() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("auth: generate random key: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// HashAPIKey produces a bcrypt hash of the given plaintext API key.
+func HashAPIKey(key string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(key), bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("auth: hash key: %w", err)
+	}
+	return string(hash), nil
+}
+
+// ProvisionUsersConfig creates a users.yaml at the given path with a single
+// service-account entry using the provided name, key hash, and scope.
+// It creates parent directories as needed. Returns an error if the file
+// already exists.
+func ProvisionUsersConfig(path, name, keyHash, scope string) error {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("auth: %s already exists", path)
+	}
+
+	if scope == "" {
+		scope = "read-only"
+	}
+
+	cfg := UsersConfig{
+		ServiceAccounts: []ServiceAccount{
+			{Name: name, KeyHash: keyHash, Scope: scope},
+		},
+	}
+
+	data, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return fmt.Errorf("auth: marshal users config: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("auth: create config directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("auth: write users config: %w", err)
+	}
+
+	return nil
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,508 @@
+package auth
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"unicode"
+
+	"golang.org/x/crypto/bcrypt"
+	"pgregory.net/rapid"
+)
+
+// printableASCII covers runes 0x20–0x7E (space through tilde).
+var printableASCII = &unicode.RangeTable{
+	R16: []unicode.Range16{{Lo: 0x0020, Hi: 0x007E, Stride: 1}},
+}
+
+// lowercaseASCII covers runes 'a'–'z'.
+var lowercaseASCII = &unicode.RangeTable{
+	R16: []unicode.Range16{{Lo: 'a', Hi: 'z', Stride: 1}},
+}
+
+// testLogger returns a discarding logger for tests.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// hashKey is a test helper that generates a bcrypt hash for the given key.
+func hashKey(t *testing.T, key string) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(key), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hashKey: %v", err)
+	}
+	return string(h)
+}
+
+// --- LoadUsersConfig tests ---
+
+func TestLoadUsersConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantNil   bool
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name:    "file does not exist → nil config, no error",
+			content: "", // special case: skip file creation
+			wantNil: true,
+			wantErr: false,
+		},
+		{
+			name: "valid config with one account",
+			content: `service_accounts:
+  - name: mcp-server
+    key_hash: "$2a$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012"
+    scope: read-only
+`,
+			wantNil:   false,
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name: "scope defaults to read-only when omitted",
+			content: `service_accounts:
+  - name: automation
+    key_hash: "$2a$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012"
+`,
+			wantNil:   false,
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name: "missing name → error",
+			content: `service_accounts:
+  - key_hash: "$2a$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012"
+`,
+			wantErr: true,
+		},
+		{
+			name: "missing key_hash → error",
+			content: `service_accounts:
+  - name: broken
+`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid YAML → error",
+			content: `[[[not yaml`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "users.yaml")
+
+			if tt.name == "file does not exist → nil config, no error" {
+				// Don't create the file
+			} else {
+				if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+					t.Fatalf("write test file: %v", err)
+				}
+			}
+
+			cfg, err := LoadUsersConfig(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if cfg != nil {
+					t.Fatalf("expected nil config, got %+v", cfg)
+				}
+				return
+			}
+			if cfg == nil {
+				t.Fatal("expected non-nil config")
+				return
+			}
+			if len(cfg.ServiceAccounts) != tt.wantCount {
+				t.Fatalf("expected %d accounts, got %d", tt.wantCount, len(cfg.ServiceAccounts))
+			}
+		})
+	}
+}
+
+// --- ValidateAPIKey tests ---
+
+func TestValidateAPIKey(t *testing.T) {
+	validKey := "test-api-key-12345"
+	validHash := hashKey(t, validKey)
+
+	cfg := &UsersConfig{
+		ServiceAccounts: []ServiceAccount{
+			{Name: "svc-1", KeyHash: validHash, Scope: "read-only"},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		cfg       *UsersConfig
+		key       string
+		wantMatch bool
+		wantName  string
+	}{
+		{
+			name:      "nil config → no match",
+			cfg:       nil,
+			key:       validKey,
+			wantMatch: false,
+		},
+		{
+			name:      "empty accounts → no match",
+			cfg:       &UsersConfig{},
+			key:       validKey,
+			wantMatch: false,
+		},
+		{
+			name:      "valid key matches",
+			cfg:       cfg,
+			key:       validKey,
+			wantMatch: true,
+			wantName:  "svc-1",
+		},
+		{
+			name:      "wrong key → no match",
+			cfg:       cfg,
+			key:       "wrong-key",
+			wantMatch: false,
+		},
+		{
+			name:      "empty key → no match",
+			cfg:       cfg,
+			key:       "",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateAPIKey(tt.cfg, tt.key)
+			if tt.wantMatch {
+				if result == nil {
+					t.Fatal("expected match, got nil")
+					return
+				}
+				if result.Name != tt.wantName {
+					t.Fatalf("expected name %q, got %q", tt.wantName, result.Name)
+				}
+			} else if result != nil {
+				t.Fatalf("expected no match, got %+v", result)
+			}
+		})
+	}
+}
+
+// --- Middleware tests ---
+
+func TestMiddleware(t *testing.T) {
+	validKey := "middleware-test-key"
+	validHash := hashKey(t, validKey)
+
+	cfg := &UsersConfig{
+		ServiceAccounts: []ServiceAccount{
+			{Name: "reader", KeyHash: validHash, Scope: "read-only"},
+		},
+	}
+
+	// A simple next handler that returns 200 OK.
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	logger := testLogger()
+
+	tests := []struct {
+		name         string
+		cfg          *UsersConfig
+		method       string
+		path         string
+		authHeader   string
+		hxRequest    bool
+		secFetchSite string
+		wantStatus   int
+	}{
+		{
+			name:       "nil config → open access, any request passes",
+			cfg:        nil,
+			method:     "GET",
+			path:       "/api/words",
+			authHeader: "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "health endpoint always exempt",
+			cfg:        cfg,
+			method:     "GET",
+			path:       "/api/health",
+			authHeader: "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "HTMX request exempt (web UI same-origin)",
+			cfg:        cfg,
+			method:     "GET",
+			path:       "/api/tags",
+			authHeader: "",
+			hxRequest:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "HTMX POST request exempt (web UI form submit)",
+			cfg:        cfg,
+			method:     "POST",
+			path:       "/api/lookup/html",
+			authHeader: "",
+			hxRequest:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:         "same-origin fetch exempt (Sec-Fetch-Site)",
+			cfg:          cfg,
+			method:       "GET",
+			path:         "/api/tags",
+			authHeader:   "",
+			secFetchSite: "same-origin",
+			wantStatus:   http.StatusOK,
+		},
+		{
+			name:       "non-API route passes through (HTML page)",
+			cfg:        cfg,
+			method:     "GET",
+			path:       "/batch",
+			authHeader: "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "API route without auth header → 401",
+			cfg:        cfg,
+			method:     "GET",
+			path:       "/api/words",
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "API route with invalid key → 401",
+			cfg:        cfg,
+			method:     "GET",
+			path:       "/api/words",
+			authHeader: "Bearer wrong-key",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "API route with malformed header → 401",
+			cfg:        cfg,
+			method:     "GET",
+			path:       "/api/words",
+			authHeader: "Basic dXNlcjpwYXNz",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "valid key GET → 200",
+			cfg:        cfg,
+			method:     "GET",
+			path:       "/api/words",
+			authHeader: "Bearer " + validKey,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "valid key POST on read-only → 403",
+			cfg:        cfg,
+			method:     "POST",
+			path:       "/api/lookup",
+			authHeader: "Bearer " + validKey,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "valid key PUT on read-only → 403",
+			cfg:        cfg,
+			method:     "PUT",
+			path:       "/api/words/1",
+			authHeader: "Bearer " + validKey,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "valid key DELETE on read-only → 403",
+			cfg:        cfg,
+			method:     "DELETE",
+			path:       "/api/words/1",
+			authHeader: "Bearer " + validKey,
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := Middleware(tt.cfg, logger, okHandler)
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			if tt.hxRequest {
+				req.Header.Set("HX-Request", "true")
+			}
+			if tt.secFetchSite != "" {
+				req.Header.Set("Sec-Fetch-Site", tt.secFetchSite)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d (body: %s)", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+
+			// Verify error responses are JSON.
+			if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+				ct := rec.Header().Get("Content-Type")
+				if ct != "application/json; charset=utf-8" {
+					t.Fatalf("expected JSON content-type, got %q", ct)
+				}
+				var body map[string]string
+				if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+					t.Fatalf("failed to decode JSON error body: %v", err)
+				}
+				if body["detail"] == "" {
+					t.Fatal("expected non-empty 'detail' in error response")
+				}
+			}
+		})
+	}
+}
+
+// TestMiddlewareReadWriteScope verifies that accounts with "read-write" scope
+// can access write endpoints.
+func TestMiddlewareReadWriteScope(t *testing.T) {
+	rwKey := "rw-key-123"
+	rwHash := hashKey(t, rwKey)
+
+	cfg := &UsersConfig{
+		ServiceAccounts: []ServiceAccount{
+			{Name: "admin-bot", KeyHash: rwHash, Scope: "read-write"},
+		},
+	}
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Middleware(cfg, testLogger(), okHandler)
+
+	methods := []string{"GET", "POST", "PUT", "DELETE"}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/words", nil)
+			req.Header.Set("Authorization", "Bearer "+rwKey)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("read-write account %s: expected 200, got %d", method, rec.Code)
+			}
+		})
+	}
+}
+
+// --- Property-based tests ---
+
+// TestPropertyValidateAPIKeyMatchesOwnHash verifies that for all valid
+// bcrypt key hashes, ValidateAPIKey returns a match with the original key.
+func TestPropertyValidateAPIKeyMatchesOwnHash(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Generate a random key (1-72 bytes — bcrypt max input).
+		key := rapid.StringOfN(rapid.RuneFrom(nil, printableASCII), 1, 72, -1).Draw(t, "key")
+
+		hash, err := bcrypt.GenerateFromPassword([]byte(key), bcrypt.MinCost)
+		if err != nil {
+			t.Fatalf("bcrypt hash: %v", err)
+		}
+
+		cfg := &UsersConfig{
+			ServiceAccounts: []ServiceAccount{
+				{Name: "test", KeyHash: string(hash), Scope: "read-only"},
+			},
+		}
+
+		result := ValidateAPIKey(cfg, key)
+		if result == nil {
+			t.Fatal("expected key to match its own hash")
+			return
+		}
+		if result.Name != "test" {
+			t.Fatalf("expected name 'test', got %q", result.Name)
+		}
+	})
+}
+
+// TestPropertyValidateAPIKeyRejectsRandomKeys verifies that random strings
+// not matching any configured hash are rejected.
+func TestPropertyValidateAPIKeyRejectsRandomKeys(t *testing.T) {
+	// Pre-generate a known key and its hash.
+	knownKey := "known-static-key-for-property-test"
+	knownHash, err := bcrypt.GenerateFromPassword([]byte(knownKey), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt hash: %v", err)
+	}
+
+	cfg := &UsersConfig{
+		ServiceAccounts: []ServiceAccount{
+			{Name: "known", KeyHash: string(knownHash), Scope: "read-only"},
+		},
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		// Generate a random key that is NOT the known key.
+		candidate := rapid.StringOfN(rapid.RuneFrom(nil, printableASCII), 1, 72, -1).Draw(t, "candidate")
+		if candidate == knownKey {
+			t.Skip("generated the known key by chance, skip")
+		}
+
+		result := ValidateAPIKey(cfg, candidate)
+		if result != nil {
+			t.Fatalf("expected no match for random key %q, got %+v", candidate, result)
+		}
+	})
+}
+
+// TestPropertyMiddlewareOpenAccessPassesAll verifies that when UsersConfig
+// is nil, all requests pass through regardless of headers.
+func TestPropertyMiddlewareOpenAccessPassesAll(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := Middleware(nil, testLogger(), okHandler)
+
+	methods := []string{"GET", "POST", "PUT", "DELETE"}
+
+	rapid.Check(t, func(t *rapid.T) {
+		method := rapid.SampledFrom(methods).Draw(t, "method")
+		path := "/api/" + rapid.StringOfN(rapid.RuneFrom(nil, lowercaseASCII), 1, 20, -1).Draw(t, "path")
+		authHeader := rapid.StringOfN(rapid.RuneFrom(nil, printableASCII), 0, 100, -1).Draw(t, "auth")
+
+		req := httptest.NewRequest(method, path, nil)
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("open access: expected 200 for %s %s, got %d", method, path, rec.Code)
+		}
+	})
+}

--- a/internal/auth/doc.go
+++ b/internal/auth/doc.go
@@ -1,0 +1,6 @@
+// Package auth provides stateless API-key authentication for service-accounts.
+// It loads service-account definitions from a users.yaml file (bcrypt-hashed
+// keys with scope) and exposes HTTP middleware that validates Bearer tokens
+// against the configured accounts. When no users.yaml is present, all requests
+// pass through unauthenticated (backward-compatible open access).
+package auth

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// Middleware returns an http.Handler that enforces API-key authentication
+// on /api/* routes (except /api/health) when cfg is non-nil.
+// When cfg is nil, all requests pass through unchanged (open access).
+//
+// Authentication rules:
+//   - GET /api/health is always exempt (Docker HEALTHCHECK, monitoring).
+//   - HTMX requests (HX-Request: true) are exempt — they originate from the web UI.
+//   - Same-origin browser fetches (Sec-Fetch-Site: same-origin) are exempt.
+//   - Non-API routes (HTML pages) pass through unauthenticated in Phase 1.
+//   - Valid Bearer token → request proceeds.
+//   - Invalid/missing Bearer token → 401 JSON.
+//   - Valid token but write method (POST/PUT/DELETE) on a read-only account → 403 JSON.
+func Middleware(cfg *UsersConfig, logger *slog.Logger, next http.Handler) http.Handler {
+	// No config → open access, skip all auth logic.
+	if cfg == nil {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// Only protect /api/* routes (except health).
+		if !strings.HasPrefix(path, "/api/") || path == "/api/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Same-origin browser requests come from the web UI — exempt them.
+		// This covers both HTMX calls (HX-Request: true) and plain fetch()
+		// from our templates. External callers (curl, MCP server) won't have
+		// these headers. Sec-Fetch-Site is set by all modern browsers.
+		if r.Header.Get("HX-Request") == "true" || r.Header.Get("Sec-Fetch-Site") == "same-origin" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Extract Bearer token.
+		token := extractBearerToken(r)
+		if token == "" {
+			logger.Warn("auth: missing or malformed Authorization header",
+				"path", path, "method", r.Method, "remote", r.RemoteAddr)
+			writeAuthError(w, http.StatusUnauthorized, "missing or invalid Authorization header")
+			return
+		}
+
+		// Validate key against configured service accounts.
+		account := ValidateAPIKey(cfg, token)
+		if account == nil {
+			logger.Warn("auth: invalid API key",
+				"path", path, "method", r.Method, "remote", r.RemoteAddr)
+			writeAuthError(w, http.StatusUnauthorized, "invalid API key")
+			return
+		}
+
+		// Scope enforcement: read-only accounts can only use GET.
+		if account.Scope == "read-only" && r.Method != http.MethodGet {
+			logger.Warn("auth: write attempt by read-only account",
+				"account", account.Name, "path", path, "method", r.Method)
+			writeAuthError(w, http.StatusForbidden, "read-only access: write operations are not permitted")
+			return
+		}
+
+		// Authenticated — proceed.
+		next.ServeHTTP(w, r)
+	})
+}
+
+// extractBearerToken parses the Authorization header for a Bearer token.
+// Returns empty string if the header is absent or malformed.
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return ""
+	}
+	return strings.TrimSpace(auth[len(prefix):])
+}
+
+// writeAuthError writes a JSON error response for authentication failures.
+func writeAuthError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"detail": msg})
+}

--- a/internal/web/handlers_db_test.go
+++ b/internal/web/handlers_db_test.go
@@ -24,7 +24,7 @@ func (m *tagMockStore) ListDistinctTags(_ context.Context) ([]string, error) {
 
 func newTagTestServer(store *tagMockStore) *Server {
 	cfg := config.DefaultConfig()
-	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
+	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db", nil)
 }
 
 func TestHandleListTags(t *testing.T) {

--- a/internal/web/handlers_flashcards_test.go
+++ b/internal/web/handlers_flashcards_test.go
@@ -130,7 +130,7 @@ func matchesFilter(sourceLang, targetLang, tags, difficulty string, f db.ListFil
 
 func newFlashcardTestServer(store *flashcardMockStore) *Server {
 	cfg := config.DefaultConfig()
-	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
+	return NewServer(store, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db", nil)
 }
 
 // TestFlashcardsPage_Returns200 verifies GET /flashcards returns 200 with HTML content type.

--- a/internal/web/integration_test.go
+++ b/internal/web/integration_test.go
@@ -504,7 +504,7 @@ func TestPropertyP21_AboutPageContentIdentical(t *testing.T) {
 		goVersion := rapid.StringMatching(`go1\.[0-9]{1,2}(\.[0-9]{1,2})?`).Draw(t, "goVersion")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, buildDate, goVersion, "/tmp/test.db")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, buildDate, goVersion, "/tmp/test.db", nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/about", nil)
 		w := httptest.NewRecorder()
@@ -560,7 +560,7 @@ func TestPropertyP22_AboutURLServesAboutPage(t *testing.T) {
 		version := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(t, "version")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db", nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/about", nil)
 		w := httptest.NewRecorder()
@@ -742,7 +742,7 @@ func TestPropertyP12_HelpDropdownContainsFiveLinksInOrder(t *testing.T) {
 		path := pagePaths[idx]
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db", nil)
 
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		w := httptest.NewRecorder()
@@ -808,7 +808,7 @@ func TestPropertyP31_ReportAnIssueOpensCorrectURL(t *testing.T) {
 		version := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(t, "version")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db", nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
@@ -838,7 +838,7 @@ func TestPropertyP32_ReportAnIssueOpensInNewTabSecurely(t *testing.T) {
 		version := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(t, "version")
 
 		cfg := config.DefaultConfig()
-		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db")
+		srv := NewServer(&stubStore{}, &cfg, slog.Default(), version, "2026-01-01", "go1.22", "/tmp/test.db", nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/user/vocabgen/internal/auth"
 	"github.com/user/vocabgen/internal/config"
 	"github.com/user/vocabgen/internal/db"
 	"github.com/user/vocabgen/internal/llm"
@@ -28,6 +29,7 @@ type Server struct {
 	buildDate     string
 	goVersion     string
 	updater       *updateChecker
+	usersConfig   *auth.UsersConfig
 }
 
 // pageData is the common data passed to all page templates.
@@ -48,7 +50,7 @@ type pageData struct {
 }
 
 // NewServer creates a Server with all routes registered.
-func NewServer(store db.Store, cfg *config.Config, logger *slog.Logger, version, buildDate, goVersion, dbPath string) *Server {
+func NewServer(store db.Store, cfg *config.Config, logger *slog.Logger, version, buildDate, goVersion, dbPath string, usersConfig *auth.UsersConfig) *Server {
 	// Resolve the initial active profile name.
 	_, defaultProfile, _ := config.ListProfiles()
 
@@ -63,6 +65,7 @@ func NewServer(store db.Store, cfg *config.Config, logger *slog.Logger, version,
 		buildDate:     buildDate,
 		goVersion:     goVersion,
 		updater:       newUpdateChecker(version, logger),
+		usersConfig:   usersConfig,
 	}
 	s.registerRoutes()
 	return s
@@ -75,7 +78,7 @@ func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
 
 	srv := &http.Server{
 		Addr:    addr,
-		Handler: s.mux,
+		Handler: auth.Middleware(s.usersConfig, s.logger, s.mux),
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -94,7 +94,7 @@ func (s *stubStore) UpdateExpressionDifficulty(ctx context.Context, id int64, di
 
 func newTestServer() *Server {
 	cfg := config.DefaultConfig()
-	return NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db")
+	return NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/tmp/test.db", nil)
 }
 
 func TestNewServer(t *testing.T) {
@@ -270,7 +270,7 @@ func TestAPIRoutesRegistered(t *testing.T) {
 // displayed in the navigation bar on all pages.
 func TestDBPathRenderedInNavBar(t *testing.T) {
 	cfg := config.DefaultConfig()
-	srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/home/user/.vocabgen/vocabgen-dev.db")
+	srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "/home/user/.vocabgen/vocabgen-dev.db", nil)
 
 	pages := []string{"/", "/batch", "/config", "/database", "/about"}
 	for _, path := range pages {
@@ -294,7 +294,7 @@ func TestDBPathRenderedInNavBar(t *testing.T) {
 // indicator appears in the navigation bar.
 func TestDBPathEmptyNotRendered(t *testing.T) {
 	cfg := config.DefaultConfig()
-	srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "")
+	srv := NewServer(&stubStore{}, &cfg, slog.Default(), "test", "unknown", "go1.22", "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

Add API-key authentication for service-account access. This enables headless/programmatic clients to authenticate with VocabGen's web server using a static API key, without requiring browser-based session auth.

## Related Issue

Fixes #101

## Changes

- Add API-key authentication support (`X-API-Key` header / `api_key` query param)
- Add auth middleware that gates protected endpoints
- Add `--api-key` CLI flag and `VOCABGEN_API_KEY` env var for key configuration
- Update server wiring to integrate auth middleware
- Update existing integration/handler tests to pass auth when enabled
- Update architecture and user-guide docs
- Update Dockerfile with API key env support
- Update CHANGELOG.md

## Checklist

- [x] `make quality` passes (build + vet + fmt + tests)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] New tests added for new functionality
