### PR TITLE
fix: add docker-entrypoint.sh to goreleaser extra_files

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,6 +42,8 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
+    extra_files:
+      - scripts/docker-entrypoint.sh
     labels:
       "org.opencontainers.image.title": "VocabGen"
       "org.opencontainers.image.description": "Vocabulary web app and flashcard tool for language learners"


### PR DESCRIPTION
The Docker build failed in the v1.5.0 release because goreleaser's build context didn't include `scripts/docker-entrypoint.sh`. This adds it via `extra_files`.